### PR TITLE
Build OpenAPI spec on PR and correct path

### DIFF
--- a/.github/workflows/build-openapi-specs.yml
+++ b/.github/workflows/build-openapi-specs.yml
@@ -1,22 +1,10 @@
-name: Update OpenAPI specs
-on: 
-  push:
-    branches:
-      - main
+name: Build OpenAPI specs
+on: [push, pull_request]
 
 jobs:
-  update:
-    if: github.repository == 'opensearch-project/opensearch-api-specification'
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: GitHub App token
-        id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          installation_id: 22958780
-
       - name: Checkout the repo
         uses: actions/checkout@v3
 
@@ -26,8 +14,23 @@ jobs:
       - name: Move OpenAPI specs to root
         run: mv build/smithyprojections/opensearch-api-specification/source/openapi/OpenSearch.openapi.json .
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: opensearch-openapi
+          path: ./OpenSearch.openapi.json
+
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        if: github.repository == 'opensearch-project/opensearch-api-specification' && github.event_name == 'push' && github.event.ref == 'refs/heads/main'
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
+        if: github.repository == 'opensearch-project/opensearch-api-specification' && github.event_name == 'push' && github.event.ref == 'refs/heads/main'
         with:
           token: ${{ steps.github_app_token.outputs.token }}
           commit-message: Update OpenAPI specs

--- a/.github/workflows/build-openapi-specs.yml
+++ b/.github/workflows/build-openapi-specs.yml
@@ -12,9 +12,10 @@ jobs:
         run: ./gradlew build
       
       - name: Move OpenAPI specs to root
-        run: mv build/smithyprojections/opensearch-api-specification/source/openapi/OpenSearch.openapi.json .
+        run: mv build/smithyprojections/opensearch-api-specification/full/openapi/OpenSearch.openapi.json .
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload OpenAPI model artifact
+        uses: actions/upload-artifact@v3
         with:
           name: opensearch-openapi
           path: ./OpenSearch.openapi.json


### PR DESCRIPTION
### Description
Build the OpenAPI spec on PR to validate the Smithy model, not only main builds.
Also correct the path to the built spec that changed due to #73 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
