### PR TITLE
Add models for the `/_remotestore/_restore` API endpoint

### DIFF
--- a/model/common_datatypes.smithy
+++ b/model/common_datatypes.smithy
@@ -28,6 +28,10 @@ enum SettingType {
     DEFAULTS = "defaults"
 }
 
+list IndexNameList {
+    member: IndexName
+}
+
 list UserDefinedValueList{
     member: String
 }

--- a/model/opensearch.smithy
+++ b/model/opensearch.smithy
@@ -17,5 +17,23 @@ use aws.protocols#restJson1
 @restJson1
 service OpenSearch {
     version: "2021-11-23",
-    operations: [PutCreateIndex, PutIndexMappingWithIndex, GetCatIndices, GetCatIndicesWithIndex, GetCatNodes, PostSearch, PostSearchWithIndex, DeleteIndex, GetDocumentDoc, GetDocumentSource, GetClusterInfo, PutUpdateClusterSettings, GetClusterSettings, PostAliases, GetSettingsIndex, GetSettingsIndexSetting]
+    operations: [
+        PutCreateIndex,
+        PutIndexMappingWithIndex,
+        GetCatIndices,
+        GetCatIndicesWithIndex,
+        GetCatNodes,
+        PostSearch,
+        PostSearchWithIndex,
+        DeleteIndex,
+        GetDocumentDoc,
+        GetDocumentSource,
+        GetClusterInfo,
+        PutUpdateClusterSettings,
+        GetClusterSettings,
+        PostAliases,
+        GetSettingsIndex,
+        GetSettingsIndexSetting,
+        PostRemoteStoreRestore
+    ]
 }

--- a/model/remotestore/restore/operations.smithy
+++ b/model/remotestore/restore/operations.smithy
@@ -7,6 +7,7 @@
 $version: "2"
 namespace OpenSearch
 
+@unstable
 @externalDocumentation(
     "OpenSearch Documentation": "https://opensearch.org/docs/latest/opensearch/remote/#restoring-from-a-backup"
 )

--- a/model/remotestore/restore/operations.smithy
+++ b/model/remotestore/restore/operations.smithy
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//  The OpenSearch Contributors require contributions made to
+//  this file be licensed under the Apache-2.0 license or a
+//  compatible open source license.
+
+$version: "2"
+namespace OpenSearch
+
+@externalDocumentation(
+    "OpenSearch Documentation": "https://opensearch.org/docs/latest/opensearch/remote/#restoring-from-a-backup"
+)
+
+@suppress(["HttpUriConflict"])
+@http(method: "POST", uri: "/_remotestore/_restore")
+@documentation("Restore one or more indices from a remote backup.")
+operation PostRemoteStoreRestore{
+    input: PostRemoteStoreRestoreInput,
+    output: PostRemoteStoreRestoreOutput
+}

--- a/model/remotestore/restore/structures.smithy
+++ b/model/remotestore/restore/structures.smithy
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//  The OpenSearch Contributors require contributions made to
+//  this file be licensed under the Apache-2.0 license or a
+//  compatible open source license.
+
+$version: "2"
+namespace OpenSearch
+
+structure PostRemoteStoreRestoreInput {
+    @httpQuery("cluster_manager_timeout")
+    cluster_manager_timeout: Time,
+
+    @httpQuery("wait_for_completion")
+    wait_for_completion: Boolean,
+
+    @required
+    indices: IndexNameList
+}
+
+structure PostRemoteStoreRestoreOutput {
+    accepted: Boolean,
+
+    remote_store: RemoteStoreRestoreInfo
+}
+
+structure RemoteStoreRestoreInfo {
+    snapshot: String,
+    indices: IndexNameList,
+    shards: RemoteStoreRestoreShardsInfo
+}
+
+structure RemoteStoreRestoreShardsInfo {
+    total: Integer,
+    failed: Integer,
+    successful: Integer
+}

--- a/model/remotestore/restore/structures.smithy
+++ b/model/remotestore/restore/structures.smithy
@@ -22,7 +22,6 @@ structure PostRemoteStoreRestoreInput {
 @unstable
 structure PostRemoteStoreRestoreOutput {
     accepted: Boolean,
-
     remote_store: RemoteStoreRestoreInfo
 }
 
@@ -39,3 +38,22 @@ structure RemoteStoreRestoreShardsInfo {
     failed: Integer,
     successful: Integer
 }
+
+apply PostRemoteStoreRestore @examples([
+    {
+        title: "Examples for Post Remote Storage Restore Operation.",
+        input: {
+            indices: ["books"]
+        },
+        output: {
+            remote_store: {
+                indices: ["books"],
+                shards: {
+                    total: 1,
+                    failed: 0,
+                    successful: 1
+                }
+            }
+        }
+    }
+])

--- a/model/remotestore/restore/structures.smithy
+++ b/model/remotestore/restore/structures.smithy
@@ -7,6 +7,7 @@
 $version: "2"
 namespace OpenSearch
 
+@unstable
 structure PostRemoteStoreRestoreInput {
     @httpQuery("cluster_manager_timeout")
     cluster_manager_timeout: Time,
@@ -18,18 +19,21 @@ structure PostRemoteStoreRestoreInput {
     indices: IndexNameList
 }
 
+@unstable
 structure PostRemoteStoreRestoreOutput {
     accepted: Boolean,
 
     remote_store: RemoteStoreRestoreInfo
 }
 
+@unstable
 structure RemoteStoreRestoreInfo {
     snapshot: String,
     indices: IndexNameList,
     shards: RemoteStoreRestoreShardsInfo
 }
 
+@unstable
 structure RemoteStoreRestoreShardsInfo {
     total: Integer,
     failed: Integer,

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   opensearch-node1:
-    image: opensearchproject/opensearch:latest
+    build: ./opensearch
     container_name: opensearch-node1
     environment:
       - cluster.name=opensearch-cluster
@@ -9,7 +9,8 @@ services:
       - discovery.seed_hosts=opensearch-node1,opensearch-node2
       - cluster.initial_master_nodes=opensearch-node1,opensearch-node2
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - path.repo=/mnt/snapshots
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m -Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true"
     ulimits:
       memlock:
         soft: -1
@@ -19,6 +20,7 @@ services:
         hard: 65536
     volumes:
       - opensearch-data1:/usr/share/opensearch/data
+      - opensearch-snapshots:/mnt/snapshots
     ports:
       - 9200:9200
       - 9600:9600 # required for Performance Analyzer
@@ -26,7 +28,7 @@ services:
       - opensearch-net
   
   opensearch-node2:
-    image: opensearchproject/opensearch:latest
+    build: ./opensearch
     container_name: opensearch-node2
     environment:
       - cluster.name=opensearch-cluster
@@ -34,7 +36,8 @@ services:
       - discovery.seed_hosts=opensearch-node1,opensearch-node2
       - cluster.initial_master_nodes=opensearch-node1,opensearch-node2
       - bootstrap.memory_lock=true
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - path.repo=/mnt/snapshots
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m -Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true"
     ulimits:
       memlock:
         soft: -1
@@ -44,12 +47,14 @@ services:
         hard: 65536
     volumes:
       - opensearch-data2:/usr/share/opensearch/data
+      - opensearch-snapshots:/mnt/snapshots
     networks:
       - opensearch-net
 
 volumes:
   opensearch-data1:
   opensearch-data2:
+  opensearch-snapshots:
 
 networks:
   opensearch-net:

--- a/test/models/remotestore/restore/OpenSearchModel.json
+++ b/test/models/remotestore/restore/OpenSearchModel.json
@@ -1,0 +1,169 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+     "title": "OpenSearch",
+     "version": "2021-11-23"
+    },
+    "paths": {
+     "/_remotestore/_restore": {
+      "post": {
+       "description": "Restore one or more indices from a remote backup.",
+       "operationId": "PostRemoteStoreRestore",
+       "requestBody": {
+        "content": {
+         "application/json": {
+          "schema": {
+           "$ref": "#/components/schemas/PostRemoteStoreRestoreRequestContent"
+          },
+          "examples": {
+           "PostRemoteStoreRestore_example1": {
+            "summary": "Examples for Post Remote Storage Restore Operation.",
+            "description": "",
+            "value": {
+             "indices": [
+              "books"
+             ]
+            }
+           }
+          }
+         }
+        },
+        "required": true
+       },
+       "parameters": [
+        {
+         "name": "cluster_manager_timeout",
+         "in": "query",
+         "schema": {
+          "type": "string",
+          "pattern": "^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$"
+         }
+        },
+        {
+         "name": "wait_for_completion",
+         "in": "query",
+         "schema": {
+          "type": "boolean"
+         }
+        }
+       ],
+       "responses": {
+        "200": {
+         "description": "PostRemoteStoreRestore 200 response",
+         "content": {
+          "application/json": {
+           "schema": {
+            "$ref": "#/components/schemas/PostRemoteStoreRestoreResponseContent"
+           },
+           "examples": {
+            "PostRemoteStoreRestore_example1": {
+             "summary": "Examples for Post Remote Storage Restore Operation.",
+             "description": "",
+             "value": {
+              "remote_store": {
+               "indices": [
+                "books"
+               ],
+               "shards": {
+                "total": 1,
+                "failed": 0,
+                "successful": 1
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    },
+    "components": {
+     "schemas": {
+      "PostRemoteStoreRestoreRequestContent": {
+       "type": "object",
+       "properties": {
+        "indices": {
+         "type": "array",
+         "items": {
+          "type": "string",
+          "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
+         }
+        }
+       },
+       "required": [
+        "indices"
+       ]
+      },
+      "PostRemoteStoreRestoreResponseContent": {
+       "type": "object",
+       "properties": {
+        "accepted": {
+         "type": "boolean"
+        },
+        "remote_store": {
+         "$ref": "#/components/schemas/RemoteStoreRestoreInfo"
+        }
+       },
+       "example": {
+        "remote_store": {
+         "indices": [
+          "books"
+         ],
+         "shards": {
+          "total": 1,
+          "failed": 0,
+          "successful": 1
+         }
+        }
+       }
+      },
+      "RemoteStoreRestoreInfo": {
+       "type": "object",
+       "properties": {
+        "snapshot": {
+         "type": "string"
+        },
+        "indices": {
+         "type": "array",
+         "items": {
+          "type": "string",
+          "pattern": "^[^+_\\-\\.][^\\\\, /*?\"<>| ,#\\nA-Z]+$"
+         }
+        },
+        "shards": {
+         "$ref": "#/components/schemas/RemoteStoreRestoreShardsInfo"
+        }
+       }
+      },
+      "RemoteStoreRestoreShardsInfo": {
+       "type": "object",
+       "properties": {
+        "total": {
+         "type": "number"
+        },
+        "failed": {
+         "type": "number"
+        },
+        "successful": {
+         "type": "number"
+        }
+       }
+      }
+     },
+     "securitySchemes": {
+      "smithy.api.httpBasicAuth": {
+       "type": "http",
+       "description": "HTTP Basic authentication",
+       "scheme": "Basic"
+      }
+     }
+    },
+    "security": [
+     {
+      "smithy.api.httpBasicAuth": []
+     }
+    ]
+   }

--- a/test/models/remotestore/restore/hooks.js
+++ b/test/models/remotestore/restore/hooks.js
@@ -1,0 +1,98 @@
+const https = require('https');
+const fetch = require('node-fetch')
+const hooks = require('hooks');
+const fs = require('fs');
+
+var host = "";
+var protocol = "https";
+var auth = "";
+
+// Reading .txt file to set URL  
+const data = fs.readFileSync('url.txt', {encoding:'utf8', flag:'r'});
+function address()
+{
+    text = data.toString();
+    text = text.split(" ");
+    host = text[0].substring(8,text[0].length);
+    auth = text[1];
+    return (protocol + "://" + auth + "@" + host); 
+}
+
+// Remote Storage Restore
+
+hooks.before("/_remotestore/_restore > POST > 200 > application/json", function(transactions, done) {
+    transactions.expected.headers['Content-Type'] =  "application/json; charset=UTF-8";
+
+    const request = async () => {
+
+        var url = address();
+
+        // Register repository for remote store
+        await fetch(url + '/_snapshot/books-repo', {
+            method: 'PUT',
+            body: JSON.stringify({
+                type: 'fs',
+                settings: {
+                    location: '/mnt/snapshots'
+                }
+            }),
+            headers: {
+                "content-type": "application/json; charset=UTF-8"
+            }
+        });
+
+        // Create an index configured for remote store
+        await fetch(url + '/books', {
+            method: 'PUT',
+            body: JSON.stringify({
+                settings : {
+                    index: {
+                        number_of_shards: 1,
+                        number_of_replicas: 0,
+                        replication: {
+                            type: 'SEGMENT'
+                        },
+                        remote_store: {
+                            enabled: true,
+                            repository: 'books-repo'
+                        }
+                    }
+                }    
+            }),
+            headers: {
+                "content-type": "application/json; charset=UTF-8"
+            }
+        });
+
+        // Close the index
+        await fetch(url + '/books/_close', {
+            method: 'POST'
+        });
+      
+        done();
+    }
+
+    request();
+});
+  
+hooks.after("/_remotestore/_restore > POST > 200 > application/json", function(transactions, done) {
+  
+    const request = async () => {
+      
+        var url = address();
+        
+        // Delete index
+        await fetch(url + '/books', {
+            method: 'DELETE'
+        });
+
+        // Delete repository
+        await fetch(url + '/_snapshot/books-repo', {
+            method: 'DELETE'
+        });
+
+        done();
+    }  
+    request();
+});
+

--- a/test/opensearch/Dockerfile
+++ b/test/opensearch/Dockerfile
@@ -1,0 +1,7 @@
+FROM opensearchproject/opensearch:latest
+
+USER root
+RUN mkdir -p /mnt/snapshots && chown -R opensearch:opensearch /mnt/snapshots
+
+USER opensearch
+VOLUME /mnt/snapshots

--- a/test/scripts/operation-filter.py
+++ b/test/scripts/operation-filter.py
@@ -22,7 +22,7 @@ class OperationFilter:
 
         shutil.copyfile(original, target)
 
-        command = 'sed "s/operations:.*$/operations: [' + self.operations + \
+        command = 'sed -e \'1h;2,$H;$!d;g\' -e "s/operations: \[[^]]*\]/operations: [' + self.operations + \
             ']/" opensearch_temp.smithy > ../../model/opensearch.smithy'
         os.system(command)
 


### PR DESCRIPTION
### Description
Add's models for the `/_remotestore/_restore` API endpoint

<img width="821" alt="Screen Shot 2022-12-07 at 10 45 26 AM" src="https://user-images.githubusercontent.com/1222964/206030365-a39252ff-417a-46b6-910f-1cddb7734470.png">

As seen [here](https://github.com/opensearch-project/OpenSearch/blob/5500114cc55d94bb8a7699f3db6870d83dc92445/server/src/main/java/org/opensearch/action/admin/cluster/remotestore/restore/RestoreRemoteStoreResponse.java#L75), `accepted` may be set in the response instead of `remote_store`, unsure of exact causal path however.

### Issues Resolved
Resolves #69 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
