### PR TITLE
Fix missing pluralization on Role

### DIFF
--- a/model/security/role.smithy
+++ b/model/security/role.smithy
@@ -16,8 +16,8 @@ structure Role {
     reserved: Boolean
     hidden: Boolean
     description: String
-    cluster_permission: ClusterPermission
-    index_permission: IndexPermission
+    cluster_permissions: ClusterPermission
+    index_permissions: IndexPermission
     tenant_permissions: TenantPermission
     static: Boolean
 }

--- a/model/security/role.smithy
+++ b/model/security/role.smithy
@@ -17,7 +17,7 @@ structure Role {
     hidden: Boolean
     description: String
     cluster_permissions: ClusterPermission
-    index_permissions: IndexPermission
+    index_permissions: IndexPermissionList
     tenant_permissions: TenantPermission
     static: Boolean
 }
@@ -31,6 +31,10 @@ structure IndexPermission {
     fls: Fls
     masked_fields: MaskedFields
     allowed_actions: AllowedActions
+}
+
+list IndexPermissionList {
+    member: IndexPermission
 }
 
 list TenantPermission {

--- a/model/security/role.smithy
+++ b/model/security/role.smithy
@@ -18,7 +18,7 @@ structure Role {
     description: String
     cluster_permissions: ClusterPermission
     index_permissions: IndexPermissionList
-    tenant_permissions: TenantPermission
+    tenant_permissions: TenantPermissionList
     static: Boolean
 }
 
@@ -38,7 +38,16 @@ list IndexPermissionList {
     member: IndexPermission
 }
 
-list TenantPermission {
+structure TenantPermission {
+    tenant_patterns: TenantPatterns
+    allowed_actions: AllowedActions
+}
+
+list TenantPermissionList {
+    member: TenantPermission
+}
+
+list TenantPatterns {
     member: String
 }
 

--- a/model/security/role.smithy
+++ b/model/security/role.smithy
@@ -28,6 +28,7 @@ list ClusterPermission {
 
 structure IndexPermission {
     index_patterns: IndexPatterns
+    dls: String
     fls: Fls
     masked_fields: MaskedFields
     allowed_actions: AllowedActions


### PR DESCRIPTION
### Description
Both `cluster_permission` and `index_permission` should be plural as per the [docs](https://opensearch.org/docs/1.2/security-plugin/access-control/api#create-role).