### PR TITLE
Added `include_named_queries_score` param in Search API and `primary_only` in Forcemerge API

### DIFF
--- a/model/_global/search/structures.smithy
+++ b/model/_global/search/structures.smithy
@@ -151,7 +151,11 @@ structure Search_QueryParams {
     rest_total_hits_as_int: RestTotalHitsAsInt,
 
     @httpQuery("search_pipeline")
-    search_pipeline: SearchPipeline
+    search_pipeline: SearchPipeline,
+
+    @httpQuery("include_named_queries_score")
+    @default(false)
+    include_named_queries_score: IncludeNamedQueriesScore
 }
 
 @documentation("The search definition using the Query DSL")

--- a/model/common_booleans.smithy
+++ b/model/common_booleans.smithy
@@ -89,6 +89,9 @@ boolean IncludeDefaults
 @documentation("Return information about disk usage and shard sizes.")
 boolean IncludeDiskInfo
 
+@documentation("Indicates whether hit.matched_queries should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false)")
+boolean IncludeNamedQueriesScore
+
 @documentation("Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested).")
 boolean IncludeSegmentFileSizes
 
@@ -130,6 +133,9 @@ boolean PreserveExisting
 
 @documentation("Set to true to return stats only for primary shards.")
 boolean Pri
+
+@documentation("Specify whether the operation should only perform on primary shards. Defaults to false.")
+boolean PrimaryOnly
 
 @documentation("Specify whether to profile the query execution.")
 boolean Profile

--- a/model/indices/forcemerge/structures.smithy
+++ b/model/indices/forcemerge/structures.smithy
@@ -13,6 +13,10 @@ structure IndicesForcemerge_QueryParams {
     @default(true)
     flush: Flush,
 
+    @httpQuery("primary_only")
+    @default(false)
+    primary_only: PrimaryOnly,
+
     @httpQuery("ignore_unavailable")
     ignore_unavailable: IgnoreUnavailable,
 

--- a/model/knn/stats/operations.smithy
+++ b/model/knn/stats/operations.smithy
@@ -26,7 +26,7 @@ operation KNNStats {
 @xVersionAdded("1.0")
 @readonly
 @suppress(["HttpUriConflict"])
-@http(method: "GET", uri: "/_plugins/_knn/{nodeId}/stats")
+@http(method: "GET", uri: "/_plugins/_knn/{node_id}/stats")
 @documentation("Provides information about the current status of the k-NN plugin.")
 operation KNNStats_WithNodeId {
     input: KNNStats_WithNodeId_Input,
@@ -48,7 +48,7 @@ operation KNNStats_WithStat {
 @xVersionAdded("1.0")
 @readonly
 @suppress(["HttpUriConflict"])
-@http(method: "GET", uri: "/_plugins/_knn/{nodeId}/stats/{stat}")
+@http(method: "GET", uri: "/_plugins/_knn/{node_id}/stats/{stat}")
 @documentation("Provides information about the current status of the k-NN plugin.")
 operation KNNStats_WithStatNodeId {
     input: KNNStats_WithStatNodeId_Input,

--- a/model/knn/stats/structures.smithy
+++ b/model/knn/stats/structures.smithy
@@ -21,7 +21,7 @@ structure KNNStats_Input with [KNNStats_QueryParams] {
 structure KNNStats_WithNodeId_Input with [KNNStats_QueryParams] {
     @required
     @httpLabel
-    nodeId: PathNodeId,
+    node_id: PathNodeId,
 }
 
 @input
@@ -35,7 +35,7 @@ structure KNNStats_WithStat_Input with [KNNStats_QueryParams] {
 structure KNNStats_WithStatNodeId_Input with [KNNStats_QueryParams] {
     @required
     @httpLabel
-    nodeId: PathNodeId,
+    node_id: PathNodeId,
 
     @required
     @httpLabel


### PR DESCRIPTION
### Description
Added `include_named_queries_score` param in Search API and `primary_only` in Forcemerge API.

- `primary_only` Param is recently introduced in https://github.com/opensearch-project/OpenSearch/pull/11269

- `include_named_queries_score` Param is recently introduced in https://github.com/opensearch-project/OpenSearch/pull/11626.

### Issues Resolved
Closes #200 
Closes #201

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
