### PR TITLE
Fix: typo, missing space.

### DIFF
--- a/OpenSearch.openapi.json
+++ b/OpenSearch.openapi.json
@@ -22364,7 +22364,7 @@
                     {
                         "name": "op_type",
                         "in": "query",
-                        "description": "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID.",
+                        "description": "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create` for requests without an explicit document ID.",
                         "schema": {
                             "$ref": "#/components/schemas/OpType"
                         }
@@ -22961,7 +22961,7 @@
                     {
                         "name": "op_type",
                         "in": "query",
-                        "description": "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID.",
+                        "description": "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create` for requests without an explicit document ID.",
                         "schema": {
                             "$ref": "#/components/schemas/OpType"
                         }
@@ -23109,7 +23109,7 @@
                     {
                         "name": "op_type",
                         "in": "query",
-                        "description": "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID.",
+                        "description": "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create` for requests without an explicit document ID.",
                         "schema": {
                             "$ref": "#/components/schemas/OpType"
                         }
@@ -31512,7 +31512,7 @@
             },
             "OpType": {
                 "type": "string",
-                "description": "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID.",
+                "description": "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create` for requests without an explicit document ID.",
                 "enum": [
                     "index",
                     "create"

--- a/model/common_enums.smithy
+++ b/model/common_enums.smithy
@@ -84,7 +84,7 @@ enum NodesStatLevel {
     SHARDS = "shards"
 }
 
-@documentation("Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID.")
+@documentation("Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create` for requests without an explicit document ID.")
 enum OpType {
     INDEX = "index"
     CREATE = "create"


### PR DESCRIPTION
### Description

Fixed a typo spotted while trying to enable warnings as errors as part of https://github.com/opensearch-project/opensearch-py/issues/558. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
