### PR TITLE
Locked OpenSearch CI cluster to version 2.11.1

### DIFF
--- a/test/opensearch/Dockerfile
+++ b/test/opensearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:latest
+FROM opensearchproject/opensearch:2.11.1
 
 USER root
 RUN mkdir -p /mnt/snapshots && chown -R opensearch:opensearch /mnt/snapshots


### PR DESCRIPTION
This is to avoid CI from grabbing OS 2.12.0 which has changes to Admin password requirements that broke CI.
(Note that We're moving toward [Native OpenAPI](https://github.com/opensearch-project/opensearch-api-specification/issues/189) so this CI will be either be replaced or heavily modified. We will handle OS 2.12.0 and up then)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
