### PR TITLE
Deprecate `master_timeout` in favor of `cluster_manager_timeout`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ build/
 .DS_Store
 
 .smithy.lsp.log
+
+# Javascript stuff
+node_modules

--- a/model/_global/search/structures.smithy
+++ b/model/_global/search/structures.smithy
@@ -323,10 +323,6 @@ structure PostSearchWithIndexInput {
 }
 
 structure PostSearchWithIndexOutput {
-
-    @required
-    index: IndexName,
-
     _scroll_id: String,
 
     took: Long,
@@ -337,3 +333,62 @@ structure PostSearchWithIndexOutput {
 
     hits: HitsMetadata
 }
+
+apply PostSearch @examples([
+    {
+        title: "Examples for Post Search Operation.",
+        input: {
+            scroll: "1d",
+            query: {
+                match_all: {}
+            },
+            fields: ["*"]
+        },
+        output: {
+            timed_out: false,
+            _shards: {
+                total: 1,
+                successful: 1,
+                skipped: 0,
+                failed: 0
+            },
+            hits: {
+                total: {
+                    value: 0,
+                    relation: "eq"
+                },
+                hits: []
+            }
+        }
+    }
+])
+
+apply PostSearchWithIndex @examples([
+    {
+        title: "Examples for Post Search With Index Operation.",
+        input: {
+            index: "books",
+            scroll: "1d",
+            query: {
+                match_all: {}
+            },
+            fields: ["*"]
+        },
+        output: {
+            timed_out: false,
+            _shards: {
+                total: 1,
+                successful: 1,
+                skipped: 0,
+                failed: 0
+            },
+            hits: {
+                total: {
+                    value: 0,
+                    relation: "eq"
+                },
+                hits: []
+            }
+        }
+    }
+])

--- a/model/cat/indices/cat_indicies/structures.smithy
+++ b/model/cat/indices/cat_indicies/structures.smithy
@@ -7,7 +7,7 @@
 $version: "2"
 namespace OpenSearch
 
-structure GetCatIndicesInput {
+structure GetCatIndicesInput with [ClusterManagerTimeout] {
     // GetCatIndicesInputCommonParameters Start
 
     @httpQuery("bytes")
@@ -24,13 +24,6 @@ structure GetCatIndicesInput {
 
     @httpQuery("pri")
     pri: Boolean,
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
 
     @httpQuery("time")
     time: Time,
@@ -52,7 +45,7 @@ structure GetCatIndicesOutput {
 
 }
 
-structure GetCatIndicesWithIndexInput {
+structure GetCatIndicesWithIndexInput with [ClusterManagerTimeout] {
     @httpLabel
     @required
     index: IndexName,
@@ -73,13 +66,6 @@ structure GetCatIndicesWithIndexInput {
 
     @httpQuery("pri")
     pri: Boolean,
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
 
     @httpQuery("time")
     time: Time,

--- a/model/cat/indices/cat_indicies/structures.smithy
+++ b/model/cat/indices/cat_indicies/structures.smithy
@@ -25,8 +25,12 @@ structure GetCatIndicesInput {
     @httpQuery("pri")
     pri: Boolean,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     @httpQuery("time")
     time: Time,
@@ -70,8 +74,12 @@ structure GetCatIndicesWithIndexInput {
     @httpQuery("pri")
     pri: Boolean,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     @httpQuery("time")
     time: Time,

--- a/model/cat/nodes/cat_nodes/structures.smithy
+++ b/model/cat/nodes/cat_nodes/structures.smithy
@@ -7,7 +7,7 @@
 $version: "2"
 namespace OpenSearch
 
-structure GetCatNodesInput {
+structure GetCatNodesInput with [ClusterManagerTimeout] {
 
     // GetCatNodesInput Start
 
@@ -19,13 +19,6 @@ structure GetCatNodesInput {
 
     @httpQuery("local")
     local: Boolean,
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
 
     @httpQuery("time")
     time: Time,

--- a/model/cat/nodes/cat_nodes/structures.smithy
+++ b/model/cat/nodes/cat_nodes/structures.smithy
@@ -20,8 +20,12 @@ structure GetCatNodesInput {
     @httpQuery("local")
     local: Boolean,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     @httpQuery("time")
     time: Time,

--- a/model/cluster/get_cluster_settings/structures.smithy
+++ b/model/cluster/get_cluster_settings/structures.smithy
@@ -15,8 +15,12 @@ structure GetClusterSettingsInput {
     @httpQuery("include_defaults")
     include_defaults: Boolean,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
 }
 

--- a/model/cluster/get_cluster_settings/structures.smithy
+++ b/model/cluster/get_cluster_settings/structures.smithy
@@ -7,20 +7,13 @@
 $version: "2"
 namespace OpenSearch
 
-structure GetClusterSettingsInput {
+structure GetClusterSettingsInput with [ClusterManagerTimeout] {
 
     @httpQuery("flat_settings")
     flat_settings: Boolean,
 
     @httpQuery("include_defaults")
     include_defaults: Boolean,
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
 
 }
 

--- a/model/cluster/put_update_cluster_settings/structures.smithy
+++ b/model/cluster/put_update_cluster_settings/structures.smithy
@@ -7,17 +7,10 @@
 $version: "2"
 namespace OpenSearch
 
-structure PutUpdateClusterSettingsInput {
+structure PutUpdateClusterSettingsInput with [ClusterManagerTimeout] {
 
     @httpQuery("flat_settings")
     flat_settings: Boolean,
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
 
     @httpQuery("timeout")
     timeout: Time,

--- a/model/cluster/put_update_cluster_settings/structures.smithy
+++ b/model/cluster/put_update_cluster_settings/structures.smithy
@@ -12,8 +12,12 @@ structure PutUpdateClusterSettingsInput {
     @httpQuery("flat_settings")
     flat_settings: Boolean,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     @httpQuery("timeout")
     timeout: Time,

--- a/model/common_structures.smithy
+++ b/model/common_structures.smithy
@@ -7,6 +7,17 @@
 $version: "2"
 namespace OpenSearch
 
+@mixin
+structure ClusterManagerTimeout {
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
+    @httpQuery("master_timeout")
+    master_timeout: Time,
+
+    @since("2.0.0")
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
+}
+
 structure ShardStatistics{
     total: Integer,
     successful: Integer,

--- a/model/indices/aliases/structures.smithy
+++ b/model/indices/aliases/structures.smithy
@@ -10,8 +10,12 @@ namespace OpenSearch
 structure PostAliasesInput {
 
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     @httpQuery("timeout")
     timeout: Time,

--- a/model/indices/aliases/structures.smithy
+++ b/model/indices/aliases/structures.smithy
@@ -7,15 +7,7 @@
 $version: "2"
 namespace OpenSearch
 
-structure PostAliasesInput {
-
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
+structure PostAliasesInput with [ClusterManagerTimeout] {
 
     @httpQuery("timeout")
     timeout: Time,

--- a/model/indices/create/structures.smithy
+++ b/model/indices/create/structures.smithy
@@ -18,8 +18,12 @@ structure PutCreateIndexInput {
     @httpQuery("wait_for_active_shards")
     wait_for_active_shards: String,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     @httpQuery("timeout")
     timeout: Time,

--- a/model/indices/create/structures.smithy
+++ b/model/indices/create/structures.smithy
@@ -7,7 +7,7 @@
 $version: "2"
 namespace OpenSearch
 
-structure PutCreateIndexInput {
+structure PutCreateIndexInput with [ClusterManagerTimeout] {
     @httpLabel
     @required
     index: IndexName,
@@ -17,13 +17,6 @@ structure PutCreateIndexInput {
 
     @httpQuery("wait_for_active_shards")
     wait_for_active_shards: String,
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
 
     @httpQuery("timeout")
     timeout: Time,

--- a/model/indices/delete/structures.smithy
+++ b/model/indices/delete/structures.smithy
@@ -7,7 +7,7 @@
 $version: "2"
 namespace OpenSearch
 
-structure DeleteIndexInput {
+structure DeleteIndexInput with [ClusterManagerTimeout] {
     @httpLabel
     @required
     index: IndexName,
@@ -20,13 +20,6 @@ structure DeleteIndexInput {
 
     @httpQuery("ignore_unavailable")
     ignore_unavailable: Boolean,
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
 
     @httpQuery("timeout")
     timeout: Time

--- a/model/indices/delete/structures.smithy
+++ b/model/indices/delete/structures.smithy
@@ -21,8 +21,12 @@ structure DeleteIndexInput {
     @httpQuery("ignore_unavailable")
     ignore_unavailable: Boolean,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     @httpQuery("timeout")
     timeout: Time

--- a/model/indices/get_document/structures.smithy
+++ b/model/indices/get_document/structures.smithy
@@ -57,7 +57,6 @@ structure GetDocumentDocOutput {
     @required
     _index: IndexName,
 
-    @required
     _type: String,
 
     @required
@@ -137,7 +136,6 @@ apply GetDocumentDoc @examples([
         },
         output: {
             _index: "books",
-            _type: "_doc",
             _id: "1",
             found: true
         }

--- a/model/indices/get_settings/structures.smithy
+++ b/model/indices/get_settings/structures.smithy
@@ -7,7 +7,7 @@
 $version: "2"
 namespace OpenSearch
 
-structure GetSettingsIndexInput {
+structure GetSettingsIndexInput with [ClusterManagerTimeout] {
 
     @httpLabel
     @required
@@ -32,13 +32,6 @@ structure GetSettingsIndexInput {
     @httpQuery("local")
     local: Boolean,
 
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
-
     // GetSettingsIndexInput CommonParameters END
 
 }
@@ -50,7 +43,7 @@ structure GetSettingsIndexOutput {
 
 }
 
-structure GetSettingsIndexSettingInput {
+structure GetSettingsIndexSettingInput with [ClusterManagerTimeout] {
 
     @httpLabel
     @required
@@ -79,13 +72,6 @@ structure GetSettingsIndexSettingInput {
 
     @httpQuery("local")
     local: Boolean,
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
 
     // GetSettingsIndexInput CommonParameters END
 

--- a/model/indices/get_settings/structures.smithy
+++ b/model/indices/get_settings/structures.smithy
@@ -32,8 +32,12 @@ structure GetSettingsIndexInput {
     @httpQuery("local")
     local: Boolean,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     // GetSettingsIndexInput CommonParameters END
 
@@ -76,8 +80,12 @@ structure GetSettingsIndexSettingInput {
     @httpQuery("local")
     local: Boolean,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     // GetSettingsIndexInput CommonParameters END
 

--- a/model/indices/put_mapping/structures.smithy
+++ b/model/indices/put_mapping/structures.smithy
@@ -25,8 +25,12 @@ structure PutIndexMappingWithIndexInput {
     @httpQuery("include_type_name")
     include_type_name: Boolean,
 
+    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
     @httpQuery("master_timeout")
     master_timeout: Time,
+
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
 
     @httpQuery("timeout")
     timeout: Time,

--- a/model/indices/put_mapping/structures.smithy
+++ b/model/indices/put_mapping/structures.smithy
@@ -7,7 +7,7 @@
 $version: "2"
 namespace OpenSearch
 
-structure PutIndexMappingWithIndexInput {
+structure PutIndexMappingWithIndexInput with [ClusterManagerTimeout] {
     @httpLabel
     @required
     index: IndexName,
@@ -24,13 +24,6 @@ structure PutIndexMappingWithIndexInput {
 
     @httpQuery("include_type_name")
     include_type_name: Boolean,
-
-    @deprecated(since: "2.0.0", message: "To promote inclusive language, use 'cluster_manager_timeout' instead.")
-    @httpQuery("master_timeout")
-    master_timeout: Time,
-
-    @httpQuery("cluster_manager_timeout")
-    cluster_manager_timeout: Time,
 
     @httpQuery("timeout")
     timeout: Time,

--- a/test/models/_global/get_cluster_info/OpenSearchModel.json
+++ b/test/models/_global/get_cluster_info/OpenSearchModel.json
@@ -13,7 +13,7 @@
       "200": {
        "description": "GetClusterInfo 200 response",
        "content": {
-        "application/json; charset=UTF-8": {
+        "application/json": {
          "schema": {
           "$ref": "#/components/schemas/GetClusterInfoResponseContent"
          }
@@ -39,14 +39,14 @@
        "type": "string"
       },
       "version": {
-       "$ref": "#/components/schemas/intermediateStructure"
+       "$ref": "#/components/schemas/Version"
       },
       "tagline": {
        "type": "string"
       }
      }
     },
-    "intermediateStructure": {
+    "Version": {
      "type": "object",
      "properties": {
       "distribution": {
@@ -65,8 +65,7 @@
        "type": "string"
       },
       "build_snapshot": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       },
       "lucene_version": {
        "type": "string"
@@ -79,6 +78,18 @@
       }
      }
     }
+   },
+   "securitySchemes": {
+    "smithy.api.httpBasicAuth": {
+     "type": "http",
+     "description": "HTTP Basic authentication",
+     "scheme": "Basic"
+    }
    }
-  }
-}
+  },
+  "security": [
+   {
+    "smithy.api.httpBasicAuth": []
+   }
+  ]
+ }

--- a/test/models/_global/search/OpenSearchModel.json
+++ b/test/models/_global/search/OpenSearchModel.json
@@ -14,6 +14,20 @@
          "application/json": {
           "schema": {
            "$ref": "#/components/schemas/PostSearchRequestContent"
+          },
+          "examples": {
+           "PostSearch_example1": {
+            "summary": "Examples for Post Search Operation.",
+            "description": "",
+            "value": {
+             "query": {
+              "match_all": {}
+             },
+             "fields": [
+              "*"
+             ]
+            }
+           }
           }
          }
         }
@@ -179,7 +193,15 @@
          "schema": {
           "type": "string",
           "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
-         }
+         },
+         "examples": {
+          "PostSearch_example1": {
+           "summary": "Examples for Post Search Operation.",
+           "description": "",
+           "value": "1d"
+          }
+         },
+         "example": "1d"
         },
         {
          "name": "search_type",
@@ -338,6 +360,28 @@
           "application/json": {
            "schema": {
             "$ref": "#/components/schemas/PostSearchResponseContent"
+           },
+           "examples": {
+            "PostSearch_example1": {
+             "summary": "Examples for Post Search Operation.",
+             "description": "",
+             "value": {
+              "timed_out": false,
+              "_shards": {
+               "total": 1,
+               "successful": 1,
+               "skipped": 0,
+               "failed": 0
+              },
+              "hits": {
+               "total": {
+                "value": 0,
+                "relation": "eq"
+               },
+               "hits": []
+              }
+             }
+            }
            }
           }
          }
@@ -354,6 +398,20 @@
          "application/json": {
           "schema": {
            "$ref": "#/components/schemas/PostSearchWithIndexRequestContent"
+          },
+          "examples": {
+           "PostSearchWithIndex_example1": {
+            "summary": "Examples for Post Search With Index Operation.",
+            "description": "",
+            "value": {
+             "query": {
+              "match_all": {}
+             },
+             "fields": [
+              "*"
+             ]
+            }
+           }
           }
          }
         }
@@ -366,7 +424,15 @@
           "type": "string",
           "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
          },
-         "required": true
+         "required": true,
+         "examples": {
+          "PostSearchWithIndex_example1": {
+           "summary": "Examples for Post Search With Index Operation.",
+           "description": "",
+           "value": "books"
+          }
+         },
+         "example": "books"
         },
         {
          "name": "allow_no_indices",
@@ -528,7 +594,15 @@
          "schema": {
           "type": "string",
           "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
-         }
+         },
+         "examples": {
+          "PostSearchWithIndex_example1": {
+           "summary": "Examples for Post Search With Index Operation.",
+           "description": "",
+           "value": "1d"
+          }
+         },
+         "example": "1d"
         },
         {
          "name": "search_type",
@@ -687,6 +761,28 @@
           "application/json": {
            "schema": {
             "$ref": "#/components/schemas/PostSearchWithIndexResponseContent"
+           },
+           "examples": {
+            "PostSearchWithIndex_example1": {
+             "summary": "Examples for Post Search With Index Operation.",
+             "description": "",
+             "value": {
+              "timed_out": false,
+              "_shards": {
+               "total": 1,
+               "successful": 1,
+               "skipped": 0,
+               "failed": 0
+              },
+              "hits": {
+               "total": {
+                "value": 0,
+                "relation": "eq"
+               },
+               "hits": []
+              }
+             }
+            }
            }
           }
          }
@@ -822,6 +918,22 @@
         "hits": {
          "$ref": "#/components/schemas/HitsMetadata"
         }
+       },
+       "example": {
+        "timed_out": false,
+        "_shards": {
+         "total": 1,
+         "successful": 1,
+         "skipped": 0,
+         "failed": 0
+        },
+        "hits": {
+         "total": {
+          "value": 0,
+          "relation": "eq"
+         },
+         "hits": []
+        }
        }
       },
       "PostSearchWithIndexRequestContent": {
@@ -879,10 +991,6 @@
       "PostSearchWithIndexResponseContent": {
        "type": "object",
        "properties": {
-        "index": {
-         "type": "string",
-         "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
-        },
         "_scroll_id": {
          "type": "string"
         },
@@ -899,9 +1007,22 @@
          "$ref": "#/components/schemas/HitsMetadata"
         }
        },
-       "required": [
-        "index"
-       ]
+       "example": {
+        "timed_out": false,
+        "_shards": {
+         "total": 1,
+         "successful": 1,
+         "skipped": 0,
+         "failed": 0
+        },
+        "hits": {
+         "total": {
+          "value": 0,
+          "relation": "eq"
+         },
+         "hits": []
+        }
+       }
       },
       "Relation": {
        "type": "string",

--- a/test/models/_global/search/OpenSearchModel.json
+++ b/test/models/_global/search/OpenSearchModel.json
@@ -23,16 +23,14 @@
          "name": "allow_no_indices",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "allow_partial_search_results",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -46,25 +44,21 @@
          "name": "analyze_wildcard",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "batched_reduce_size",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
          "name": "ccs_minimize_roundtrips",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -99,59 +93,49 @@
          "name": "explain",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "from",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
          "name": "ignore_throttled",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "ignore_unavailable",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "lenient",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "max_concurrent_shard_requests",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int64",
-          "nullable": true
+          "type": "number"
          }
         },
         {
          "name": "pre_filter_shard_size",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int64",
-          "nullable": true
+          "type": "number"
          }
         },
         {
@@ -172,16 +156,14 @@
          "name": "request_cache",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "rest_total_hits_as_int",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -197,8 +179,7 @@
          "schema": {
           "type": "string",
           "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
-         },
-         "example": "1d"
+         }
         },
         {
          "name": "search_type",
@@ -211,17 +192,14 @@
          "name": "seq_no_primary_term",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "size",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
@@ -278,8 +256,7 @@
          "name": "stored_fields",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -300,9 +277,7 @@
          "name": "suggest_size",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int64",
-          "nullable": true
+          "type": "number"
          }
         },
         {
@@ -316,9 +291,7 @@
          "name": "terminate_after",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
@@ -333,33 +306,28 @@
          "name": "track_scores",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "track_total_hits",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
          "name": "typed_keys",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "version",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         }
        ],
@@ -398,23 +366,20 @@
           "type": "string",
           "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
          },
-         "required": true,
-         "example": "books"
+         "required": true
         },
         {
          "name": "allow_no_indices",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "allow_partial_search_results",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -428,25 +393,21 @@
          "name": "analyze_wildcard",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "batched_reduce_size",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
          "name": "ccs_minimize_roundtrips",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -481,59 +442,49 @@
          "name": "explain",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "from",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
          "name": "ignore_throttled",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "ignore_unavailable",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "lenient",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "max_concurrent_shard_requests",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int64",
-          "nullable": true
+          "type": "number"
          }
         },
         {
          "name": "pre_filter_shard_size",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int64",
-          "nullable": true
+          "type": "number"
          }
         },
         {
@@ -554,16 +505,14 @@
          "name": "request_cache",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "rest_total_hits_as_int",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -579,8 +528,7 @@
          "schema": {
           "type": "string",
           "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
-         },
-         "example": "1d"
+         }
         },
         {
          "name": "search_type",
@@ -593,17 +541,14 @@
          "name": "seq_no_primary_term",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "size",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
@@ -660,8 +605,7 @@
          "name": "stored_fields",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -682,9 +626,7 @@
          "name": "suggest_size",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int64",
-          "nullable": true
+          "type": "number"
          }
         },
         {
@@ -698,9 +640,7 @@
          "name": "terminate_after",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
@@ -715,33 +655,28 @@
          "name": "track_scores",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "track_total_hits",
          "in": "query",
          "schema": {
-          "type": "number",
-          "format": "int32",
-          "nullable": true
+          "type": "number"
          }
         },
         {
          "name": "typed_keys",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "version",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         }
        ],
@@ -785,13 +720,15 @@
         "_index": {
          "type": "string"
         },
+        "_type": {
+         "type": "string"
+        },
         "_id": {
          "type": "string"
         },
         "_score": {
          "type": "number",
-         "format": "float",
-         "nullable": true
+         "format": "float"
         },
         "_source": {},
         "fields": {}
@@ -805,8 +742,7 @@
         },
         "max_score": {
          "type": "number",
-         "format": "double",
-         "nullable": true
+         "format": "double"
         },
         "hits": {
          "type": "array",
@@ -823,22 +759,16 @@
          "type": "string"
         },
         "explain": {
-         "type": "boolean",
-         "nullable": true
+         "type": "boolean"
         },
         "from": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "seq_no_primary_term": {
-         "type": "boolean",
-         "nullable": true
+         "type": "boolean"
         },
         "size": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "source": {
          "type": "string"
@@ -847,17 +777,14 @@
          "type": "string"
         },
         "terminate_after": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "timeout": {
          "type": "string",
          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
         },
         "version": {
-         "type": "boolean",
-         "nullable": true
+         "type": "boolean"
         },
         "fields": {
          "type": "array",
@@ -866,9 +793,7 @@
          }
         },
         "min_score": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "indices_boost": {
          "type": "array",
@@ -886,13 +811,10 @@
          "type": "string"
         },
         "took": {
-         "type": "number",
-         "format": "int64",
-         "nullable": true
+         "type": "number"
         },
         "timed_out": {
-         "type": "boolean",
-         "nullable": true
+         "type": "boolean"
         },
         "_shards": {
          "$ref": "#/components/schemas/ShardStatistics"
@@ -909,22 +831,16 @@
          "type": "string"
         },
         "explain": {
-         "type": "boolean",
-         "nullable": true
+         "type": "boolean"
         },
         "from": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "seq_no_primary_term": {
-         "type": "boolean",
-         "nullable": true
+         "type": "boolean"
         },
         "size": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "source": {
          "type": "string"
@@ -933,17 +849,14 @@
          "type": "string"
         },
         "terminate_after": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "timeout": {
          "type": "string",
          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
         },
         "version": {
-         "type": "boolean",
-         "nullable": true
+         "type": "boolean"
         },
         "fields": {
          "type": "array",
@@ -952,9 +865,7 @@
          }
         },
         "min_score": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "indices_boost": {
          "type": "array",
@@ -968,17 +879,18 @@
       "PostSearchWithIndexResponseContent": {
        "type": "object",
        "properties": {
+        "index": {
+         "type": "string",
+         "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
+        },
         "_scroll_id": {
          "type": "string"
         },
         "took": {
-         "type": "number",
-         "format": "int64",
-         "nullable": true
+         "type": "number"
         },
         "timed_out": {
-         "type": "boolean",
-         "nullable": true
+         "type": "boolean"
         },
         "_shards": {
          "$ref": "#/components/schemas/ShardStatistics"
@@ -986,7 +898,10 @@
         "hits": {
          "$ref": "#/components/schemas/HitsMetadata"
         }
-       }
+       },
+       "required": [
+        "index"
+       ]
       },
       "Relation": {
        "type": "string",
@@ -1006,24 +921,16 @@
        "type": "object",
        "properties": {
         "total": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "successful": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "skipped": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "failed": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         }
        }
       },
@@ -1039,9 +946,7 @@
        "type": "object",
        "properties": {
         "value": {
-         "type": "number",
-         "format": "int32",
-         "nullable": true
+         "type": "number"
         },
         "relation": {
          "$ref": "#/components/schemas/Relation"
@@ -1136,8 +1041,18 @@
        "type": "object",
        "additionalProperties": {}
       }
+     },
+     "securitySchemes": {
+      "smithy.api.httpBasicAuth": {
+       "type": "http",
+       "description": "HTTP Basic authentication",
+       "scheme": "Basic"
+      }
      }
-    }
-}
-  
-  
+    },
+    "security": [
+     {
+      "smithy.api.httpBasicAuth": []
+     }
+    ]
+   }

--- a/test/models/_global/search/hooks.js
+++ b/test/models/_global/search/hooks.js
@@ -42,15 +42,7 @@ hooks.before("/_search > POST > 200 > application/json",function(transactions,do
               "content-type": "application/json; charset=UTF-8"
           }
       });
-    
-      var query = {
-        query: {
-          match_all: {}
-        },
-        fields: ["*"]
-      }
-  
-      transactions.request.body = JSON.stringify(query);
+
       done();
   }
   request();
@@ -96,14 +88,6 @@ hooks.before("/{index}/_search > POST > 200 > application/json",function(transac
           }
       });
     
-      var query = {
-        query: {
-          match_all: {}
-        },
-        fields: ["*"]
-      }
-  
-      transactions.request.body = JSON.stringify(query);
       done();
   }
   request();

--- a/test/models/cat/indices/cat_indices/OpenSearchModel.json
+++ b/test/models/cat/indices/cat_indices/OpenSearchModel.json
@@ -11,11 +11,27 @@
      "operationId": "GetCatIndices",
      "parameters": [
       {
+       "name": "master_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+        "deprecated": true
+       }
+      },
+      {
+       "name": "cluster_manager_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+       }
+      },
+      {
        "name": "bytes",
        "in": "query",
        "schema": {
-        "type": "number",
-        "nullable": true
+        "type": "number"
        }
       },
       {
@@ -36,24 +52,14 @@
        "name": "include_unloaded_segments",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
        "name": "pri",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
-       }
-      },
-      {
-       "name": "master_timeout",
-       "in": "query",
-       "schema": {
-        "type": "string",
-        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+        "type": "boolean"
        }
       },
       {
@@ -62,6 +68,13 @@
        "schema": {
         "type": "string",
         "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+       }
+      },
+      {
+       "name": "format",
+       "in": "query",
+       "schema": {
+        "type": "string"
        }
       }
      ],
@@ -92,14 +105,37 @@
         "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
        },
        "required": true,
+       "examples": {
+        "GetCatIndicesWithIndex_example1": {
+         "summary": "Examples for Cat indices with Index Operation.",
+         "description": "",
+         "value": "books"
+        }
+       },
        "example": "books"
+      },
+      {
+       "name": "master_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+        "deprecated": true
+       }
+      },
+      {
+       "name": "cluster_manager_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+       }
       },
       {
        "name": "bytes",
        "in": "query",
        "schema": {
-        "type": "number",
-        "nullable": true
+        "type": "number"
        }
       },
       {
@@ -120,24 +156,14 @@
        "name": "include_unloaded_segments",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
        "name": "pri",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
-       }
-      },
-      {
-       "name": "master_timeout",
-       "in": "query",
-       "schema": {
-        "type": "string",
-        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+        "type": "boolean"
        }
       },
       {
@@ -146,6 +172,13 @@
        "schema": {
         "type": "string",
         "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+       }
+      },
+      {
+       "name": "format",
+       "in": "query",
+       "schema": {
+        "type": "string"
        }
       }
      ],
@@ -186,7 +219,18 @@
       "red"
      ]
     }
+   },
+   "securitySchemes": {
+    "smithy.api.httpBasicAuth": {
+     "type": "http",
+     "description": "HTTP Basic authentication",
+     "scheme": "Basic"
+    }
    }
-  }
-}
-
+  },
+  "security": [
+   {
+    "smithy.api.httpBasicAuth": []
+   }
+  ]
+ }

--- a/test/models/cat/nodes/cat_nodes/OpenSearchModel.json
+++ b/test/models/cat/nodes/cat_nodes/OpenSearchModel.json
@@ -11,35 +11,41 @@
      "operationId": "GetCatNodes",
      "parameters": [
       {
+       "name": "master_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+        "deprecated": true
+       }
+      },
+      {
+       "name": "cluster_manager_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+       }
+      },
+      {
        "name": "bytes",
        "in": "query",
        "schema": {
-        "type": "number",
-        "nullable": true
+        "type": "number"
        }
       },
       {
        "name": "full_id",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
        "name": "local",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
-       }
-      },
-      {
-       "name": "master_timeout",
-       "in": "query",
-       "schema": {
-        "type": "string",
-        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+        "type": "boolean"
        }
       },
       {
@@ -54,8 +60,14 @@
        "name": "include_unloaded_segments",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
+       }
+      },
+      {
+       "name": "format",
+       "in": "query",
+       "schema": {
+        "type": "string"
        }
       }
      ],
@@ -77,7 +89,18 @@
   "components": {
    "schemas": {
     "GetCatNodesOutputPayload": {}
+   },
+   "securitySchemes": {
+    "smithy.api.httpBasicAuth": {
+     "type": "http",
+     "description": "HTTP Basic authentication",
+     "scheme": "Basic"
+    }
    }
-  }
-}
-
+  },
+  "security": [
+   {
+    "smithy.api.httpBasicAuth": []
+   }
+  ]
+ }

--- a/test/models/cluster/get_cluster_settings/OpenSearchModel.json
+++ b/test/models/cluster/get_cluster_settings/OpenSearchModel.json
@@ -11,29 +11,43 @@
        "operationId": "GetClusterSettings",
        "parameters": [
         {
+         "name": "master_timeout",
+         "in": "query",
+         "schema": {
+          "type": "string",
+          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+          "deprecated": true
+         }
+        },
+        {
+         "name": "cluster_manager_timeout",
+         "in": "query",
+         "schema": {
+          "type": "string",
+          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+         }
+        },
+        {
          "name": "flat_settings",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "include_defaults",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
+         },
+         "examples": {
+          "GetClusterSettings_example1": {
+           "summary": "Examples for Get cluster settings Operation.",
+           "description": "",
+           "value": true
+          }
          },
          "example": true
-        },
-        {
-         "name": "master_timeout",
-         "in": "query",
-         "schema": {
-          "type": "string",
-          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
-         }
         }
        ],
        "responses": {
@@ -43,6 +57,13 @@
           "application/json": {
            "schema": {
             "$ref": "#/components/schemas/GetClusterSettingsResponseContent"
+           },
+           "examples": {
+            "GetClusterSettings_example1": {
+             "summary": "Examples for Get cluster settings Operation.",
+             "description": "",
+             "value": {}
+            }
            }
           }
          }
@@ -71,9 +92,18 @@
        "type": "object",
        "additionalProperties": {}
       }
+     },
+     "securitySchemes": {
+      "smithy.api.httpBasicAuth": {
+       "type": "http",
+       "description": "HTTP Basic authentication",
+       "scheme": "Basic"
+      }
      }
-    }
-}
-  
-  
-  
+    },
+    "security": [
+     {
+      "smithy.api.httpBasicAuth": []
+     }
+    ]
+   }

--- a/test/models/cluster/put_update_cluster_settings/OpenSearchModel.json
+++ b/test/models/cluster/put_update_cluster_settings/OpenSearchModel.json
@@ -20,19 +20,27 @@
      },
      "parameters": [
       {
-       "name": "flat_settings",
-       "in": "query",
-       "schema": {
-        "type": "boolean",
-        "nullable": true
-       }
-      },
-      {
        "name": "master_timeout",
        "in": "query",
        "schema": {
         "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+        "deprecated": true
+       }
+      },
+      {
+       "name": "cluster_manager_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
         "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+       }
+      },
+      {
+       "name": "flat_settings",
+       "in": "query",
+       "schema": {
+        "type": "boolean"
        }
       },
       {
@@ -76,8 +84,7 @@
      "type": "object",
      "properties": {
       "acknowledged": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       },
       "persistent": {
        "$ref": "#/components/schemas/UserDefinedValueMap"
@@ -91,8 +98,18 @@
      "type": "object",
      "additionalProperties": {}
     }
+   },
+   "securitySchemes": {
+    "smithy.api.httpBasicAuth": {
+     "type": "http",
+     "description": "HTTP Basic authentication",
+     "scheme": "Basic"
+    }
    }
-  }
-}
-
-
+  },
+  "security": [
+   {
+    "smithy.api.httpBasicAuth": []
+   }
+  ]
+ }

--- a/test/models/indices/aliases/OpenSearchModel.json
+++ b/test/models/indices/aliases/OpenSearchModel.json
@@ -7,13 +7,20 @@
   "paths": {
    "/_aliases": {
     "post": {
-     "description": "TO CONFIRM.",
+     "description": "Adds or removes index aliases.",
      "operationId": "PostAliases",
      "requestBody": {
       "content": {
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/PostAliasesRequestContent"
+        },
+        "examples": {
+         "PostAliases_example1": {
+          "summary": "Examples for Post Aliases Operation.",
+          "description": "",
+          "value": {}
+         }
         }
        }
       }
@@ -21,6 +28,15 @@
      "parameters": [
       {
        "name": "master_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+        "deprecated": true
+       }
+      },
+      {
+       "name": "cluster_manager_timeout",
        "in": "query",
        "schema": {
         "type": "string",
@@ -43,6 +59,15 @@
         "application/json": {
          "schema": {
           "$ref": "#/components/schemas/PostAliasesResponseContent"
+         },
+         "examples": {
+          "PostAliases_example1": {
+           "summary": "Examples for Post Aliases Operation.",
+           "description": "",
+           "value": {
+            "acknowledged": true
+           }
+          }
          }
         }
        }
@@ -79,8 +104,7 @@
      "type": "object",
      "properties": {
       "acknowledged": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       }
      },
      "required": [
@@ -116,12 +140,10 @@
        "type": "string"
       },
       "is_hidden": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       },
       "is_write_index": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       },
       "must_exist": {
        "type": "string"
@@ -134,7 +156,18 @@
       }
      }
     }
+   },
+   "securitySchemes": {
+    "smithy.api.httpBasicAuth": {
+     "type": "http",
+     "description": "HTTP Basic authentication",
+     "scheme": "Basic"
+    }
    }
-  }
-}
-
+  },
+  "security": [
+   {
+    "smithy.api.httpBasicAuth": []
+   }
+  ]
+ }

--- a/test/models/indices/create/OpenSearchModel.json
+++ b/test/models/indices/create/OpenSearchModel.json
@@ -14,6 +14,13 @@
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/PutCreateIndexRequestContent"
+        },
+        "examples": {
+         "PutCreateIndex_example1": {
+          "summary": "Examples for Create Index Operation.",
+          "description": "",
+          "value": {}
+         }
         }
        }
       }
@@ -27,14 +34,37 @@
         "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
        },
        "required": true,
+       "examples": {
+        "PutCreateIndex_example1": {
+         "summary": "Examples for Create Index Operation.",
+         "description": "",
+         "value": "books"
+        }
+       },
        "example": "books"
+      },
+      {
+       "name": "master_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+        "deprecated": true
+       }
+      },
+      {
+       "name": "cluster_manager_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+       }
       },
       {
        "name": "include_type_name",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
@@ -42,14 +72,6 @@
        "in": "query",
        "schema": {
         "type": "string"
-       }
-      },
-      {
-       "name": "master_timeout",
-       "in": "query",
-       "schema": {
-        "type": "string",
-        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
        }
       },
       {
@@ -68,6 +90,17 @@
         "application/json": {
          "schema": {
           "$ref": "#/components/schemas/PutCreateIndexResponseContent"
+         },
+         "examples": {
+          "PutCreateIndex_example1": {
+           "summary": "Examples for Create Index Operation.",
+           "description": "",
+           "value": {
+            "index": "books",
+            "shards_acknowledged": true,
+            "acknowledged": true
+           }
+          }
          }
         }
        }
@@ -100,12 +133,10 @@
        "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
       },
       "shards_acknowledged": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       },
       "acknowledged": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       }
      },
      "required": [
@@ -123,7 +154,18 @@
      "type": "object",
      "additionalProperties": {}
     }
+   },
+   "securitySchemes": {
+    "smithy.api.httpBasicAuth": {
+     "type": "http",
+     "description": "HTTP Basic authentication",
+     "scheme": "Basic"
+    }
    }
-  }
-}
-
+  },
+  "security": [
+   {
+    "smithy.api.httpBasicAuth": []
+   }
+  ]
+ }

--- a/test/models/indices/delete/OpenSearchModel.json
+++ b/test/models/indices/delete/OpenSearchModel.json
@@ -18,13 +18,37 @@
         "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
        },
        "required": true,
+       "examples": {
+        "DeleteIndex_example1": {
+         "summary": "Examples for Delete Index Operation.",
+         "description": "",
+         "value": "books"
+        }
+       },
        "example": "books"
+      },
+      {
+       "name": "master_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+        "deprecated": true
+       }
+      },
+      {
+       "name": "cluster_manager_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+       }
       },
       {
        "name": "allow_no_indices",
        "in": "query",
        "schema": {
-         "type": "boolean"
+        "type": "boolean"
        }
       },
       {
@@ -38,16 +62,7 @@
        "name": "ignore_unavailable",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
-       }
-      },
-      {
-       "name": "master_timeout",
-       "in": "query",
-       "schema": {
-        "type": "string",
-        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+        "type": "boolean"
        }
       },
       {
@@ -66,6 +81,15 @@
         "application/json": {
          "schema": {
           "$ref": "#/components/schemas/DeleteIndexResponseContent"
+         },
+         "examples": {
+          "DeleteIndex_example1": {
+           "summary": "Examples for Delete Index Operation.",
+           "description": "",
+           "value": {
+            "acknowledged": true
+           }
+          }
          }
         }
        }
@@ -80,8 +104,7 @@
      "type": "object",
      "properties": {
       "acknowledged": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       }
      },
      "example": {
@@ -98,7 +121,18 @@
       "none"
      ]
     }
+   },
+   "securitySchemes": {
+    "smithy.api.httpBasicAuth": {
+     "type": "http",
+     "description": "HTTP Basic authentication",
+     "scheme": "Basic"
+    }
    }
-  }
-}
-
+  },
+  "security": [
+   {
+    "smithy.api.httpBasicAuth": []
+   }
+  ]
+ }

--- a/test/models/indices/get_document/OpenSearchModel.json
+++ b/test/models/indices/get_document/OpenSearchModel.json
@@ -18,6 +18,13 @@
         "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
        },
        "required": true,
+       "examples": {
+        "GetDocumentDoc_example1": {
+         "summary": "Examples for Get document doc Operation.",
+         "description": "",
+         "value": "books"
+        }
+       },
        "example": "books"
       },
       {
@@ -27,6 +34,13 @@
         "type": "string"
        },
        "required": true,
+       "examples": {
+        "GetDocumentDoc_example1": {
+         "summary": "Examples for Get document doc Operation.",
+         "description": "",
+         "value": "1"
+        }
+       },
        "example": "1"
       },
       {
@@ -40,16 +54,14 @@
        "name": "realtime",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
        "name": "refresh",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
@@ -63,8 +75,7 @@
        "name": "stored_fields",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
@@ -92,9 +103,7 @@
        "name": "version",
        "in": "query",
        "schema": {
-        "type": "number",
-        "format": "int32",
-        "nullable": true
+        "type": "number"
        }
       },
       {
@@ -112,6 +121,18 @@
         "application/json": {
          "schema": {
           "$ref": "#/components/schemas/GetDocumentDocResponseContent"
+         },
+         "examples": {
+          "GetDocumentDoc_example1": {
+           "summary": "Examples for Get document doc Operation.",
+           "description": "",
+           "value": {
+            "_index": "books",
+            "_type": "_doc",
+            "_id": "1",
+            "found": true
+           }
+          }
          }
         }
        }
@@ -132,6 +153,13 @@
         "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
        },
        "required": true,
+       "examples": {
+        "GetDocumentSource_example1": {
+         "summary": "Examples for Get document source Operation.",
+         "description": "",
+         "value": "books"
+        }
+       },
        "example": "books"
       },
       {
@@ -141,6 +169,13 @@
         "type": "string"
        },
        "required": true,
+       "examples": {
+        "GetDocumentSource_example1": {
+         "summary": "Examples for Get document source Operation.",
+         "description": "",
+         "value": "1"
+        }
+       },
        "example": "1"
       },
       {
@@ -154,16 +189,14 @@
        "name": "realtime",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
        "name": "refresh",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
@@ -177,8 +210,7 @@
        "name": "stored_fields",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
@@ -206,9 +238,7 @@
        "name": "version",
        "in": "query",
        "schema": {
-        "type": "number",
-        "format": "int32",
-        "nullable": true
+        "type": "number"
        }
       },
       {
@@ -243,23 +273,16 @@
        "type": "string"
       },
       "version": {
-       "type": "number",
-       "format": "int32",
-       "nullable": true
+       "type": "number"
       },
       "seq_no": {
-       "type": "number",
-       "format": "int64",
-       "nullable": true
+       "type": "number"
       },
       "primary_term": {
-       "type": "number",
-       "format": "int64",
-       "nullable": true
+       "type": "number"
       },
       "found": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       },
       "_routing": {
        "type": "string"
@@ -274,10 +297,12 @@
      "required": [
       "_id",
       "_index",
+      "_type",
       "found"
      ],
      "example": {
       "_index": "books",
+      "_type": "_doc",
       "_id": "1",
       "found": true
      }
@@ -294,7 +319,18 @@
       "external_gte"
      ]
     }
+   },
+   "securitySchemes": {
+    "smithy.api.httpBasicAuth": {
+     "type": "http",
+     "description": "HTTP Basic authentication",
+     "scheme": "Basic"
+    }
    }
-  }
-}
-
+  },
+  "security": [
+   {
+    "smithy.api.httpBasicAuth": []
+   }
+  ]
+ }

--- a/test/models/indices/get_document/OpenSearchModel.json
+++ b/test/models/indices/get_document/OpenSearchModel.json
@@ -128,7 +128,6 @@
            "description": "",
            "value": {
             "_index": "books",
-            "_type": "_doc",
             "_id": "1",
             "found": true
            }
@@ -297,12 +296,10 @@
      "required": [
       "_id",
       "_index",
-      "_type",
       "found"
      ],
      "example": {
       "_index": "books",
-      "_type": "_doc",
       "_id": "1",
       "found": true
      }

--- a/test/models/indices/get_settings/OpenSearchModel.json
+++ b/test/models/indices/get_settings/OpenSearchModel.json
@@ -18,14 +18,37 @@
           "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
          },
          "required": true,
+         "examples": {
+          "GetSettingsIndex_example1": {
+           "summary": "Examples for Get settings Index Operation.",
+           "description": "",
+           "value": "books"
+          }
+         },
          "example": "books"
+        },
+        {
+         "name": "master_timeout",
+         "in": "query",
+         "schema": {
+          "type": "string",
+          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+          "deprecated": true
+         }
+        },
+        {
+         "name": "cluster_manager_timeout",
+         "in": "query",
+         "schema": {
+          "type": "string",
+          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+         }
         },
         {
          "name": "allow_no_indices",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -39,8 +62,7 @@
          "name": "flat_settings",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -54,24 +76,14 @@
          "name": "ignore_unavailable",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "local",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
-         }
-        },
-        {
-         "name": "master_timeout",
-         "in": "query",
-         "schema": {
-          "type": "string",
-          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+          "type": "boolean"
          }
         }
        ],
@@ -102,6 +114,13 @@
           "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
          },
          "required": true,
+         "examples": {
+          "GetSettingsIndexSetting_example1": {
+           "summary": "Examples for Get settings Index-setting Operation.",
+           "description": "",
+           "value": "books"
+          }
+         },
          "example": "books"
         },
         {
@@ -111,14 +130,37 @@
           "type": "string"
          },
          "required": true,
+         "examples": {
+          "GetSettingsIndexSetting_example1": {
+           "summary": "Examples for Get settings Index-setting Operation.",
+           "description": "",
+           "value": "index"
+          }
+         },
          "example": "index"
+        },
+        {
+         "name": "master_timeout",
+         "in": "query",
+         "schema": {
+          "type": "string",
+          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+          "deprecated": true
+         }
+        },
+        {
+         "name": "cluster_manager_timeout",
+         "in": "query",
+         "schema": {
+          "type": "string",
+          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+         }
         },
         {
          "name": "allow_no_indices",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -132,8 +174,7 @@
          "name": "flat_settings",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
@@ -147,24 +188,14 @@
          "name": "ignore_unavailable",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
+          "type": "boolean"
          }
         },
         {
          "name": "local",
          "in": "query",
          "schema": {
-          "type": "boolean",
-          "nullable": true
-         }
-        },
-        {
-         "name": "master_timeout",
-         "in": "query",
-         "schema": {
-          "type": "string",
-          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+          "type": "boolean"
          }
         }
        ],
@@ -197,6 +228,18 @@
       },
       "GetSettingsIndexOutputPayload": {},
       "GetSettingsIndexSettingOutputPayload": {}
+     },
+     "securitySchemes": {
+      "smithy.api.httpBasicAuth": {
+       "type": "http",
+       "description": "HTTP Basic authentication",
+       "scheme": "Basic"
+      }
      }
-    }
-}
+    },
+    "security": [
+     {
+      "smithy.api.httpBasicAuth": []
+     }
+    ]
+   }

--- a/test/models/indices/put_mapping/OpenSearchModel.json
+++ b/test/models/indices/put_mapping/OpenSearchModel.json
@@ -14,6 +14,13 @@
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/PutIndexMappingWithIndexRequestContent"
+        },
+        "examples": {
+         "PutIndexMappingWithIndex_example1": {
+          "summary": "Examples for Put Index Mapping with index Operation.",
+          "description": "",
+          "value": {}
+         }
         }
        }
       }
@@ -27,14 +34,37 @@
         "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
        },
        "required": true,
+       "examples": {
+        "PutIndexMappingWithIndex_example1": {
+         "summary": "Examples for Put Index Mapping with index Operation.",
+         "description": "",
+         "value": "books"
+        }
+       },
        "example": "books"
+      },
+      {
+       "name": "master_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$",
+        "deprecated": true
+       }
+      },
+      {
+       "name": "cluster_manager_timeout",
+       "in": "query",
+       "schema": {
+        "type": "string",
+        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+       }
       },
       {
        "name": "allow_no_indices",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
@@ -48,24 +78,14 @@
        "name": "ignore_unavailable",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       },
       {
        "name": "include_type_name",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
-       }
-      },
-      {
-       "name": "master_timeout",
-       "in": "query",
-       "schema": {
-        "type": "string",
-        "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+        "type": "boolean"
        }
       },
       {
@@ -80,8 +100,7 @@
        "name": "write_index_only",
        "in": "query",
        "schema": {
-        "type": "boolean",
-        "nullable": true
+        "type": "boolean"
        }
       }
      ],
@@ -92,6 +111,15 @@
         "application/json": {
          "schema": {
           "$ref": "#/components/schemas/PutIndexMappingWithIndexResponseContent"
+         },
+         "examples": {
+          "PutIndexMappingWithIndex_example1": {
+           "summary": "Examples for Put Index Mapping with index Operation.",
+           "description": "",
+           "value": {
+            "acknowledged": true
+           }
+          }
          }
         }
        }
@@ -122,16 +150,25 @@
      "type": "object",
      "properties": {
       "acknowledged": {
-       "type": "boolean",
-       "nullable": true
+       "type": "boolean"
       }
      },
      "example": {
       "acknowledged": true
      }
     }
+   },
+   "securitySchemes": {
+    "smithy.api.httpBasicAuth": {
+     "type": "http",
+     "description": "HTTP Basic authentication",
+     "scheme": "Basic"
+    }
    }
-  }
-}
-
-
+  },
+  "security": [
+   {
+    "smithy.api.httpBasicAuth": []
+   }
+  ]
+ }


### PR DESCRIPTION
### Description
Deprecates `master_timeout` in favor of `cluster_manager_timeout`, reflecting the inclusive naming changes from OpenSearch 2.0

### Issues Resolved
Resolves #67 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
