### PR TITLE
Correct index metric enum options

### DIFF
--- a/model/common_strings.smithy
+++ b/model/common_strings.smithy
@@ -28,7 +28,26 @@ string PathComponentTemplateNames
 string PathFields
 
 @xDataType("array")
-@xEnumOptions(["_all", "completion", "docs", "fielddata", "query_cache", "flush", "get", "indexing", "merge", "request_cache", "refresh", "search", "segments", "store", "warmer", "suggest"])
+@xEnumOptions([
+    "_all",
+    "store",
+    "indexing",
+    "get",
+    "search",
+    "merge",
+    "flush",
+    "refresh",
+    "query_cache",
+    "fielddata",
+    "docs",
+    "warmer",
+    "completion",
+    "segments",
+    "translog",
+    "suggest",
+    "request_cache",
+    "recovery"
+])
 @pattern("^(?!_|template|query|field|point|clear|usage|stats|hot|reload|painless).+$")
 @documentation("Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified.")
 string PathIndexMetric
@@ -44,7 +63,26 @@ string PathIndexNames
 string PathIndices
 
 @xDataType("array")
-@xEnumOptions(["_all", "completion", "docs", "fielddata", "query_cache", "flush", "get", "indexing", "merge", "request_cache", "refresh", "search", "segments", "store", "warmer", "suggest"])
+@xEnumOptions([
+    "_all",
+    "store",
+    "indexing",
+    "get",
+    "search",
+    "merge",
+    "flush",
+    "refresh",
+    "query_cache",
+    "fielddata",
+    "docs",
+    "warmer",
+    "completion",
+    "segments",
+    "translog",
+    "suggest",
+    "request_cache",
+    "recovery"
+])
 @pattern("^(?!_|template|query|field|point|clear|usage|stats|hot|reload|painless).+$")
 @documentation("Limit the information returned the specific metrics.")
 string PathIndicesStatsMetric


### PR DESCRIPTION
### Description
Corrects the index metric enum options, based off https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/admin/indices/stats/CommonStatsFlags.java#L261-L277

Specifically adding the `recovery` and `translog` options which were missing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
