### PR TITLE
Mark `keep_alive` as `time` type and correct `_shards` field name

### DIFF
--- a/model/_global/create_pit/structures.smithy
+++ b/model/_global/create_pit/structures.smithy
@@ -37,6 +37,6 @@ structure CreatePit_Input with [CreatePit_QueryParams] {
 @output
 structure CreatePit_Output {
     pit_id: String,
-    _shard: ShardStatistics,
+    _shards: ShardStatistics,
     creation_time: Long
 }

--- a/model/common_strings.smithy
+++ b/model/common_strings.smithy
@@ -270,6 +270,8 @@ string Format
 
 string Index
 
+@xDataType("time")
+@pattern("^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$")
 @documentation("Specify the keep alive for point in time.")
 string KeepAlive
 


### PR DESCRIPTION
### Description
Corrects the `keep_alive` parameter and `_shards` response field of the PIT apis.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
