### PR TITLE
Workflow to auto update specs

### DIFF
--- a/.github/workflows/update_specs.yml
+++ b/.github/workflows/update_specs.yml
@@ -1,0 +1,36 @@
+name: Update OpenAPI specs
+on: 
+  push:
+    branches:
+      - main
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Build
+        run: ./gradlew build
+      
+      - name: Move OpenAPI specs to root
+        run: mv build/smithyprojections/opensearch-api-specification/source/openapi/OpenSearch.openapi.json .
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ steps.github_app_token.outputs.token }}
+          commit-message: Update OpenAPI specs
+          title: Update OpenAPI specs
+          body: |
+            I've noticed an update to the models. This pull request updates the OpenAPI specs accordingly.
+          branch: create-pull-request/specs-update


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
When a change is merged to Smithy models, this workflow runs to auto-update the specs which will be displayed as mentioned in #75.

An example PR on my fork: https://github.com/VachaShah/opensearch-api-specification/pull/2
### Issues Resolved
Part of #34 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
