### PR TITLE
Adds API spec coverage report.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -24,7 +26,7 @@ jobs:
         run: |
           docker build . --tag opensearch-with-api-plugin
           docker run -d -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e OPENSEARCH_INITIAL_ADMIN_PASSWORD="${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}" opensearch-with-api-plugin
-          sleep 30
+          sleep 15
       - name: Display OpenSearch Info
         run: |
           curl -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} --insecure https://localhost:9200/ | jq
@@ -38,4 +40,22 @@ jobs:
           cat diff.json | jq '.newEndpoints | group_by(.pathUrl)[] | .[0].pathUrl + ": " + (map(.method) | tostring)' --raw-output
           echo "-------- Legacy APIs"
           cat diff.json | jq '.missingEndpoints | group_by(.pathUrl)[] | .[0].pathUrl + ": " + (map(.method) | tostring)' --raw-output
-
+      - name: Gather Coverage
+        id: coverage
+        shell: bash
+        run: |
+          echo "current=`cat OpenSearch.openapi.json | jq '.paths | keys[]' | wc -l`" >> $GITHUB_OUTPUT
+          echo "total=`cat OpenSearch.auto.openapi.json | jq '.paths | keys[]' | wc -l`" >> $GITHUB_OUTPUT
+      - name: Calculate Percent
+        id: math
+        shell: bash
+        run: |
+          echo "percent=$((${{ steps.coverage.outputs.current }}*100/${{ steps.coverage.outputs.total }}))" >> $GITHUB_OUTPUT
+      - name: Report Coverage
+        shell: bash
+        run: |
+          echo "API specs implemented for ${{ steps.coverage.outputs.current }}/${{ steps.coverage.outputs.total }} (${{ steps.math.outputs.percent }}%) APIs."
+      # - uses: mshick/add-pr-comment@v2
+      #   with:
+      #     message: |
+      #       API specs implemented for ${{ steps.coverage.outputs.current }}/${{ steps.coverage.outputs.total }} (${{ steps.math.outputs.percent }}%) APIs.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 env:
   JAVA_VERSION: 11
-  OPENSEARCH_VERSION: 2.12.0
   OPENSEARCH_INITIAL_ADMIN_PASSWORD: BobgG7YrtsdKf9M
 
 jobs:
@@ -15,47 +14,29 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Install API Plugin
-        run: |
-          wget https://github.com/dblock/opensearch-api/releases/download/v${{ env.OPENSEARCH_VERSION }}/opensearch-api-${{ env.OPENSEARCH_VERSION }}.0.zip
-          echo "FROM opensearchproject/opensearch:${{ env.OPENSEARCH_VERSION }}" >> Dockerfile
-          echo "ADD ./opensearch-api-${{ env.OPENSEARCH_VERSION }}.0.zip /tmp/" >> Dockerfile
-          echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-api-${{ env.OPENSEARCH_VERSION }}.0.zip" >> Dockerfile
-          cat Dockerfile
       - name: Build and Run Docker Container
         run: |
-          docker build . --tag opensearch-with-api-plugin
-          docker run -d -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e OPENSEARCH_INITIAL_ADMIN_PASSWORD="${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}" opensearch-with-api-plugin
+          docker build coverage --tag opensearch-with-api-plugin
+          docker run -d -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e OPENSEARCH_INITIAL_ADMIN_PASSWORD="$OPENSEARCH_INITIAL_ADMIN_PASSWORD" opensearch-with-api-plugin
           sleep 15
       - name: Display OpenSearch Info
         run: |
-          curl -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} --insecure https://localhost:9200/ | jq
+          curl   -ks -u "admin:$OPENSEARCH_INITIAL_ADMIN_PASSWORD" https://localhost:9200/ | jq
       - name: Dump and Compare API
         run: |
-          curl -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} --insecure https://localhost:9200/_plugins/api | jq > OpenSearch.auto.openapi.json
-          docker run --mount type=bind,source=.,target=/specs openapitools/openapi-diff:latest /specs/OpenSearch.openapi.json /specs/OpenSearch.auto.openapi.json --json /specs/diff.json
+          curl -ks -u "admin:$OPENSEARCH_INITIAL_ADMIN_PASSWORD" https://localhost:9200/_plugins/api | jq > OpenSearch.auto.openapi.json
+          docker run --rm --mount type=bind,source=.,target=/specs openapitools/openapi-diff:latest /specs/OpenSearch.openapi.json /specs/OpenSearch.auto.openapi.json --json /specs/diff.json
       - name: Show Diff
         run: |
           echo "-------- Missing APIs"
-          cat diff.json | jq '.newEndpoints | group_by(.pathUrl)[] | .[0].pathUrl + ": " + (map(.method) | tostring)' --raw-output
+          jq -r '.newEndpoints | group_by(.pathUrl)[] | "\(.[0].pathUrl): \([.[].method])"' diff.json
           echo "-------- Legacy APIs"
-          cat diff.json | jq '.missingEndpoints | group_by(.pathUrl)[] | .[0].pathUrl + ": " + (map(.method) | tostring)' --raw-output
+          jq -r '.missingEndpoints | group_by(.pathUrl)[] | "\(.[0].pathUrl): \([.[].method])"' diff.json
       - name: Gather Coverage
         id: coverage
         shell: bash
         run: |
-          echo "current=`cat OpenSearch.openapi.json | jq '.paths | keys[]' | wc -l`" >> $GITHUB_OUTPUT
-          echo "total=`cat OpenSearch.auto.openapi.json | jq '.paths | keys[]' | wc -l`" >> $GITHUB_OUTPUT
-      - name: Calculate Percent
-        id: math
-        shell: bash
-        run: |
-          echo "percent=$((${{ steps.coverage.outputs.current }}*100/${{ steps.coverage.outputs.total }}))" >> $GITHUB_OUTPUT
-      - name: Report Coverage
-        shell: bash
-        run: |
-          echo "API specs implemented for ${{ steps.coverage.outputs.current }}/${{ steps.coverage.outputs.total }} (${{ steps.math.outputs.percent }}%) APIs."
-      # - uses: mshick/add-pr-comment@v2
-      #   with:
-      #     message: |
-      #       API specs implemented for ${{ steps.coverage.outputs.current }}/${{ steps.coverage.outputs.total }} (${{ steps.math.outputs.percent }}%) APIs.
+          current=`jq -r '.paths | keys | length' OpenSearch.openapi.json`
+          total=`jq -r '.paths | keys | length' OpenSearch.auto.openapi.json`
+          percent=$((current * 100 / total))
+          echo "API specs implemented for $current/$total ($percent%) APIs."

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,22 +28,34 @@ jobs:
       - name: Checkout OpenSearch
         uses: actions/checkout@v2
         with:
-          repository: 'dblock/OpenSearch'
+          repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: ${{ env.OPENSEARCH_VERSION }}-api-plugin
-      - name: Build API Plugin
+          ref: ${{ env.OPENSEARCH_VERSION }}
+      - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: |
+          git fetch origin 2.x
+          git cherry-pick -n c0581a0a3ca37a97bfdffc90f78a7e1b2afd7029 --strategy-option theirs
           ./gradlew :server:assemble -Dbuild.snapshot=false
           ./gradlew :libs:opensearch-core:assemble -Dbuild.snapshot=false
-          ./gradlew :plugins:api:assemble -Dbuild.snapshot=false
+          ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+      - name: Checkout OpenSearch API Plugin
+        uses: actions/checkout@v2
+        with:
+          repository: 'dblock/opensearch-api'
+          path: opensearch-api
+          ref: 2.x
+      - name: Build API Plugin
+        working-directory: ./opensearch-api
+        run: |
+          ./gradlew assemble -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} -Dbuild.snapshot=false
       - name: Install API Plugin
         run: |
           echo "FROM opensearchproject/opensearch:${{ env.OPENSEARCH_VERSION }}" >> Dockerfile
-          echo "ADD ./OpenSearch/plugins/api/build/distributions/api-${{ env.OPENSEARCH_VERSION }}.zip /tmp/" >> Dockerfile
           echo "COPY ./OpenSearch/server/build/distributions/opensearch-${{ env.OPENSEARCH_VERSION }}.jar /usr/share/opensearch/lib/" >> Dockerfile
           echo "COPY ./OpenSearch/libs/core/build/distributions/opensearch-core-${{ env.OPENSEARCH_VERSION }}.jar /usr/share/opensearch/lib/" >> Dockerfile
-          echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/api-${{ env.OPENSEARCH_VERSION }}.zip" >> Dockerfile
+          echo "ADD ./opensearch-api/build/distributions/opensearch-api-${{ env.OPENSEARCH_VERSION }}.0.zip /tmp/" >> Dockerfile
+          echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-api-${{ env.OPENSEARCH_VERSION }}.0.zip" >> Dockerfile
           cat Dockerfile
       - name: Build and Run Docker Container
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,66 @@
+name: API Coverage
+
+on: [push, pull_request]
+
+# git clone git@github.com:dblock/OpenSearch.git
+# cd OpenSearch
+# git remote add upstream git@github.com:opensearch-project/OpenSearch.git
+# git fetch upstream --tags
+# git checkout 2.11.1
+# git checkout -b 2.11.1-api-plugin
+# git cherry-pick ffa9ce9d41ac4d8a15b7041b4c8c60c4d3b1cffc
+# git push origin 2.11.1-api-plugin
+
+env:
+  JAVA_VERSION: 11
+  OPENSEARCH_VERSION: 2.11.1
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+      - name: Checkout OpenSearch
+        uses: actions/checkout@v2
+        with:
+          repository: 'dblock/OpenSearch'
+          path: OpenSearch
+          ref: ${{ env.OPENSEARCH_VERSION }}-api-plugin
+      - name: Build API Plugin
+        working-directory: ./OpenSearch
+        run: |
+          ./gradlew :server:assemble -Dbuild.snapshot=false
+          ./gradlew :libs:opensearch-core:assemble -Dbuild.snapshot=false
+          ./gradlew :plugins:api:assemble -Dbuild.snapshot=false
+      - name: Install API Plugin
+        run: |
+          echo "FROM opensearchproject/opensearch:${{ env.OPENSEARCH_VERSION }}" >> Dockerfile
+          echo "ADD ./OpenSearch/plugins/api/build/distributions/api-${{ env.OPENSEARCH_VERSION }}.zip /tmp/" >> Dockerfile
+          echo "COPY ./OpenSearch/server/build/distributions/opensearch-${{ env.OPENSEARCH_VERSION }}.jar /usr/share/opensearch/lib/" >> Dockerfile
+          echo "COPY ./OpenSearch/libs/core/build/distributions/opensearch-core-${{ env.OPENSEARCH_VERSION }}.jar /usr/share/opensearch/lib/" >> Dockerfile
+          echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/api-${{ env.OPENSEARCH_VERSION }}.zip" >> Dockerfile
+          cat Dockerfile
+      - name: Build and Run Docker Container
+        run: |
+          docker build . --tag opensearch-with-api-plugin
+          docker run --detach -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" opensearch-with-api-plugin
+          sleep 30
+      - name: Display OpenSearch Info
+        run: |
+          curl -u admin:admin --insecure https://localhost:9200/ | jq
+      - name: Dump and Compare API
+        run: |
+          curl -u admin:admin --insecure https://localhost:9200/_plugins/api | jq > OpenSearch.auto.openapi.json
+          docker run --mount type=bind,source=.,target=/specs openapitools/openapi-diff:latest /specs/OpenSearch.openapi.json /specs/OpenSearch.auto.openapi.json --json /specs/diff.json
+      - name: Show Diff
+        run: |
+          echo "-------- Missing APIs"
+          cat diff.json | jq '.newEndpoints | group_by(.pathUrl)[] | .[0].pathUrl + ": " + (map(.method) | tostring)' --raw-output
+          echo "-------- Legacy APIs"
+          cat diff.json | jq '.missingEndpoints | group_by(.pathUrl)[] | .[0].pathUrl + ": " + (map(.method) | tostring)' --raw-output
+

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,18 +2,10 @@ name: API Coverage
 
 on: [push, pull_request]
 
-# git clone git@github.com:dblock/OpenSearch.git
-# cd OpenSearch
-# git remote add upstream git@github.com:opensearch-project/OpenSearch.git
-# git fetch upstream --tags
-# git checkout 2.11.1
-# git checkout -b 2.11.1-api-plugin
-# git cherry-pick ffa9ce9d41ac4d8a15b7041b4c8c60c4d3b1cffc
-# git push origin 2.11.1-api-plugin
-
 env:
   JAVA_VERSION: 11
-  OPENSEARCH_VERSION: 2.11.1
+  OPENSEARCH_VERSION: 2.12.0
+  OPENSEARCH_INITIAL_ADMIN_PASSWORD: BobgG7YrtsdKf9M
 
 jobs:
   coverage:
@@ -21,53 +13,24 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Setup Java
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: ${{ env.OPENSEARCH_VERSION }}
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: |
-          git fetch origin 2.x
-          git cherry-pick -n c0581a0a3ca37a97bfdffc90f78a7e1b2afd7029 --strategy-option theirs
-          ./gradlew :server:assemble -Dbuild.snapshot=false
-          ./gradlew :libs:opensearch-core:assemble -Dbuild.snapshot=false
-          ./gradlew publishToMavenLocal -Dbuild.snapshot=false
-      - name: Checkout OpenSearch API Plugin
-        uses: actions/checkout@v2
-        with:
-          repository: 'dblock/opensearch-api'
-          path: opensearch-api
-          ref: 2.x
-      - name: Build API Plugin
-        working-directory: ./opensearch-api
-        run: |
-          ./gradlew assemble -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} -Dbuild.snapshot=false
       - name: Install API Plugin
         run: |
+          wget https://github.com/dblock/opensearch-api/releases/download/v${{ env.OPENSEARCH_VERSION }}/opensearch-api-${{ env.OPENSEARCH_VERSION }}.0.zip
           echo "FROM opensearchproject/opensearch:${{ env.OPENSEARCH_VERSION }}" >> Dockerfile
-          echo "COPY ./OpenSearch/server/build/distributions/opensearch-${{ env.OPENSEARCH_VERSION }}.jar /usr/share/opensearch/lib/" >> Dockerfile
-          echo "COPY ./OpenSearch/libs/core/build/distributions/opensearch-core-${{ env.OPENSEARCH_VERSION }}.jar /usr/share/opensearch/lib/" >> Dockerfile
-          echo "ADD ./opensearch-api/build/distributions/opensearch-api-${{ env.OPENSEARCH_VERSION }}.0.zip /tmp/" >> Dockerfile
+          echo "ADD ./opensearch-api-${{ env.OPENSEARCH_VERSION }}.0.zip /tmp/" >> Dockerfile
           echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-api-${{ env.OPENSEARCH_VERSION }}.0.zip" >> Dockerfile
           cat Dockerfile
       - name: Build and Run Docker Container
         run: |
           docker build . --tag opensearch-with-api-plugin
-          docker run --detach -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" opensearch-with-api-plugin
+          docker run -d -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e OPENSEARCH_INITIAL_ADMIN_PASSWORD="${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}" opensearch-with-api-plugin
           sleep 30
       - name: Display OpenSearch Info
         run: |
-          curl -u admin:admin --insecure https://localhost:9200/ | jq
+          curl -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} --insecure https://localhost:9200/ | jq
       - name: Dump and Compare API
         run: |
-          curl -u admin:admin --insecure https://localhost:9200/_plugins/api | jq > OpenSearch.auto.openapi.json
+          curl -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} --insecure https://localhost:9200/_plugins/api | jq > OpenSearch.auto.openapi.json
           docker run --mount type=bind,source=.,target=/specs openapitools/openapi-diff:latest /specs/OpenSearch.openapi.json /specs/OpenSearch.auto.openapi.json --json /specs/diff.json
       - name: Show Diff
         run: |

--- a/coverage/Dockerfile
+++ b/coverage/Dockerfile
@@ -1,0 +1,7 @@
+ARG OPENSEARCH_VERSION=2.12.0
+FROM opensearchproject/opensearch:${OPENSEARCH_VERSION}
+ARG OPENSEARCH_VERSION
+RUN /usr/share/opensearch/bin/opensearch-plugin \
+    install \
+    --batch \
+    https://github.com/dblock/opensearch-api/releases/download/v${OPENSEARCH_VERSION}/opensearch-api-${OPENSEARCH_VERSION}.0.zip

--- a/coverage/README.md
+++ b/coverage/README.md
@@ -1,0 +1,7 @@
+### API Coverage
+
+Uses the [opensearch-api plugin](https://github.com/dblock/opensearch-api), and [openapi-diff](https://github.com/OpenAPITools/openapi-diff) to show the difference between OpenSearch APIs, and the [OpenAPI spec checked into this repo](../OpenSearch.openapi.json).
+
+API coverage is run on all pull requests via the [coverage workflow](../.github/workflows/coverage.yml).
+
+


### PR DESCRIPTION
### Description

This report uses the API plugin from https://github.com/dblock/opensearch-api and [a tool](https://github.com/OpenAPITools/openapi-diff) to show the difference between OpenSearch 2.12 APIs and the OpenAPI spec checked into this repo.

See output in https://github.com/opensearch-project/opensearch-api-specification/actions/runs/8104297882/job/22150630111.

```
API specs implemented for 232/649 (35%) APIs.
```

The commented action code can be enabled after this is merged, otherwise it fails with a permissions error.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-api-specification/issues/168.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
