### PR TITLE
Corrections for `notifications` namespace

### DIFF
--- a/spec/namespaces/notifications.yaml
+++ b/spec/namespaces/notifications.yaml
@@ -6,67 +6,69 @@ info:
 paths:
   /_plugins/_notifications/configs:
     delete:
-      operationId: notifications.delete_config.0
-      x-operation-group: notifications.delete_config
+      operationId: notifications.delete_configs.0
+      x-operation-group: notifications.delete_configs
       x-version-added: '2.2'
-      description: Delete channel configuration.
-      parameters:
-        - $ref: '#/components/parameters/notifications.delete_config::query.config_id'
-        - $ref: '#/components/parameters/notifications.delete_config::query.config_id_list'
-      responses:
-        '200':
-          $ref: '#/components/responses/notifications.delete_config@200'
-    get:
-      operationId: notifications.get_config.0
-      x-operation-group: notifications.get_config
-      x-version-added: '2.0'
-      description: Get channel configuration.
+      description: Delete multiple channel configurations.
       externalDocs:
-        url: https://opensearch.org/docs/latest/observing-your-data/notifications/api/#get-channel-configuration
+        url: https://opensearch.org/docs/latest/observing-your-data/notifications/api/#delete-channel-configuration
       parameters:
-        - $ref: '#/components/parameters/notifications.get_config::query.last_updated_time_ms'
-        - $ref: '#/components/parameters/notifications.get_config::query.created_time_ms'
-        - $ref: '#/components/parameters/notifications.get_config::query.config_type'
-        - $ref: '#/components/parameters/notifications.get_config::query.email.email_account_id'
-        - $ref: '#/components/parameters/notifications.get_config::query.email.email_group_id_list'
-        - $ref: '#/components/parameters/notifications.get_config::query.smtp_account.method'
-        - $ref: '#/components/parameters/notifications.get_config::query.ses_account.region'
-        - $ref: '#/components/parameters/notifications.get_config::query.name'
-        - $ref: '#/components/parameters/notifications.get_config::query.name.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.description'
-        - $ref: '#/components/parameters/notifications.get_config::query.description.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.slack.url'
-        - $ref: '#/components/parameters/notifications.get_config::query.slack.url.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.chime.url'
-        - $ref: '#/components/parameters/notifications.get_config::query.chime.url.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.microsoft_teams.url'
-        - $ref: '#/components/parameters/notifications.get_config::query.microsoft_teams.url.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.webhook.url'
-        - $ref: '#/components/parameters/notifications.get_config::query.webhook.url.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.smtp_account.host'
-        - $ref: '#/components/parameters/notifications.get_config::query.smtp_account.host.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.smtp_account.from_address'
-        - $ref: '#/components/parameters/notifications.get_config::query.smtp_account.from_address.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.sns.topic_arn'
-        - $ref: '#/components/parameters/notifications.get_config::query.sns.topic_arn.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.sns.role_arn'
-        - $ref: '#/components/parameters/notifications.get_config::query.sns.role_arn.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.ses_account.role_arn'
-        - $ref: '#/components/parameters/notifications.get_config::query.ses_account.role_arn.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.ses_account.from_address'
-        - $ref: '#/components/parameters/notifications.get_config::query.ses_account.from_address.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.is_enabled'
-        - $ref: '#/components/parameters/notifications.get_config::query.email.recipient_list.recipient'
-        - $ref: '#/components/parameters/notifications.get_config::query.email.recipient_list.recipient.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.email_group.recipient_list.recipient'
-        - $ref: '#/components/parameters/notifications.get_config::query.email_group.recipient_list.recipient.keyword'
-        - $ref: '#/components/parameters/notifications.get_config::query.query'
-        - $ref: '#/components/parameters/notifications.get_config::query.text_query'
-      requestBody:
-        $ref: '#/components/requestBodies/notifications.get_config'
+        - $ref: '#/components/parameters/notifications.delete_configs::query.config_id'
+        - $ref: '#/components/parameters/notifications.delete_configs::query.config_id_list'
       responses:
         '200':
-          $ref: '#/components/responses/notifications.get_config@200'
+          $ref: '#/components/responses/notifications.delete_configs@200'
+    get:
+      operationId: notifications.get_configs.0
+      x-operation-group: notifications.get_configs
+      x-version-added: '2.0'
+      description: Get multiple channel configurations with filtering.
+      externalDocs:
+        url: https://opensearch.org/docs/latest/observing-your-data/notifications/api/#list-all-notification-configurations
+      parameters:
+        - $ref: '#/components/parameters/notifications.get_configs::query.last_updated_time_ms'
+        - $ref: '#/components/parameters/notifications.get_configs::query.created_time_ms'
+        - $ref: '#/components/parameters/notifications.get_configs::query.config_type'
+        - $ref: '#/components/parameters/notifications.get_configs::query.email.email_account_id'
+        - $ref: '#/components/parameters/notifications.get_configs::query.email.email_group_id_list'
+        - $ref: '#/components/parameters/notifications.get_configs::query.smtp_account.method'
+        - $ref: '#/components/parameters/notifications.get_configs::query.ses_account.region'
+        - $ref: '#/components/parameters/notifications.get_configs::query.name'
+        - $ref: '#/components/parameters/notifications.get_configs::query.name.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.description'
+        - $ref: '#/components/parameters/notifications.get_configs::query.description.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.slack.url'
+        - $ref: '#/components/parameters/notifications.get_configs::query.slack.url.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.chime.url'
+        - $ref: '#/components/parameters/notifications.get_configs::query.chime.url.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.microsoft_teams.url'
+        - $ref: '#/components/parameters/notifications.get_configs::query.microsoft_teams.url.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.webhook.url'
+        - $ref: '#/components/parameters/notifications.get_configs::query.webhook.url.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.smtp_account.host'
+        - $ref: '#/components/parameters/notifications.get_configs::query.smtp_account.host.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.smtp_account.from_address'
+        - $ref: '#/components/parameters/notifications.get_configs::query.smtp_account.from_address.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.sns.topic_arn'
+        - $ref: '#/components/parameters/notifications.get_configs::query.sns.topic_arn.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.sns.role_arn'
+        - $ref: '#/components/parameters/notifications.get_configs::query.sns.role_arn.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.ses_account.role_arn'
+        - $ref: '#/components/parameters/notifications.get_configs::query.ses_account.role_arn.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.ses_account.from_address'
+        - $ref: '#/components/parameters/notifications.get_configs::query.ses_account.from_address.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.is_enabled'
+        - $ref: '#/components/parameters/notifications.get_configs::query.email.recipient_list.recipient'
+        - $ref: '#/components/parameters/notifications.get_configs::query.email.recipient_list.recipient.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.email_group.recipient_list.recipient'
+        - $ref: '#/components/parameters/notifications.get_configs::query.email_group.recipient_list.recipient.keyword'
+        - $ref: '#/components/parameters/notifications.get_configs::query.query'
+        - $ref: '#/components/parameters/notifications.get_configs::query.text_query'
+      requestBody:
+        $ref: '#/components/requestBodies/notifications.get_configs'
+      responses:
+        '200':
+          $ref: '#/components/responses/notifications.get_configs@200'
     post:
       operationId: notifications.create_config.0
       x-operation-group: notifications.create_config
@@ -81,10 +83,10 @@ paths:
           $ref: '#/components/responses/notifications.create_config@200'
   /_plugins/_notifications/configs/{config_id}:
     delete:
-      operationId: notifications.delete_config.1
+      operationId: notifications.delete_config.0
       x-operation-group: notifications.delete_config
       x-version-added: '2.0'
-      description: Delete channel configuration.
+      description: Delete a channel configuration.
       externalDocs:
         url: https://opensearch.org/docs/latest/observing-your-data/notifications/api/#delete-channel-configuration
       parameters:
@@ -93,10 +95,10 @@ paths:
         '200':
           $ref: '#/components/responses/notifications.delete_config@200'
     get:
-      operationId: notifications.get_config.1
+      operationId: notifications.get_config.0
       x-operation-group: notifications.get_config
       x-version-added: '2.0'
-      description: Get channel configuration.
+      description: Get a specific channel configuration.
       parameters:
         - $ref: '#/components/parameters/notifications.get_config::path.config_id'
       responses:
@@ -137,6 +139,8 @@ paths:
       x-operation-group: notifications.send_test
       x-version-added: '2.0'
       description: Send a test notification.
+      externalDocs:
+        url: https://opensearch.org/docs/latest/observing-your-data/notifications/api/#send-test-notification
       parameters:
         - $ref: '#/components/parameters/notifications.send_test::path.config_id'
       responses:
@@ -161,11 +165,26 @@ components:
           schema:
             $ref: '../schemas/notifications._common.yaml#/components/schemas/NotificationsConfig'
       required: true
-    notifications.get_config:
+    notifications.get_configs:
       content:
         application/json:
           schema:
-            $ref: '../schemas/notifications._common.yaml#/components/schemas/NotificationsConfigs_GetRequestContent'
+            type: object
+            properties:
+              config_id_list:
+                type: array
+                items:
+                  type: string
+              sort_field:
+                type: string
+              sort_order:
+                type: string
+              from_index:
+                type: integer
+                format: int32
+              max_items:
+                type: integer
+                format: int32
     notifications.update_config:
       content:
         application/json:
@@ -187,29 +206,25 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              delete_response_list:
-                $ref: '../schemas/notifications._common.yaml#/components/schemas/DeleteResponseList'
+            $ref: '../schemas/notifications._common.yaml#/components/schemas/DeleteConfigsResponse'
+    notifications.delete_configs@200:
+      description: ''
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/notifications._common.yaml#/components/schemas/DeleteConfigsResponse'
     notifications.get_config@200:
       description: ''
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              start_index:
-                type: integer
-                format: int64
-              total_hits:
-                type: integer
-                format: int64
-              total_hit_relation:
-                $ref: '../schemas/notifications._common.yaml#/components/schemas/TotalHitRelation'
-              config_list:
-                type: array
-                items:
-                  $ref: '../schemas/notifications._common.yaml#/components/schemas/NotificationsConfigsOutputItem'
+            $ref: '../schemas/notifications._common.yaml#/components/schemas/GetConfigsResponse'
+    notifications.get_configs@200:
+      description: ''
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/notifications._common.yaml#/components/schemas/GetConfigsResponse'
     notifications.list_features@200:
       description: ''
       content:
@@ -249,218 +264,218 @@ components:
     notifications.delete_config::path.config_id:
       name: config_id
       in: path
+      description: The ID of the channel configuration to delete.
       schema:
         type: string
       required: true
-    notifications.delete_config::query.config_id:
+    notifications.delete_configs::query.config_id:
       name: config_id
       in: query
-      description: A channel ID.
+      description: The ID of the channel configuration to delete.
       schema:
         type: string
-        description: A channel ID.
-    notifications.delete_config::query.config_id_list:
+      required: true
+    notifications.delete_configs::query.config_id_list:
       name: config_id_list
       in: query
-      description: A comma-separated list of channel IDs.
+      description: A comma-separated list of channel IDs to delete.
       schema:
         type: string
-        description: A comma-separated list of channel IDs.
     notifications.get_config::path.config_id:
       name: config_id
       in: path
       schema:
         type: string
       required: true
-    notifications.get_config::query.chime.url:
+    notifications.get_configs::query.chime.url:
       name: chime.url
       in: query
       schema:
         type: string
-    notifications.get_config::query.chime.url.keyword:
+    notifications.get_configs::query.chime.url.keyword:
       name: chime.url.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.config_type:
+    notifications.get_configs::query.config_type:
       name: config_type
       in: query
       description: Type of notification configuration.
       schema:
         $ref: '../schemas/notifications._common.yaml#/components/schemas/NotificationConfigType'
-    notifications.get_config::query.created_time_ms:
+    notifications.get_configs::query.created_time_ms:
       name: created_time_ms
       in: query
       schema:
         type: integer
         format: int64
-    notifications.get_config::query.description:
+    notifications.get_configs::query.description:
       name: description
       in: query
       schema:
         type: string
-    notifications.get_config::query.description.keyword:
+    notifications.get_configs::query.description.keyword:
       name: description.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.email.email_account_id:
+    notifications.get_configs::query.email.email_account_id:
       name: email.email_account_id
       in: query
       schema:
         type: string
-    notifications.get_config::query.email.email_group_id_list:
+    notifications.get_configs::query.email.email_group_id_list:
       name: email.email_group_id_list
       in: query
       schema:
         type: string
-    notifications.get_config::query.email.recipient_list.recipient:
+    notifications.get_configs::query.email.recipient_list.recipient:
       name: email.recipient_list.recipient
       in: query
       schema:
         type: string
-    notifications.get_config::query.email.recipient_list.recipient.keyword:
+    notifications.get_configs::query.email.recipient_list.recipient.keyword:
       name: email.recipient_list.recipient.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.email_group.recipient_list.recipient:
+    notifications.get_configs::query.email_group.recipient_list.recipient:
       name: email_group.recipient_list.recipient
       in: query
       schema:
         type: string
-    notifications.get_config::query.email_group.recipient_list.recipient.keyword:
+    notifications.get_configs::query.email_group.recipient_list.recipient.keyword:
       name: email_group.recipient_list.recipient.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.is_enabled:
+    notifications.get_configs::query.is_enabled:
       name: is_enabled
       in: query
       schema:
         type: boolean
-    notifications.get_config::query.last_updated_time_ms:
+    notifications.get_configs::query.last_updated_time_ms:
       name: last_updated_time_ms
       in: query
       schema:
         type: integer
         format: int64
-    notifications.get_config::query.microsoft_teams.url:
+    notifications.get_configs::query.microsoft_teams.url:
       name: microsoft_teams.url
       in: query
       schema:
         type: string
-    notifications.get_config::query.microsoft_teams.url.keyword:
+    notifications.get_configs::query.microsoft_teams.url.keyword:
       name: microsoft_teams.url.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.name:
+    notifications.get_configs::query.name:
       name: name
       in: query
       schema:
         type: string
-    notifications.get_config::query.name.keyword:
+    notifications.get_configs::query.name.keyword:
       name: name.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.query:
+    notifications.get_configs::query.query:
       name: query
       in: query
       schema:
         type: string
-    notifications.get_config::query.ses_account.from_address:
+    notifications.get_configs::query.ses_account.from_address:
       name: ses_account.from_address
       in: query
       schema:
         type: string
-    notifications.get_config::query.ses_account.from_address.keyword:
+    notifications.get_configs::query.ses_account.from_address.keyword:
       name: ses_account.from_address.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.ses_account.region:
+    notifications.get_configs::query.ses_account.region:
       name: ses_account.region
       in: query
       schema:
         type: string
-    notifications.get_config::query.ses_account.role_arn:
+    notifications.get_configs::query.ses_account.role_arn:
       name: ses_account.role_arn
       in: query
       schema:
         type: string
-    notifications.get_config::query.ses_account.role_arn.keyword:
+    notifications.get_configs::query.ses_account.role_arn.keyword:
       name: ses_account.role_arn.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.slack.url:
+    notifications.get_configs::query.slack.url:
       name: slack.url
       in: query
       schema:
         type: string
-    notifications.get_config::query.slack.url.keyword:
+    notifications.get_configs::query.slack.url.keyword:
       name: slack.url.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.smtp_account.from_address:
+    notifications.get_configs::query.smtp_account.from_address:
       name: smtp_account.from_address
       in: query
       schema:
         type: string
-    notifications.get_config::query.smtp_account.from_address.keyword:
+    notifications.get_configs::query.smtp_account.from_address.keyword:
       name: smtp_account.from_address.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.smtp_account.host:
+    notifications.get_configs::query.smtp_account.host:
       name: smtp_account.host
       in: query
       schema:
         type: string
-    notifications.get_config::query.smtp_account.host.keyword:
+    notifications.get_configs::query.smtp_account.host.keyword:
       name: smtp_account.host.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.smtp_account.method:
+    notifications.get_configs::query.smtp_account.method:
       name: smtp_account.method
       in: query
       schema:
         type: string
-    notifications.get_config::query.sns.role_arn:
+    notifications.get_configs::query.sns.role_arn:
       name: sns.role_arn
       in: query
       schema:
         type: string
-    notifications.get_config::query.sns.role_arn.keyword:
+    notifications.get_configs::query.sns.role_arn.keyword:
       name: sns.role_arn.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.sns.topic_arn:
+    notifications.get_configs::query.sns.topic_arn:
       name: sns.topic_arn
       in: query
       schema:
         type: string
-    notifications.get_config::query.sns.topic_arn.keyword:
+    notifications.get_configs::query.sns.topic_arn.keyword:
       name: sns.topic_arn.keyword
       in: query
       schema:
         type: string
-    notifications.get_config::query.text_query:
+    notifications.get_configs::query.text_query:
       name: text_query
       in: query
       schema:
         type: string
-    notifications.get_config::query.webhook.url:
+    notifications.get_configs::query.webhook.url:
       name: webhook.url
       in: query
       schema:
         type: string
-    notifications.get_config::query.webhook.url.keyword:
+    notifications.get_configs::query.webhook.url.keyword:
       name: webhook.url.keyword
       in: query
       schema:

--- a/spec/schemas/notifications._common.yaml
+++ b/spec/schemas/notifications._common.yaml
@@ -6,10 +6,31 @@ info:
 paths: {}
 components:
   schemas:
+    DeleteConfigsResponse:
+      type: object
+      properties:
+        delete_response_list:
+          $ref: '#/components/schemas/DeleteResponseList'
     DeleteResponseList:
       type: object
       additionalProperties:
         $ref: '#/components/schemas/RestStatus'
+    GetConfigsResponse:
+      type: object
+      properties:
+        start_index:
+          type: integer
+          format: int64
+        total_hits:
+          type: integer
+          format: int64
+        total_hit_relation:
+          $ref: '#/components/schemas/TotalHitRelation'
+        config_list:
+          type: array
+          maxItems: 1
+          items:
+            $ref: '#/components/schemas/NotificationsConfigsOutputItem'
     RestStatus:
       type: string
       enum:
@@ -30,23 +51,6 @@ components:
         - not_modified
         - use_proxy
         - temporary_redirect
-    NotificationsConfigs_GetRequestContent:
-      type: object
-      properties:
-        config_id_list:
-          type: array
-          items:
-            type: string
-        sort_field:
-          type: string
-        sort_order:
-          type: string
-        from_index:
-          type: integer
-          format: int32
-        max_items:
-          type: integer
-          format: int32
     NotificationConfigType:
       type: string
       description: Type of notification configuration.


### PR DESCRIPTION
- Moved `DELETE /_plugins/_notifications/configs` to its own namespace `notifications.delete_configs`
- Moved `GET /_plugins/_notifications/configs` to its own namespace `notifications.get_configs`
- Filled in missing urls and descriptions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).