### PR TITLE
Support outputting externalDocs on Operation types

### DIFF
--- a/openapi-traits/src/main/java/org/opensearch/smithy/openapi/extensions/mappers/VendorExtensionsOpenApiMapper.java
+++ b/openapi-traits/src/main/java/org/opensearch/smithy/openapi/extensions/mappers/VendorExtensionsOpenApiMapper.java
@@ -1,25 +1,54 @@
 package org.opensearch.smithy.openapi.extensions.mappers;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
 import org.opensearch.smithy.openapi.traits.VendorExtensionsTrait;
+
+import software.amazon.smithy.jsonschema.JsonSchemaConfig;
 import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiJsonSchemaMapper;
 import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
+import software.amazon.smithy.openapi.model.ExternalDocumentation;
 import software.amazon.smithy.openapi.model.OperationObject;
 
 public class VendorExtensionsOpenApiMapper implements OpenApiMapper {
+    private static final Method GET_RESOLVED_EXTERNAL_DOCS;
+
+    static {
+        try {
+            GET_RESOLVED_EXTERNAL_DOCS = OpenApiJsonSchemaMapper.class.getDeclaredMethod("getResolvedExternalDocs", Shape.class, JsonSchemaConfig.class);
+            GET_RESOLVED_EXTERNAL_DOCS.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("Unable to get OpenApiJsonSchemaMapper.getResolvedExternalDocs method", e);
+        }
+    }
+
+    private static Optional<ExternalDocumentation> getResolvedExternalDocs(Shape shape, JsonSchemaConfig config) {
+        try {
+            return (Optional<ExternalDocumentation>) GET_RESOLVED_EXTERNAL_DOCS.invoke(null, shape, config);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Failed calling OpenApiJsonSchemaMapper.getResolvedExternalDocs method", e);
+        }
+    }
+
     @Override
     public OperationObject updateOperation(Context<? extends Trait> context, OperationShape shape, OperationObject operation, String httpMethodName, String path) {
-        return shape.getTrait(VendorExtensionsTrait.class)
-                .map(trait -> {
-                    OperationObject.Builder builder = operation.toBuilder();
+        OperationObject.Builder builder = operation.toBuilder();
 
+        getResolvedExternalDocs(shape, context.getConfig()).ifPresent(builder::externalDocs);
+
+        shape.getTrait(VendorExtensionsTrait.class)
+                .ifPresent(trait -> {
                     trait.getNode()
                             .getMembers()
                             .forEach((k, v) -> builder.putExtension(k.getValue(), v));
+                });
 
-                    return builder.build();
-                })
-                .orElse(operation);
+        return builder.build();
     }
 }


### PR DESCRIPTION
### Description
Support outputting externalDocs on Operation types

Currently Smithy only outputs externalDocs on Service shapes or on schema shapes.

Results in:
```json
        "/_aliases": {
            "post": {
                "description": "Updates index aliases.",
                "externalDocs": {
                    "description": "API Reference",
                    "url": "https://opensearch.org/docs/latest/api-reference/alias/"
                },
                "operationId": "IndicesUpdateAliases",
                "requestBody": {
                    "content": {
                        "application/json": {
                            "schema": {
                                "$ref": "#/components/schemas/IndicesUpdateAliases_BodyParams"
                            }
                        }
                    }
                },
                ...
            }
        }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
