### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,19 +1,16 @@
-- [Current Maintainers](#current-maintainers)
-- [Maintainer Responsibilities](#maintainer-responsibilities)
+## Overview
+
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Current Maintainers
 
-| Maintainer               | GitHub ID                                              | Affiliation |
-| ------------------------ | ------------------------------------------------------ | ----------- |
-| Abhi Kalra               | [abhivka7](https://github.com/abhivka7)                |   Amazon    |
-| Daniel Doubrovkine       | [dblock](https://github.com/dblock)                    |   Amazon    |
-| Harsha Vamsi Kalluri     | [harshavamsi](https://github.com/harshavamsi)          |   Amazon    |
-| Pranav Garg              | [pgtgrly](https://github.com/pgtgrly)                  |   Amazon    |
-| Sachet Alva              | [sachetalva](https://github.com/sachetalva)            |   Amazon    |
-| Theo Truong              | [nhtruong](https://github.com/nhtruong)                |   Amazon    |
-| Thomas Farr              | [Xtansia](https://github.com/Xtansia)                  |   Amazon    |
-| Vacha Shah               | [VachaShah](https://github.com/VachaShah)              |   Amazon    |
-
-## Maintainer Responsibilities
-
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+| Maintainer           | GitHub ID                                     | Affiliation |
+| -------------------- | --------------------------------------------- | ----------- |
+| Abhi Kalra           | [abhivka7](https://github.com/abhivka7)       | Amazon      |
+| Daniel Doubrovkine   | [dblock](https://github.com/dblock)           | Amazon      |
+| Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
+| Pranav Garg          | [pgtgrly](https://github.com/pgtgrly)         | Amazon      |
+| Sachet Alva          | [sachetalva](https://github.com/sachetalva)   | Amazon      |
+| Theo Truong          | [nhtruong](https://github.com/nhtruong)       | Amazon      |
+| Thomas Farr          | [Xtansia](https://github.com/Xtansia)         | Amazon      |
+| Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.