### PR TITLE
Adding wait_for_completion and task_execution_timeout params

### DIFF
--- a/model/common_strings.smithy
+++ b/model/common_strings.smithy
@@ -361,3 +361,8 @@ string Timeout
 @pattern("^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$")
 @documentation("The maximum time to wait for wait_for_metadata_version before timing out.")
 string WaitForTimeout
+
+@xDataType("time")
+@pattern("^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$")
+@documentation("Explicit task execution timeout, only useful when wait_for_completion is false, defaults to 1h.")
+string TaskExecutionTimeout

--- a/model/indices/clone/structures.smithy
+++ b/model/indices/clone/structures.smithy
@@ -21,6 +21,13 @@ structure IndicesClone_QueryParams {
     @httpQuery("wait_for_active_shards")
     @documentation("Set the number of active shards to wait for on the cloned index before the operation returns.")
     wait_for_active_shards: WaitForActiveShards,
+
+    @httpQuery("wait_for_completion")
+    @default(true)
+    wait_for_completion: WaitForCompletionTrue,
+
+    @httpQuery("task_execution_timeout")
+    task_execution_timeout: TaskExecutionTimeout,
 }
 
 // TODO: Fill in Body Parameters

--- a/model/indices/forcemerge/structures.smithy
+++ b/model/indices/forcemerge/structures.smithy
@@ -28,6 +28,10 @@ structure IndicesForcemerge_QueryParams {
 
     @httpQuery("only_expunge_deletes")
     only_expunge_deletes: OnlyExpungeDeletes,
+
+    @httpQuery("wait_for_completion")
+    @default(true)
+    wait_for_completion: WaitForCompletionTrue,
 }
 
 

--- a/model/indices/open/structures.smithy
+++ b/model/indices/open/structures.smithy
@@ -31,6 +31,13 @@ structure IndicesOpen_QueryParams {
     @httpQuery("wait_for_active_shards")
     @documentation("Sets the number of active shards to wait for before the operation returns.")
     wait_for_active_shards: WaitForActiveShards,
+
+    @httpQuery("wait_for_completion")
+    @default(true)
+    wait_for_completion: WaitForCompletionTrue,
+
+    @httpQuery("task_execution_timeout")
+    task_execution_timeout: TaskExecutionTimeout,
 }
 
 

--- a/model/indices/shrink/structures.smithy
+++ b/model/indices/shrink/structures.smithy
@@ -25,6 +25,13 @@ structure IndicesShrink_QueryParams {
     @httpQuery("wait_for_active_shards")
     @documentation("Set the number of active shards to wait for on the shrunken index before the operation returns.")
     wait_for_active_shards: WaitForActiveShards,
+
+    @httpQuery("wait_for_completion")
+    @default(true)
+    wait_for_completion: WaitForCompletionTrue,
+
+    @httpQuery("task_execution_timeout")
+    task_execution_timeout: TaskExecutionTimeout,
 }
 
 // TODO: Fill in Body Parameters

--- a/model/indices/split/structures.smithy
+++ b/model/indices/split/structures.smithy
@@ -25,6 +25,13 @@ structure IndicesSplit_QueryParams {
     @httpQuery("wait_for_active_shards")
     @documentation("Set the number of active shards to wait for on the shrunken index before the operation returns.")
     wait_for_active_shards: WaitForActiveShards,
+
+    @httpQuery("wait_for_completion")
+    @default(true)
+    wait_for_completion: WaitForCompletionTrue,
+
+    @httpQuery("task_execution_timeout")
+    task_execution_timeout: TaskExecutionTimeout,
 }
 
 // TODO: Fill in Body Parameters


### PR DESCRIPTION
### Description
Adding `wait_for_completion` parameter in shrink, split, clone, open, forcemerge APIs.
Adding `task_execution_timeout` parameter in shrink, split, clone, open APIs.

### Issues Resolved
Resolves #148 and #152 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
