### PR TITLE
Moving health_check to correct directory and renaming structure

### DIFF
--- a/model/opensearch.smithy
+++ b/model/opensearch.smithy
@@ -310,6 +310,7 @@ service OpenSearch {
         Search_Get_WithIndex,
         Search_Post,
         Search_Post_WithIndex,
+        SecurityHealth,
         SnapshotCleanupRepository,
         SnapshotClone,
         SnapshotCreateRepository_Post,

--- a/model/security/health/operations.smithy
+++ b/model/security/health/operations.smithy
@@ -13,14 +13,14 @@ use opensearch.openapi#vendorExtensions
 )
 
 @vendorExtensions(
-    "x-operation-group": "security.health_check",
+    "x-operation-group": "security.health",
     "x-version-added": "1.0",
 )
 @readonly
 @suppress(["HttpUriConflict"])
 @http(method: "GET", uri: "/_plugins/_security/health")
 @documentation("Checks to see if the Security plugin is up and running.")
-operation HealthCheck {
-    input: HealthCheck_Input,
-    output: HealthCheck_Output
+operation SecurityHealth {
+    input: SecurityHealth_Input,
+    output: SecurityHealth_Output
 }

--- a/model/security/health/structures.smithy
+++ b/model/security/health/structures.smithy
@@ -7,16 +7,12 @@
 $version: "2"
 namespace OpenSearch
 
-structure HealthResponse{
+@input
+structure SecurityHealth_Input {
+}
+
+structure SecurityHealth_Output {
     message: String
     mode: String
     status: String
-}
-
-@input
-structure HealthCheck_Input {
-}
-
-structure HealthCheck_Output {
-    content: HealthResponse
 }


### PR DESCRIPTION
### Description
As we discussed at one meetup of CCI, we should move health_check from plugins folder to security.
Added this structure to opensearch.smithy file
Also i fixed few mistakes in structure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
