### PR TITLE
Publishing OpenAPI specs to Github Pages

### DIFF
--- a/.github/workflows/update_specs.yml
+++ b/.github/workflows/update_specs.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update:
+    if: github.repository == 'opensearch-project/opensearch-api-specification'
     runs-on: ubuntu-latest
     steps:
       - name: GitHub App token

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<html>
+    <head>
+        <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
+        <script src="https://unpkg.com/swagger-ui-dist@4/swagger-ui-bundle.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+        <title>My New API</title>
+    </head>
+    <body>
+        <div id="swagger-ui"></div> <!-- Div to hold the UI component -->
+        <script>
+            window.onload = function () {
+                // Begin Swagger UI call region
+                const ui = SwaggerUIBundle({
+                    url: "swagger.json", //Location of Open API spec in the repo
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIBundle.SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                        SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                })
+                window.ui = ui
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Framework to host API specs using Swagger UI on Github Pages.

Specs on my repo: https://vachashah.github.io/opensearch-api-specification/
Workflow for auto updating specs: #76 

### Issues Resolved
Part of #34 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
