### PR TITLE
Correct cat.cluster_manager version added

### DIFF
--- a/model/cat/cluster_manager/operations.smithy
+++ b/model/cat/cluster_manager/operations.smithy
@@ -12,7 +12,7 @@ namespace OpenSearch
 )
 
 @xOperationGroup("cat.cluster_manager")
-@xVersionAdded("1.0")
+@xVersionAdded("2.0")
 @readonly
 @suppress(["HttpUriConflict"])
 @http(method: "GET", uri: "/_cat/cluster_manager")

--- a/model/cat/master/operations.smithy
+++ b/model/cat/master/operations.smithy
@@ -15,7 +15,7 @@ namespace OpenSearch
 @xOperationGroup("cat.master")
 @xVersionAdded("1.0")
 @xDeprecationMessage("To promote inclusive language, please use '/_cat/cluster_manager' instead.")
-@xVersionDeprecated("1.0")
+@xVersionDeprecated("2.0")
 @readonly
 @suppress(["HttpUriConflict"])
 @http(method: "GET", uri: "/_cat/master")


### PR DESCRIPTION
### Description
Correct the cat.cluster_manager version added and conversely the cat.master version deprecated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
