### PR TITLE
adding reload search analyzer specs

### DIFF
--- a/model/indices/reload_search_analyzer/operations.smithy
+++ b/model/indices/reload_search_analyzer/operations.smithy
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//  The OpenSearch Contributors require contributions made to
+//  this file be licensed under the Apache-2.0 license or a
+//  compatible open source license.
+
+$version: "2"
+namespace OpenSearch
+use opensearch.openapi#vendorExtensions
+
+@externalDocumentation(
+    "API Reference": "https://opensearch.org/docs/latest/api-reference/reload-search-analyzer/"
+)
+
+@vendorExtensions(
+    "x-operation-group": "indices.reload_search_analyzer",
+    "x-version-added": "1.0",
+)
+@readonly
+@suppress(["HttpUriConflict"])
+@http(method: "GET", uri: "/{index}/_reload_search_analyzers")
+@documentation("Detects any changes to synonym files for any configured search analyzers.")
+operation ReloadSearchAnalyzer_Get {
+    input: ReloadSearchAnalyzer_Get_Input,
+    output: ReloadSearchAnalyzer_Get_Output
+}
+
+@vendorExtensions(
+    "x-operation-group": "indices.reload_search_analyzer",
+    "x-version-added": "1.0",
+)
+@idempotent
+@suppress(["HttpUriConflict", "HttpMethodSemantics.UnexpectedPayload"])
+@http(method: "POST", uri: "/{index}/_reload_search_analyzers")
+@documentation("Detects any changes to synonym files for any configured search analyzers.")
+operation ReloadSearchAnalyzer_Post {
+    input: ReloadSearchAnalyzer_Post_Input,
+    output: ReloadSearchAnalyzer_Post_Output
+}

--- a/model/indices/reload_search_analyzer/structures.smithy
+++ b/model/indices/reload_search_analyzer/structures.smithy
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//  The OpenSearch Contributors require contributions made to
+//  this file be licensed under the Apache-2.0 license or a
+//  compatible open source license.
+
+$version: "2"
+namespace OpenSearch
+
+@mixin
+structure ReloadSearchAnalyzer_QueryParams {
+    @httpQuery("ignore_unavailable")
+    ignore_unavailable: IgnoreUnavailable,
+
+    @httpQuery("allow_no_indices")
+    allow_no_indices: AllowNoIndices,
+
+    @httpQuery("expand_wildcards")
+    @default("open")
+    expand_wildcards: ExpandWildcards,
+}
+
+structure ReloadDetails {
+  index: PathIndices,
+  reloaded_analyzers: ReloadedAnalyzers,
+  reloaded_node_ids: ReloadedNodeIds
+}
+
+list ReloadedAnalyzers {
+    member: String
+}
+
+list ReloadedNodeIds {
+    member: String
+}
+
+@input
+structure ReloadSearchAnalyzer_Get_Input with [ReloadSearchAnalyzer_QueryParams]{
+    @required
+    @httpLabel
+    index: PathIndices,
+}
+
+@input
+structure ReloadSearchAnalyzer_Post_Input with [ReloadSearchAnalyzer_QueryParams]{
+    @required
+    @httpLabel
+    index: PathIndices,
+}
+
+@output
+structure ReloadSearchAnalyzer_Get_Output {
+    _shards: ShardStatistics,
+
+    reload_details: ReloadDetails
+}
+
+@output
+structure ReloadSearchAnalyzer_Post_Output {
+    _shards: ShardStatistics,
+
+    reload_details: ReloadDetails
+}


### PR DESCRIPTION
### Description
We need to recheck output structure, i'm not 100% sure.
Because i got "no handler found for uri [/index_name/_reload_search_analyzers] and method [GET]" when i test it.
I just used response structure from [documentation](https://opensearch.org/docs/latest/api-reference/reload-search-analyzer/)

### Issues Resolved
[#63]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
