### PR TITLE
Updating search and node metric querystring parameters

### DIFF
--- a/model/_global/search/structures.smithy
+++ b/model/_global/search/structures.smithy
@@ -149,6 +149,9 @@ structure Search_QueryParams {
     @httpQuery("rest_total_hits_as_int")
     @default(false)
     rest_total_hits_as_int: RestTotalHitsAsInt,
+
+    @httpQuery("search_pipeline")
+    search_pipeline: SearchPipeline
 }
 
 @documentation("The search definition using the Query DSL")

--- a/model/common_strings.smithy
+++ b/model/common_strings.smithy
@@ -66,7 +66,7 @@ string PathNodeId
 string PathNodesInfoMetric
 
 @xDataType("array")
-@xEnumOptions(["_all", "breaker", "fs", "http", "indices", "jvm", "os", "process", "thread_pool", "transport", "discovery", "indexing_pressure"])
+@xEnumOptions(["_all", "breaker", "fs", "http", "indices", "jvm", "os", "process", "thread_pool", "transport", "discovery", "indexing_pressure", "search_pipeline"])
 @pattern("^(?!_|template|query|field|point|clear|usage|stats|hot|reload|painless).+$")
 @documentation("Limit the information returned to the specified metrics.")
 string PathNodesStatsMetric
@@ -248,6 +248,9 @@ string ParentTaskId
 
 @documentation("The pipeline id to preprocess incoming documents with.")
 string Pipeline
+
+@documentation("Customizable sequence of processing stages applied to search queries.")
+string SearchPipeline
 
 @documentation("Specify the node or shard the operation should be performed on.")
 string Preference


### PR DESCRIPTION
### Description
Updating [search endpoints](https://opensearch.org/docs/latest/search-plugins/search-pipelines/using-search-pipeline/) to support query string and [retrieve pipeline stats](https://opensearch.org/docs/latest/search-plugins/search-pipelines/search-pipeline-metrics/) API specs

### Issues Resolved
[#171 ] 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
