### PR TITLE
Removed line-wrap for all yaml files

### DIFF
--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2114,8 +2114,7 @@ components:
                   $ref: '../schemas/_core.mget.yaml#/components/schemas/Operation'
               ids:
                 $ref: '../schemas/_common.yaml#/components/schemas/Ids'
-            description: Document identifiers; can be either `docs` (containing full document information) or `ids` (when index is
-              provided in the URL.
+            description: Document identifiers; can be either `docs` (containing full document information) or `ids` (when index is provided in the URL.
       required: true
     msearch:
       content:
@@ -2153,8 +2152,7 @@ components:
                 type: array
                 items:
                   $ref: '../schemas/_common.yaml#/components/schemas/Id'
-            description: Define ids, documents, parameters or a list of parameters per document here. You must at least provide a
-              list of document ids. See documentation.
+            description: Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.
     put_script:
       content:
         application/json:
@@ -2182,8 +2180,7 @@ components:
                 $ref: '../schemas/_core.rank_eval.yaml#/components/schemas/RankEvalMetric'
             required:
               - requests
-            description: The ranking evaluation search definition, including search requests, document ratings and ranking metric
-              definition.
+            description: The ranking evaluation search definition, including search requests, document ratings and ranking metric definition.
       required: true
     reindex:
       content:
@@ -2300,9 +2297,8 @@ components:
                   additionalProperties:
                     type: number
               docvalue_fields:
-                description: >-
+                description: |-
                   Array of wildcard (`*`) patterns.
-
                   The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.
                 type: array
                 items:
@@ -2324,17 +2320,14 @@ components:
               post_filter:
                 $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
               profile:
-                description: >-
-                  Set to `true` to return detailed timing information about the execution of individual components in a
-                  search request.
-
+                description: |-
+                  Set to `true` to return detailed timing information about the execution of individual components in a search request.
                   NOTE: This is a debugging tool and adds significant overhead to search execution.
                 type: boolean
               query:
                 $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
               rescore:
-                description: Can be used to improve precision by reordering just the top (for example 100 - 500) documents returned by
-                  the `query` and `post_filter` phases.
+                description: Can be used to improve precision by reordering just the top (for example 100 - 500) documents returned by the `query` and `post_filter` phases.
                 oneOf:
                   - $ref: '../schemas/_core.search.yaml#/components/schemas/Rescore'
                   - type: array
@@ -2360,9 +2353,8 @@ components:
               _source:
                 $ref: '../schemas/_core.search.yaml#/components/schemas/SourceConfig'
               fields:
-                description: >-
+                description: |-
                   Array of wildcard (`*`) patterns.
-
                   The request returns values for field names matching these patterns in the `hits.fields` property of the response.
                 type: array
                 items:
@@ -2370,21 +2362,14 @@ components:
               suggest:
                 $ref: '../schemas/_core.search.yaml#/components/schemas/Suggester'
               terminate_after:
-                description: >-
+                description: |-
                   Maximum number of documents to collect for each shard.
-
                   If a query reaches this limit, Opensearch terminates the query early.
-
                   Opensearch collects documents before sorting.
-
                   Use with caution.
-
                   Opensearch applies this parameter to each shard handling the request.
-
                   When possible, let Opensearch perform early termination automatically.
-
                   Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
-
                   If set to `0` (default), the query does not terminate early.
                 type: number
               timeout:
@@ -2873,8 +2858,7 @@ components:
                 description: The overall evaluation quality calculated by the defined metric
                 type: number
               details:
-                description: The details section contains one entry for every query in the original requests section, keyed by the
-                  search request id
+                description: The details section contains one entry for every query in the original requests section, keyed by the search request id
                 type: object
                 additionalProperties:
                   $ref: '../schemas/_core.rank_eval.yaml#/components/schemas/RankEvalMetricDetail'
@@ -3169,11 +3153,9 @@ components:
     bulk::query.pipeline:
       in: query
       name: pipeline
-      description: >-
+      description: |-
         ID of the pipeline to use to preprocess incoming documents.
-
         If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
-
         If a final pipeline is configured it will always run, regardless of the value of this parameter.
       schema:
         type: string
@@ -3181,10 +3163,8 @@ components:
     bulk::query.refresh:
       in: query
       name: refresh
-      description: >-
-        If `true`, Opensearch refreshes the affected shards to make this operation visible to search, if `wait_for` then
-        wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
-
+      description: |-
+        If `true`, Opensearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
         Valid values: `true`, `false`, `wait_for`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Refresh'
@@ -3206,8 +3186,7 @@ components:
     bulk::query.timeout:
       in: query
       name: timeout
-      description: 'Period each action waits for the following operations: automatic index creation, dynamic mapping updates,
-        waiting for active shards.'
+      description: 'Period each action waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.'
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
@@ -3251,10 +3230,8 @@ components:
     count::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -3298,11 +3275,9 @@ components:
     count::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3324,8 +3299,7 @@ components:
     count::query.lenient:
       in: query
       name: lenient
-      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will
-        be ignored.
+      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
       schema:
         type: boolean
       style: form
@@ -3380,11 +3354,9 @@ components:
     create::path.index:
       in: path
       name: index
-      description: >-
+      description: |-
         Name of the data stream or index to target.
-
         If the target doesn’t exist and matches the name or wildcard (`*`) pattern of an index template with a `data_stream` definition, this request creates the data stream.
-
         If the target doesn’t exist and doesn’t match a data stream template, this request creates the index.
       required: true
       schema:
@@ -3393,11 +3365,9 @@ components:
     create::query.pipeline:
       in: query
       name: pipeline
-      description: >-
+      description: |-
         ID of the pipeline to use to preprocess incoming documents.
-
         If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
-
         If a final pipeline is configured it will always run, regardless of the value of this parameter.
       schema:
         type: string
@@ -3405,10 +3375,8 @@ components:
     create::query.refresh:
       in: query
       name: refresh
-      description: >-
-        If `true`, Opensearch refreshes the affected shards to make this operation visible to search, if `wait_for` then
-        wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
-
+      description: |-
+        If `true`, Opensearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
         Valid values: `true`, `false`, `wait_for`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Refresh'
@@ -3423,8 +3391,7 @@ components:
     create::query.timeout:
       in: query
       name: timeout
-      description: 'Period the request waits for the following operations: automatic index creation, dynamic mapping updates,
-        waiting for active shards.'
+      description: 'Period the request waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.'
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
@@ -3534,10 +3501,8 @@ components:
     delete::query.refresh:
       in: query
       name: refresh
-      description: >-
-        If `true`, Opensearch refreshes the affected shards to make this operation visible to search, if `wait_for` then
-        wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
-
+      description: |-
+        If `true`, Opensearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
         Valid values: `true`, `false`, `wait_for`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Refresh'
@@ -3628,12 +3593,9 @@ components:
     delete_by_query::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
-
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -3676,11 +3638,9 @@ components:
     delete_by_query::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3702,8 +3662,7 @@ components:
     delete_by_query::query.lenient:
       in: query
       name: lenient
-      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will
-        be ignored.
+      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
       schema:
         type: boolean
       style: form
@@ -3830,19 +3789,13 @@ components:
     delete_by_query::query.terminate_after:
       in: query
       name: terminate_after
-      description: >-
+      description: |-
         Maximum number of documents to collect for each shard.
-
         If a query reaches this limit, Opensearch terminates the query early.
-
         Opensearch collects documents before sorting.
-
         Use with caution.
-
         Opensearch applies this parameter to each shard handling the request.
-
         When possible, let Opensearch perform early termination automatically.
-
         Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
       schema:
         type: number
@@ -4180,8 +4133,7 @@ components:
     explain::query.lenient:
       in: query
       name: lenient
-      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will
-        be ignored.
+      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
       schema:
         type: boolean
       style: form
@@ -4218,8 +4170,7 @@ components:
     field_caps::path.index:
       in: path
       name: index
-      description: Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards
-        (*). To target all data streams and indices, omit this parameter or use * or _all.
+      description: Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4227,11 +4178,9 @@ components:
     field_caps::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
+      description: |-
         If false, the request returns an error if any wildcard expression, index alias,
-
         or `_all` value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request
-
         targeting `foo*,bar*` returns an error if an index starts with foo but no index starts with bar.
       schema:
         type: boolean
@@ -4239,9 +4188,7 @@ components:
     field_caps::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: Type of index that wildcard patterns can match. If the request can target data streams, this argument
-        determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as
-        `open,hidden`.
+      description: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
@@ -4320,8 +4267,7 @@ components:
     get::query.refresh:
       in: query
       name: refresh
-      description: If true, Opensearch refreshes the affected shards to make this operation visible to search. If false, do
-        nothing with refreshes.
+      description: If true, Opensearch refreshes the affected shards to make this operation visible to search. If false, do nothing with refreshes.
       schema:
         type: boolean
       style: form
@@ -4345,8 +4291,7 @@ components:
     get::query.version:
       in: query
       name: version
-      description: Explicit version number for concurrency control. The specified version must match the current version of
-        the document for the request to succeed.
+      description: Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/VersionNumber'
       style: form
@@ -4436,8 +4381,7 @@ components:
     get_source::query.refresh:
       in: query
       name: refresh
-      description: If true, Opensearch refreshes the affected shards to make this operation visible to search. If false, do
-        nothing with refreshes.
+      description: If true, Opensearch refreshes the affected shards to make this operation visible to search. If false, do nothing with refreshes.
       schema:
         type: boolean
       style: form
@@ -4451,8 +4395,7 @@ components:
     get_source::query.version:
       in: query
       name: version
-      description: Explicit version number for concurrency control. The specified version must match the current version of
-        the document for the request to succeed.
+      description: Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/VersionNumber'
       style: form
@@ -4509,11 +4452,9 @@ components:
     index::query.pipeline:
       in: query
       name: pipeline
-      description: >-
+      description: |-
         ID of the pipeline to use to preprocess incoming documents.
-
         If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
-
         If a final pipeline is configured it will always run, regardless of the value of this parameter.
       schema:
         type: string
@@ -4521,10 +4462,8 @@ components:
     index::query.refresh:
       in: query
       name: refresh
-      description: >-
-        If `true`, Opensearch refreshes the affected shards to make this operation visible to search, if `wait_for` then
-        wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
-
+      description: |-
+        If `true`, Opensearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
         Valid values: `true`, `false`, `wait_for`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Refresh'
@@ -4546,8 +4485,7 @@ components:
     index::query.timeout:
       in: query
       name: timeout
-      description: 'Period the request waits for the following operations: automatic index creation, dynamic mapping updates,
-        waiting for active shards.'
+      description: 'Period the request waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.'
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
@@ -4579,8 +4517,7 @@ components:
     mget::path.index:
       in: path
       name: index
-      description: Name of the index to retrieve documents from when `ids` are specified, or when a document in the `docs`
-        array does not specify an index.
+      description: Name of the index to retrieve documents from when `ids` are specified, or when a document in the `docs` array does not specify an index.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
@@ -4595,9 +4532,8 @@ components:
     mget::query._source_excludes:
       in: query
       name: _source_excludes
-      description: >-
+      description: |-
         A comma-separated list of source fields to exclude from the response.
-
         You can also use this parameter to exclude fields from the subset specified in `_source_includes` query parameter.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Fields'
@@ -4605,11 +4541,9 @@ components:
     mget::query._source_includes:
       in: query
       name: _source_includes
-      description: >-
+      description: |-
         A comma-separated list of source fields to include in the response.
-
         If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `_source_excludes` query parameter.
-
         If the `_source` parameter is `false`, this parameter is ignored.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Fields'
@@ -4660,8 +4594,7 @@ components:
     msearch::query.ccs_minimize_roundtrips:
       in: query
       name: ccs_minimize_roundtrips
-      description: If true, network roundtrips between the coordinating node and remote clusters are minimized for
-        cross-cluster search requests.
+      description: If true, network roundtrips between the coordinating node and remote clusters are minimized for cross-cluster search requests.
       schema:
         type: boolean
       style: form
@@ -4682,10 +4615,7 @@ components:
     msearch::query.pre_filter_shard_size:
       in: query
       name: pre_filter_shard_size
-      description: Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query
-        rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can
-        limit the number of shards significantly if for instance a shard can not match any documents based on its
-        rewrite method i.e., if date filters are mandatory to match but the shard bounds and the query are disjoint.
+      description: Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method i.e., if date filters are mandatory to match but the shard bounds and the query are disjoint.
       schema:
         type: number
       style: form
@@ -4771,17 +4701,15 @@ components:
     mtermvectors::query.field_statistics:
       in: query
       name: field_statistics
-      description: If `true`, the response includes the document count, sum of document frequencies, and sum of total term
-        frequencies.
+      description: If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies.
       schema:
         type: boolean
       style: form
     mtermvectors::query.fields:
       in: query
       name: fields
-      description: >-
+      description: |-
         Comma-separated list or wildcard expressions of fields to include in the statistics.
-
         Used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Fields'
@@ -4789,8 +4717,7 @@ components:
     mtermvectors::query.ids:
       in: query
       name: ids
-      description: A comma-separated list of documents ids. You must define ids as parameter or set "ids" or "docs" in the
-        request body
+      description: A comma-separated list of documents ids. You must define ids as parameter or set "ids" or "docs" in the request body
       schema:
         type: array
         items:
@@ -4912,10 +4839,8 @@ components:
     rank_eval::path.index:
       in: path
       name: index
-      description: >-
-        Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`)
-        expressions are supported.
-
+      description: |-
+        Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.
         To target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.
       required: true
       schema:
@@ -4924,10 +4849,7 @@ components:
     rank_eval::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets
-        only missing or closed indices. This behavior applies even if the request targets other open indices. For
-        example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with
-        `bar`.
+      description: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
       style: form
@@ -5052,8 +4974,7 @@ components:
     scroll::query.rest_total_hits_as_int:
       in: query
       name: rest_total_hits_as_int
-      description: If true, the API response’s hit.total property is returned as an integer. If false, the API response’s
-        hit.total property is returned as an object.
+      description: If true, the API response’s hit.total property is returned as an integer. If false, the API response’s hit.total property is returned as an object.
       schema:
         type: boolean
       style: form
@@ -5086,17 +5007,12 @@ components:
     search::query._source:
       in: query
       name: _source
-      description: >-
+      description: |-
         Indicates which source fields are returned for matching documents.
-
         These fields are returned in the `hits._source` property of the search response.
-
         Valid values are:
-
         `true` to return the entire document source;
-
         `false` to not return the document source;
-
         `<string>` to return the source fields that are specified as a comma-separated list (supports wildcard (`*`) patterns).
       schema:
         $ref: '../schemas/_core.search.yaml#/components/schemas/SourceConfigParam'
@@ -5104,11 +5020,9 @@ components:
     search::query._source_excludes:
       in: query
       name: _source_excludes
-      description: >-
+      description: |-
         A comma-separated list of source fields to exclude from the response.
-
         You can also use this parameter to exclude fields from the subset specified in `_source_includes` query parameter.
-
         If the `_source` parameter is `false`, this parameter is ignored.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Fields'
@@ -5127,12 +5041,9 @@ components:
     search::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
-
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -5140,8 +5051,7 @@ components:
     search::query.allow_partial_search_results:
       in: query
       name: allow_partial_search_results
-      description: If true, returns partial results if there are shard request timeouts or shard failures. If false, returns
-        an error with no partial results.
+      description: If true, returns partial results if there are shard request timeouts or shard failures. If false, returns an error with no partial results.
       schema:
         type: boolean
       style: form
@@ -5166,9 +5076,8 @@ components:
     search::query.batched_reduce_size:
       in: query
       name: batched_reduce_size
-      description: >-
+      description: |-
         The number of shard results that should be reduced at once on the coordinating node.
-
         This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
       schema:
         type: number
@@ -5176,8 +5085,7 @@ components:
     search::query.ccs_minimize_roundtrips:
       in: query
       name: ccs_minimize_roundtrips
-      description: If true, network round-trips between the coordinating node and the remote clusters are minimized when
-        executing cross-cluster search (CCS) requests.
+      description: If true, network round-trips between the coordinating node and the remote clusters are minimized when executing cross-cluster search (CCS) requests.
       schema:
         type: boolean
       style: form
@@ -5209,11 +5117,9 @@ components:
     search::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -5253,20 +5159,16 @@ components:
     search::query.include_named_queries_score:
       name: include_named_queries_score
       in: query
-      description: Indicates whether hit.matched_queries should be rendered as a map that includes the name of the matched
-        query associated with its score (true) or as an array containing the name of the matched queries (false)
+      description: Indicates whether hit.matched_queries should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false)
       schema:
         type: boolean
         default: false
-        description: Indicates whether hit.matched_queries should be rendered as a map that includes the name of the matched
-          query associated with its score (true) or as an array containing the name of the matched queries (false)
+        description: Indicates whether hit.matched_queries should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false)
     search::query.lenient:
       in: query
       name: lenient
-      description: >-
-        If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be
-        ignored.
-
+      description: |-
+        If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
         This parameter can only be used when the `q` query string parameter is specified.
       schema:
         type: boolean
@@ -5274,9 +5176,8 @@ components:
     search::query.max_concurrent_shard_requests:
       in: query
       name: max_concurrent_shard_requests
-      description: >-
+      description: |-
         Defines the number of concurrent shard requests per node this search executes concurrently.
-
         This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.
       schema:
         type: number
@@ -5284,18 +5185,12 @@ components:
     search::query.pre_filter_shard_size:
       in: query
       name: pre_filter_shard_size
-      description: >-
-        Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if
-        the number of shards the search request expands to exceeds the threshold.
-
+      description: |-
+        Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold.
         This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method (if date filters are mandatory to match but the shard bounds and the query are disjoint).
-
         When unspecified, the pre-filter phase is executed if any of these conditions is met:
-
         the request targets more than 128 shards;
-
         the request targets one or more read-only index;
-
         the primary sort of the query targets an indexed field.
       schema:
         type: number
@@ -5303,21 +5198,14 @@ components:
     search::query.preference:
       in: query
       name: preference
-      description: >-
+      description: |-
         Nodes and shards used for the search.
-
         By default, Opensearch selects from eligible nodes and shards using adaptive replica selection, accounting for allocation awareness. Valid values are:
-
         `_only_local` to run the search only on shards on the local node;
-
         `_local` to, if possible, run the search on shards on the local node, or if not, select shards using the default method;
-
         `_only_nodes:<node-id>,<node-id>` to run the search on only the specified nodes IDs, where, if suitable shards exist on more than one selected node, use shards on those nodes using the default method, or if none of the specified nodes are available, select shards from any available node using the default method;
-
         `_prefer_nodes:<node-id>,<node-id>` to if possible, run the search on the specified nodes IDs, or if not, select shards using the default method;
-
         `_shards:<shard>,<shard>` to run the search only on the specified shards;
-
         `<custom-string>` (any string that does not start with `_`) to route searches with the same `<custom-string>` to the same shards in the same order.
       schema:
         type: string
@@ -5436,9 +5324,8 @@ components:
     search::query.suggest_mode:
       in: query
       name: suggest_mode
-      description: >-
+      description: |-
         Specifies the suggest mode.
-
         This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/SuggestMode'
@@ -5446,9 +5333,8 @@ components:
     search::query.suggest_size:
       in: query
       name: suggest_size
-      description: >-
+      description: |-
         Number of suggestions to return.
-
         This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
       schema:
         type: number
@@ -5456,9 +5342,8 @@ components:
     search::query.suggest_text:
       in: query
       name: suggest_text
-      description: >-
+      description: |-
         The source text for which the suggestions should be returned.
-
         This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
       schema:
         type: string
@@ -5466,21 +5351,14 @@ components:
     search::query.terminate_after:
       in: query
       name: terminate_after
-      description: >-
+      description: |-
         Maximum number of documents to collect for each shard.
-
         If a query reaches this limit, Opensearch terminates the query early.
-
         Opensearch collects documents before sorting.
-
         Use with caution.
-
         Opensearch applies this parameter to each shard handling the request.
-
         When possible, let Opensearch perform early termination automatically.
-
         Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
-
         If set to `0` (default), the query does not terminate early.
       schema:
         type: number
@@ -5536,12 +5414,9 @@ components:
     search_shards::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
-
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -5549,13 +5424,10 @@ components:
     search_shards::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -5603,12 +5475,9 @@ components:
     search_template::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
-
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -5623,13 +5492,10 @@ components:
     search_template::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -5727,17 +5593,15 @@ components:
     termvectors::query.field_statistics:
       in: query
       name: field_statistics
-      description: If `true`, the response includes the document count, sum of document frequencies, and sum of total term
-        frequencies.
+      description: If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies.
       schema:
         type: boolean
       style: form
     termvectors::query.fields:
       in: query
       name: fields
-      description: >-
+      description: |-
         Comma-separated list or wildcard expressions of fields to include in the statistics.
-
         Used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Fields'
@@ -5965,12 +5829,9 @@ components:
     update_by_query::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
-
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -6013,13 +5874,10 @@ components:
     update_by_query::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -6041,8 +5899,7 @@ components:
     update_by_query::query.lenient:
       in: query
       name: lenient
-      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will
-        be ignored.
+      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
       schema:
         type: boolean
       style: form
@@ -6058,11 +5915,9 @@ components:
     update_by_query::query.pipeline:
       in: query
       name: pipeline
-      description: >-
+      description: |-
         ID of the pipeline to use to preprocess incoming documents.
-
         If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
-
         If a final pipeline is configured it will always run, regardless of the value of this parameter.
       schema:
         type: string
@@ -6175,19 +6030,13 @@ components:
     update_by_query::query.terminate_after:
       in: query
       name: terminate_after
-      description: >-
+      description: |-
         Maximum number of documents to collect for each shard.
-
         If a query reaches this limit, Opensearch terminates the query early.
-
         Opensearch collects documents before sorting.
-
         Use with caution.
-
         Opensearch applies this parameter to each shard handling the request.
-
         When possible, let Opensearch perform early termination automatically.
-
         Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
       schema:
         type: number
@@ -6195,8 +6044,7 @@ components:
     update_by_query::query.timeout:
       in: query
       name: timeout
-      description: 'Period each update request waits for the following operations: dynamic mapping updates, waiting for active
-        shards.'
+      description: 'Period each update request waits for the following operations: dynamic mapping updates, waiting for active shards.'
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -955,8 +955,7 @@ components:
     cat.aliases::path.name:
       in: path
       name: name
-      description: A comma-separated list of aliases to retrieve. Supports wildcards (`*`).  To retrieve all aliases, omit
-        this parameter or use `*` or `_all`.
+      description: A comma-separated list of aliases to retrieve. Supports wildcards (`*`).  To retrieve all aliases, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Names'
@@ -2158,12 +2157,10 @@ components:
     cat.segment_replication::query.allow_no_indices:
       name: allow_no_indices
       in: query
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-        string or when no indices have been specified).
+      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
       schema:
         type: boolean
-        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-          string or when no indices have been specified).
+        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
     cat.segment_replication::query.bytes:
       name: bytes
       in: query
@@ -2588,15 +2585,13 @@ components:
     cat.tasks::query.nodes:
       name: nodes
       in: query
-      description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return
-        information from the node you're connecting to, leave empty to get information from all nodes.
+      description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return
-          information from the node you're connecting to, leave empty to get information from all nodes.
+        description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
       explode: true
     cat.tasks::query.parent_task_id:
       in: query

--- a/spec/namespaces/cluster.yaml
+++ b/spec/namespaces/cluster.yaml
@@ -458,8 +458,7 @@ components:
             type: object
             properties:
               current_node:
-                description: Specifies the node ID or the name of the node to only explain a shard that is currently located on the
-                  specified node.
+                description: Specifies the node ID or the name of the node to only explain a shard that is currently located on the specified node.
                 type: string
               index:
                 $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
@@ -946,9 +945,7 @@ components:
     cluster.health::path.index:
       in: path
       name: index
-      description: Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard
-        expressions (*) are supported. To target all data streams and indices in a cluster, omit this parameter or use
-        _all or *.
+      description: Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard expressions (*) are supported. To target all data streams and indices in a cluster, omit this parameter or use _all or *.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -984,16 +981,14 @@ components:
     cluster.health::query.local:
       in: query
       name: local
-      description: If true, the request retrieves information from the local node only. Defaults to false, which means
-        information is retrieved from the master node.
+      description: If true, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the master node.
       schema:
         type: boolean
       style: form
     cluster.health::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -1003,48 +998,42 @@ components:
     cluster.health::query.timeout:
       in: query
       name: timeout
-      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and
-        returns an error.
+      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
     cluster.health::query.wait_for_active_shards:
       in: query
       name: wait_for_active_shards
-      description: A number controlling to how many active shards to wait for, all to wait for all shards in the cluster to be
-        active, or 0 to not wait.
+      description: A number controlling to how many active shards to wait for, all to wait for all shards in the cluster to be active, or 0 to not wait.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/WaitForActiveShards'
       style: form
     cluster.health::query.wait_for_events:
       in: query
       name: wait_for_events
-      description: Can be one of immediate, urgent, high, normal, low, languid. Wait until all currently queued events with
-        the given priority are processed.
+      description: Can be one of immediate, urgent, high, normal, low, languid. Wait until all currently queued events with the given priority are processed.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/WaitForEvents'
       style: form
     cluster.health::query.wait_for_no_initializing_shards:
       in: query
       name: wait_for_no_initializing_shards
-      description: A boolean value which controls whether to wait (until the timeout provided) for the cluster to have no
-        shard initializations. Defaults to false, which means it will not wait for initializing shards.
+      description: A boolean value which controls whether to wait (until the timeout provided) for the cluster to have no shard initializations. Defaults to false, which means it will not wait for initializing shards.
       schema:
         type: boolean
       style: form
     cluster.health::query.wait_for_no_relocating_shards:
       in: query
       name: wait_for_no_relocating_shards
-      description: A boolean value which controls whether to wait (until the timeout provided) for the cluster to have no
-        shard relocations. Defaults to false, which means it will not wait for relocating shards.
+      description: A boolean value which controls whether to wait (until the timeout provided) for the cluster to have no shard relocations. Defaults to false, which means it will not wait for relocating shards.
       schema:
         type: boolean
       style: form
     cluster.health::query.wait_for_nodes:
       in: query
       name: wait_for_nodes
-      description: The request waits until the specified number N of nodes is available. It also accepts >=N, <=N, >N and <N.
-        Alternatively, it is possible to use ge(N), le(N), gt(N) and lt(N) notation.
+      description: The request waits until the specified number N of nodes is available. It also accepts >=N, <=N, >N and <N. Alternatively, it is possible to use ge(N), le(N), gt(N) and lt(N) notation.
       schema:
         oneOf:
           - type: string
@@ -1053,8 +1042,7 @@ components:
     cluster.health::query.wait_for_status:
       in: query
       name: wait_for_status
-      description: One of green, yellow or red. Will wait (until the timeout provided) until the status of the cluster changes
-        to the one provided or better, i.e. green > yellow > red. By default, will not wait for any status.
+      description: One of green, yellow or red. Will wait (until the timeout provided) until the status of the cluster changes to the one provided or better, i.e. green > yellow > red. By default, will not wait for any status.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/HealthStatus'
       style: form
@@ -1118,15 +1106,11 @@ components:
     cluster.put_component_template::path.name:
       in: path
       name: name
-      description: >-
+      description: |-
         Name of the component template to create.
-
         Opensearch includes the following built-in component templates: `logs-mappings`; 'logs-settings`; `metrics-mappings`; `metrics-settings`;`synthetics-mapping`; `synthetics-settings`.
-
         Opensearch Agent uses these templates to configure backing indices for its data streams.
-
         If you use Opensearch Agent and want to overwrite one of these templates, set the `version` for your replacement template higher than the current version.
-
         If you don’t use Opensearch Agent and want to disable all built-in component and index templates, set `stack.templates.enabled` to `false` using the cluster update settings API.
       required: true
       schema:
@@ -1246,8 +1230,7 @@ components:
     cluster.reroute::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -1271,8 +1254,7 @@ components:
     cluster.reroute::query.timeout:
       in: query
       name: timeout
-      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and
-        returns an error.
+      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
@@ -1295,8 +1277,7 @@ components:
     cluster.state::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-        string or when no indices have been specified)
+      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       schema:
         type: boolean
       style: form

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -1747,13 +1747,10 @@ components:
               index_routing:
                 $ref: '../schemas/_common.yaml#/components/schemas/Routing'
               is_write_index:
-                description: >-
+                description: |-
                   If `true`, sets the write index or data stream for the alias.
-
                   If an alias points to multiple indices or data streams and `is_write_index` isn’t set, the alias rejects write requests.
-
                   If an index alias points to one index and `is_write_index` isn’t set, the index automatically acts as the write index.
-
                   Data stream aliases don’t automatically set a write data stream, even if the alias points to one data stream.
                 type: boolean
               routing:
@@ -1770,9 +1767,8 @@ components:
               index_patterns:
                 $ref: '../schemas/_common.yaml#/components/schemas/Indices'
               composed_of:
-                description: >-
+                description: |-
                   An ordered list of component template names.
-
                   Component templates are merged in the order specified, meaning that the last component template specified has the highest precedence.
                 type: array
                 items:
@@ -1945,19 +1941,16 @@ components:
             type: object
             properties:
               allow_auto_create:
-                description: >-
+                description: |-
                   This setting overrides the value of the `action.auto_create_index` cluster setting.
-
                   If set to `true` in a template, then indices can be automatically created using that template even if auto-creation of indices is disabled via `actions.auto_create_index`.
-
                   If set to `false`, then indices or data streams matching the template must always be explicitly created, and may never be automatically created.
                 type: boolean
               index_patterns:
                 $ref: '../schemas/_common.yaml#/components/schemas/Indices'
               composed_of:
-                description: >-
+                description: |-
                   An ordered list of component template names.
-
                   Component templates are merged in the order specified, meaning that the last component template specified has the highest precedence.
                 type: array
                 items:
@@ -1977,8 +1970,7 @@ components:
                 $ref: '../schemas/_common.yaml#/components/schemas/VersionNumber'
               _meta:
                 $ref: '../schemas/_common.yaml#/components/schemas/Metadata'
-            description: New index template definition, which will be included in the simulation, as if it already exists in the
-              system
+            description: New index template definition, which will be included in the simulation, as if it already exists in the system
     indices.simulate_template:
       content:
         application/json:
@@ -2547,8 +2539,7 @@ components:
     indices.add_block::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-        string or when no indices have been specified)
+      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       schema:
         type: boolean
       style: form
@@ -2593,11 +2584,9 @@ components:
     indices.analyze::path.index:
       in: path
       name: index
-      description: >-
+      description: |-
         Index used to derive the analyzer.
-
         If specified, the `analyzer` or field parameter overrides this value.
-
         If no index is specified or the index does not have a default analyzer, the analyze API uses the standard analyzer.
       required: true
       schema:
@@ -2624,10 +2613,8 @@ components:
     indices.clear_cache::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -2635,13 +2622,10 @@ components:
     indices.clear_cache::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -2772,10 +2756,8 @@ components:
     indices.close::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -2790,13 +2772,10 @@ components:
     indices.close::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -2923,10 +2902,8 @@ components:
     indices.delete::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -2941,13 +2918,10 @@ components:
     indices.delete::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3054,8 +3028,7 @@ components:
     indices.delete_index_template::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -3065,8 +3038,7 @@ components:
     indices.delete_index_template::query.timeout:
       in: query
       name: timeout
-      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and
-        returns an error.
+      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
@@ -3119,10 +3091,8 @@ components:
     indices.exists::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -3130,13 +3100,10 @@ components:
     indices.exists::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3190,10 +3157,8 @@ components:
     indices.exists_alias::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -3201,13 +3166,10 @@ components:
     indices.exists_alias::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3215,8 +3177,7 @@ components:
     indices.exists_alias::query.ignore_unavailable:
       in: query
       name: ignore_unavailable
-      description: If `false`, requests that include a missing data stream or index in the target indices or data streams
-        return an error.
+      description: If `false`, requests that include a missing data stream or index in the target indices or data streams return an error.
       schema:
         type: boolean
       style: form
@@ -3261,8 +3222,7 @@ components:
     indices.exists_index_template::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -3322,10 +3282,8 @@ components:
     indices.flush::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -3333,13 +3291,10 @@ components:
     indices.flush::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3378,8 +3333,7 @@ components:
     indices.forcemerge::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-        string or when no indices have been specified)
+      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
       schema:
         type: boolean
       style: form
@@ -3494,16 +3448,14 @@ components:
     indices.get::query.local:
       in: query
       name: local
-      description: If true, the request retrieves information from the local node only. Defaults to false, which means
-        information is retrieved from the master node.
+      description: If true, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the master node.
       schema:
         type: boolean
       style: form
     indices.get::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -3535,10 +3487,8 @@ components:
     indices.get_alias::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -3546,13 +3496,10 @@ components:
     indices.get_alias::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3603,10 +3550,8 @@ components:
     indices.get_field_mapping::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -3614,13 +3559,10 @@ components:
     indices.get_field_mapping::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3671,16 +3613,14 @@ components:
     indices.get_index_template::query.local:
       in: query
       name: local
-      description: If true, the request retrieves information from the local node only. Defaults to false, which means
-        information is retrieved from the master node.
+      description: If true, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the master node.
       schema:
         type: boolean
       style: form
     indices.get_index_template::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -3701,10 +3641,8 @@ components:
     indices.get_mapping::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -3719,13 +3657,10 @@ components:
     indices.get_mapping::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3797,11 +3732,9 @@ components:
     indices.get_settings::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -3906,12 +3839,10 @@ components:
     indices.get_upgrade::query.allow_no_indices:
       name: allow_no_indices
       in: query
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-        string or when no indices have been specified).
+      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
       schema:
         type: boolean
-        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-          string or when no indices have been specified).
+        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
     indices.get_upgrade::query.expand_wildcards:
       name: expand_wildcards
       in: query
@@ -3928,15 +3859,11 @@ components:
     indices.open::path.index:
       in: path
       name: index
-      description: >-
+      description: |-
         Comma-separated list of data streams, indices, and aliases used to limit the request.
-
         Supports wildcards (`*`).
-
         By default, you must explicitly name the indices you using to limit the request.
-
         To limit a request using `_all`, `*`, or other wildcard expressions, change the `action.destructive_requires_name` setting to false.
-
         You can update this setting in the `opensearch.yml` file or using the cluster update settings API.
       required: true
       schema:
@@ -3945,10 +3872,8 @@ components:
     indices.open::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -3963,13 +3888,10 @@ components:
     indices.open::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -4117,8 +4039,7 @@ components:
     indices.put_mapping::path.index:
       in: path
       name: index
-      description: A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or
-        omit to add the mapping on all indices.
+      description: A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4126,10 +4047,8 @@ components:
     indices.put_mapping::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -4144,13 +4063,10 @@ components:
     indices.put_mapping::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -4359,10 +4275,8 @@ components:
     indices.refresh::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -4370,13 +4284,10 @@ components:
     indices.refresh::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -4401,13 +4312,10 @@ components:
     indices.resolve_index::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -4489,10 +4397,8 @@ components:
     indices.segments::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -4500,13 +4406,10 @@ components:
     indices.segments::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -4720,17 +4623,14 @@ components:
     indices.simulate_template::query.create:
       in: query
       name: create
-      description: If true, the template passed in the body is only used if no existing templates match the same index
-        patterns. If false, the simulation uses the template with the highest priority. Note that the template is not
-        permanently added or updated in either case; it is only used for the simulation.
+      description: If true, the template passed in the body is only used if no existing templates match the same index patterns. If false, the simulation uses the template with the highest priority. Note that the template is not permanently added or updated in either case; it is only used for the simulation.
       schema:
         type: boolean
       style: form
     indices.simulate_template::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -4880,8 +4780,7 @@ components:
     indices.stats::query.include_segment_file_sizes:
       in: query
       name: include_segment_file_sizes
-      description: If true, the call reports the aggregated disk usage of each one of the Lucene index files (only applies if
-        segment stats are requested).
+      description: If true, the call reports the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested).
       schema:
         type: boolean
       style: form
@@ -4940,12 +4839,10 @@ components:
     indices.upgrade::query.allow_no_indices:
       name: allow_no_indices
       in: query
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-        string or when no indices have been specified).
+      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
       schema:
         type: boolean
-        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-          string or when no indices have been specified).
+        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
     indices.upgrade::query.expand_wildcards:
       name: expand_wildcards
       in: query
@@ -4995,10 +4892,8 @@ components:
     indices.validate_query::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: >-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only
-        missing or closed indices.
-
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
         This behavior applies even if the request targets other open indices.
       schema:
         type: boolean
@@ -5038,13 +4933,10 @@ components:
     indices.validate_query::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: >-
+      description: |-
         Type of index that wildcard patterns can match.
-
         If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-
         Supports comma-separated values, such as `open,hidden`.
-
         Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
@@ -5066,8 +4958,7 @@ components:
     indices.validate_query::query.lenient:
       in: query
       name: lenient
-      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will
-        be ignored.
+      description: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
       schema:
         type: boolean
       style: form

--- a/spec/namespaces/ingest.yaml
+++ b/spec/namespaces/ingest.yaml
@@ -143,16 +143,12 @@ components:
                 description: Description of the ingest pipeline.
                 type: string
               on_failure:
-                description: Processors to run immediately after a processor failure. Each processor supports a processor-level
-                  `on_failure` value. If a processor without an `on_failure` value fails, Opensearch uses this
-                  pipeline-level parameter as a fallback. The processors in this parameter run sequentially in the order
-                  specified. Opensearch will not attempt to run the pipeline's remaining processors.
+                description: Processors to run immediately after a processor failure. Each processor supports a processor-level `on_failure` value. If a processor without an `on_failure` value fails, Opensearch uses this pipeline-level parameter as a fallback. The processors in this parameter run sequentially in the order specified. Opensearch will not attempt to run the pipeline's remaining processors.
                 type: array
                 items:
                   $ref: '../schemas/ingest._common.yaml#/components/schemas/ProcessorContainer'
               processors:
-                description: Processors used to perform transformations on documents before indexing. Processors run sequentially in the
-                  order specified.
+                description: Processors used to perform transformations on documents before indexing. Processors run sequentially in the order specified.
                 type: array
                 items:
                   $ref: '../schemas/ingest._common.yaml#/components/schemas/ProcessorContainer'
@@ -309,8 +305,7 @@ components:
     ingest.put_pipeline::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -320,8 +315,7 @@ components:
     ingest.put_pipeline::query.timeout:
       in: query
       name: timeout
-      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and
-        returns an error.
+      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form

--- a/spec/namespaces/knn.yaml
+++ b/spec/namespaces/knn.yaml
@@ -332,12 +332,10 @@ components:
     knn.search_models::query.allow_no_indices:
       name: allow_no_indices
       in: query
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-        string or when no indices have been specified).
+      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
       schema:
         type: boolean
-        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all`
-          string or when no indices have been specified).
+        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
     knn.search_models::query.allow_partial_search_results:
       name: allow_partial_search_results
       in: query
@@ -364,15 +362,11 @@ components:
     knn.search_models::query.batched_reduce_size:
       name: batched_reduce_size
       in: query
-      description: The number of shard results that should be reduced at once on the coordinating node. This value should be
-        used as a protection mechanism to reduce the memory overhead per search request if the potential number of
-        shards in the request can be large.
+      description: The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
       schema:
         type: integer
         default: 512
-        description: The number of shard results that should be reduced at once on the coordinating node. This value should be
-          used as a protection mechanism to reduce the memory overhead per search request if the potential number of
-          shards in the request can be large.
+        description: The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
         format: int32
     knn.search_models::query.ccs_minimize_roundtrips:
       name: ccs_minimize_roundtrips
@@ -452,28 +446,19 @@ components:
     knn.search_models::query.max_concurrent_shard_requests:
       name: max_concurrent_shard_requests
       in: query
-      description: The number of concurrent shard requests per node this search executes concurrently. This value should be
-        used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.
+      description: The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.
       schema:
         type: integer
         default: 5
-        description: The number of concurrent shard requests per node this search executes concurrently. This value should be
-          used to limit the impact of the search on the cluster in order to limit the number of concurrent shard
-          requests.
+        description: The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.
         format: int32
     knn.search_models::query.pre_filter_shard_size:
       name: pre_filter_shard_size
       in: query
-      description: Threshold that enforces a pre-filter round-trip to prefilter search shards based on query rewriting if the
-        number of shards the search request expands to exceeds the threshold. This filter round-trip can limit the
-        number of shards significantly if for instance a shard can not match any documents based on its rewrite method
-        ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
+      description: Threshold that enforces a pre-filter round-trip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter round-trip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
       schema:
         type: integer
-        description: Threshold that enforces a pre-filter round-trip to prefilter search shards based on query rewriting if the
-          number of shards the search request expands to exceeds the threshold. This filter round-trip can limit the
-          number of shards significantly if for instance a shard can not match any documents based on its rewrite method
-          ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
+        description: Threshold that enforces a pre-filter round-trip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter round-trip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
         format: int32
     knn.search_models::query.preference:
       name: preference
@@ -608,12 +593,10 @@ components:
     knn.search_models::query.terminate_after:
       name: terminate_after
       in: query
-      description: The maximum number of documents to collect for each shard, upon reaching which the query execution will
-        terminate early.
+      description: The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
       schema:
         type: integer
-        description: The maximum number of documents to collect for each shard, upon reaching which the query execution will
-          terminate early.
+        description: The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
         format: int32
     knn.search_models::query.timeout:
       name: timeout
@@ -652,13 +635,11 @@ components:
     knn.stats::path.node_id:
       name: node_id
       in: path
-      description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return
-        information from the node you're connecting to, leave empty to get information from all nodes.
+      description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
       schema:
         type: string
         pattern: ^(?!_|template|query|field|point|clear|usage|stats|hot|reload|painless).+$
-        description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return
-          information from the node you're connecting to, leave empty to get information from all nodes.
+        description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
         x-data-type: array
       required: true
     knn.stats::path.stat:

--- a/spec/namespaces/nodes.yaml
+++ b/spec/namespaces/nodes.yaml
@@ -443,25 +443,21 @@ components:
     nodes.hot_threads::path.node_id:
       name: node_id
       in: path
-      description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return
-        information from the node you're connecting to, leave empty to get information from all nodes.
+      description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
       schema:
         type: string
         pattern: ^(?!_|template|query|field|point|clear|usage|stats|hot|reload|painless).+$
-        description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return
-          information from the node you're connecting to, leave empty to get information from all nodes.
+        description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
         x-data-type: array
       required: true
     nodes.hot_threads::query.ignore_idle_threads:
       name: ignore_idle_threads
       in: query
-      description: Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an
-        empty task queue.
+      description: Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue.
       schema:
         type: boolean
         default: true
-        description: Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an
-          empty task queue.
+        description: Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue.
     nodes.hot_threads::query.interval:
       name: interval
       in: query
@@ -524,8 +520,7 @@ components:
     nodes.info::query.timeout:
       in: query
       name: timeout
-      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and
-        returns an error.
+      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
@@ -549,8 +544,7 @@ components:
     nodes.stats::path.index_metric:
       in: path
       name: index_metric
-      description: Limit the information returned for indices metric to the specific index metrics. It can be used only if
-        indices (or all) metric is specified.
+      description: Limit the information returned for indices metric to the specific index metrics. It can be used only if indices (or all) metric is specified.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Metrics'
@@ -602,8 +596,7 @@ components:
     nodes.stats::query.include_segment_file_sizes:
       in: query
       name: include_segment_file_sizes
-      description: If true, the call reports the aggregated disk usage of each one of the Lucene index files (only applies if
-        segment stats are requested).
+      description: If true, the call reports the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested).
       schema:
         type: boolean
       style: form
@@ -617,8 +610,7 @@ components:
     nodes.stats::query.timeout:
       in: query
       name: timeout
-      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and
-        returns an error.
+      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
@@ -644,8 +636,7 @@ components:
     nodes.usage::path.node_id:
       in: path
       name: node_id
-      description: A comma-separated list of node IDs or names to limit the returned information; use `_local` to return
-        information from the node you're connecting to, leave empty to get information from all nodes
+      description: A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/NodeIds'

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -284,32 +284,22 @@ components:
             type: object
             properties:
               ignore_unavailable:
-                description: If `true`, the request ignores data streams and indices in `indices` that are missing or closed. If
-                  `false`, the request returns an error for any data stream or index that is missing or closed.
+                description: If `true`, the request ignores data streams and indices in `indices` that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed.
                 type: boolean
               include_global_state:
-                description: If `true`, the current cluster state is included in the snapshot. The cluster state includes persistent
-                  cluster settings, composable index templates, legacy index templates, ingest pipelines, and ILM
-                  policies. It also includes data stored in system indices, such as Watches and task records
-                  (configurable via `feature_states`).
+                description: If `true`, the current cluster state is included in the snapshot. The cluster state includes persistent cluster settings, composable index templates, legacy index templates, ingest pipelines, and ILM policies. It also includes data stored in system indices, such as Watches and task records (configurable via `feature_states`).
                 type: boolean
               indices:
                 $ref: '../schemas/_common.yaml#/components/schemas/Indices'
               feature_states:
-                description: Feature states to include in the snapshot. Each feature state includes one or more system indices
-                  containing related data. You can view a list of eligible features using the get features API. If
-                  `include_global_state` is `true`, all current feature states are included by default. If
-                  `include_global_state` is `false`, no feature states are included by default.
+                description: Feature states to include in the snapshot. Each feature state includes one or more system indices containing related data. You can view a list of eligible features using the get features API. If `include_global_state` is `true`, all current feature states are included by default. If `include_global_state` is `false`, no feature states are included by default.
                 type: array
                 items:
                   type: string
               metadata:
                 $ref: '../schemas/_common.yaml#/components/schemas/Metadata'
               partial:
-                description: If `true`, allows restoring a partial snapshot of indices with unavailable shards. Only shards that were
-                  successfully included in the snapshot will be restored. All missing shards will be recreated as empty.
-                  If `false`, the entire restore operation will fail if one or more indices included in the snapshot do
-                  not have all primary shards available.
+                description: If `true`, allows restoring a partial snapshot of indices with unavailable shards. Only shards that were successfully included in the snapshot will be restored. All missing shards will be recreated as empty. If `false`, the entire restore operation will fail if one or more indices included in the snapshot do not have all primary shards available.
                 type: boolean
             description: The snapshot definition
     snapshot.create_repository:
@@ -386,8 +376,7 @@ components:
             type: object
             properties:
               accepted:
-                description: Equals `true` if the snapshot was accepted. Present when the request had `wait_for_completion` set to
-                  `false`
+                description: Equals `true` if the snapshot was accepted. Present when the request had `wait_for_completion` set to `false`
                 type: boolean
               snapshot:
                 $ref: '../schemas/snapshot._common.yaml#/components/schemas/SnapshotInfo'
@@ -428,8 +417,7 @@ components:
                 description: The total number of snapshots that match the request when ignoring size limit or after query parameter.
                 type: number
               remaining:
-                description: The number of remaining snapshots that were not returned due to size limits and that can be fetched by
-                  additional requests using the next field value.
+                description: The number of remaining snapshots that were not returned due to size limits and that can be fetched by additional requests using the next field value.
                 type: number
             required:
               - total
@@ -579,8 +567,7 @@ components:
     snapshot.create::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -590,8 +577,7 @@ components:
     snapshot.create::query.wait_for_completion:
       in: query
       name: wait_for_completion
-      description: If `true`, the request returns a response when the snapshot is complete. If `false`, the request returns a
-        response when the snapshot initializes.
+      description: If `true`, the request returns a response when the snapshot is complete. If `false`, the request returns a response when the snapshot initializes.
       schema:
         type: boolean
       style: form
@@ -702,8 +688,7 @@ components:
     snapshot.get::path.repository:
       in: path
       name: repository
-      description: Comma-separated list of snapshot repository names used to limit the request. Wildcard (*) expressions are
-        supported.
+      description: Comma-separated list of snapshot repository names used to limit the request. Wildcard (*) expressions are supported.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Name'
@@ -736,8 +721,7 @@ components:
     snapshot.get::query.master_timeout:
       in: query
       name: master_timeout
-      description: Period to wait for a connection to the master node. If no response is received before the timeout expires,
-        the request fails and returns an error.
+      description: Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
       deprecated: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
@@ -747,8 +731,7 @@ components:
     snapshot.get::query.verbose:
       in: query
       name: verbose
-      description: If true, returns additional information about each snapshot such as the version of Opensearch which took
-        the snapshot, the start and end times of the snapshot, and the number of shards snapshotted.
+      description: If true, returns additional information about each snapshot such as the version of Opensearch which took the snapshot, the start and end times of the snapshot, and the number of shards snapshotted.
       schema:
         type: boolean
       style: form

--- a/spec/namespaces/tasks.yaml
+++ b/spec/namespaces/tasks.yaml
@@ -141,8 +141,7 @@ components:
     tasks.cancel::query.wait_for_completion:
       in: query
       name: wait_for_completion
-      description: Should the request block until the cancellation of the task and its descendant tasks is completed. Defaults
-        to false
+      description: Should the request block until the cancellation of the task and its descendant tasks is completed. Defaults to false
       schema:
         type: boolean
       style: form
@@ -198,29 +197,25 @@ components:
     tasks.list::query.nodes:
       name: nodes
       in: query
-      description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return
-        information from the node you're connecting to, leave empty to get information from all nodes.
+      description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return
-          information from the node you're connecting to, leave empty to get information from all nodes.
+        description: Comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
       explode: true
     tasks.list::query.parent_task_id:
       in: query
       name: parent_task_id
-      description: Parent task ID used to limit returned information. To return all tasks, omit this parameter or use a value
-        of `-1`.
+      description: Parent task ID used to limit returned information. To return all tasks, omit this parameter or use a value of `-1`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Id'
       style: form
     tasks.list::query.timeout:
       in: query
       name: timeout
-      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and
-        returns an error.
+      description: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form

--- a/spec/schemas/_common.aggregations.yaml
+++ b/spec/schemas/_common.aggregations.yaml
@@ -1937,8 +1937,7 @@ components:
         - type: object
           properties:
             compression:
-              description: Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling
-                control of memory usage and approximation error.
+              description: Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.
               type: number
     BucketScriptAggregation:
       allOf:
@@ -1985,29 +1984,20 @@ components:
               items:
                 type: string
             fractions:
-              description: >-
-                A list of doubles indicating the distribution of the samples with which to compare to the `buckets_path`
-                results.
-
+              description: |-
+                A list of doubles indicating the distribution of the samples with which to compare to the `buckets_path` results.
                 In typical usage this is the overall proportion of documents in each bucket, which is compared with the actual
-
                 document proportions in each bucket from the sibling aggregation counts. The default is to assume that overall
-
                 documents are uniformly distributed on these buckets, which they would be if one used equal percentiles of a
-
                 metric to define the bucket end points.
               type: array
               items:
                 type: number
             sampling_method:
-              description: >-
-                Indicates the sampling methodology when calculating the K-S test. Note, this is sampling of the returned
-                values.
-
+              description: |-
+                Indicates the sampling methodology when calculating the K-S test. Note, this is sampling of the returned values.
                 This determines the cumulative distribution function (CDF) points used comparing the two samples. Default is
-
                 `upper_tail`, which emphasizes the upper end of the CDF points. Valid options are: `upper_tail`, `uniform`,
-
                 and `lower_tail`.
               type: string
     BucketCorrelationAggregation:
@@ -2101,27 +2091,19 @@ components:
                 values will use more memory and create narrower categories. Max allowed value is 100.
               type: number
             similarity_threshold:
-              description: >-
+              description: |-
                 The minimum percentage of tokens that must match for text to be added to the category bucket. Must
-
                 be between 1 and 100. The larger the value the narrower the categories. Larger values will increase memory
-
                 usage and create narrower categories.
               type: number
             categorization_filters:
-              description: >-
+              description: |-
                 This property expects an array of regular expressions. The expressions are used to filter out matching
-
                 sequences from the categorization field values. You can use this functionality to fine tune the categorization
-
                 by excluding sequences from consideration when categories are defined. For example, you can exclude SQL
-
                 statements that appear in your log files. This property cannot be used at the same time as categorization_analyzer.
-
                 If you only want to define simple regular expression filters that are applied prior to tokenization, setting
-
                 this property is the easiest method. If you also want to customize the tokenizer or post-tokenization filtering,
-
                 use the categorization_analyzer property instead and include the filters as pattern_replace character filters.
               type: array
               items:
@@ -2317,8 +2299,7 @@ components:
             time_zone:
               $ref: '_common.yaml#/components/schemas/TimeZone'
             keyed:
-              description: Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than
-                an array.
+              description: Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.
               type: boolean
     CalendarInterval:
       type: string
@@ -2382,8 +2363,7 @@ components:
             time_zone:
               $ref: '_common.yaml#/components/schemas/TimeZone'
             keyed:
-              description: Set to `true` to associate a unique string key with each bucket and returns the ranges as a hash rather
-                than an array.
+              description: Set to `true` to associate a unique string key with each bucket and returns the ranges as a hash rather than an array.
               type: boolean
     DateRangeExpression:
       type: object
@@ -2503,8 +2483,7 @@ components:
             filters:
               $ref: '#/components/schemas/BucketsQueryContainer'
             other_bucket:
-              description: Set to `true` to add a bucket to the response which will contain all documents that do not match any of the
-                given filters.
+              description: Set to `true` to add a bucket to the response which will contain all documents that do not match any of the given filters.
               type: boolean
             other_bucket_key:
               description: The key with which the other bucket is returned.
@@ -2825,12 +2804,10 @@ components:
           description: Specifies the maximum number of feature importance values per document.
           type: number
         prediction_field_type:
-          description: 'Specifies the type of the predicted field to write. Acceptable values are: string, number, boolean. When
-            boolean is provided 1.0 is transformed to true and 0.0 to false.'
+          description: 'Specifies the type of the predicted field to write. Acceptable values are: string, number, boolean. When boolean is provided 1.0 is transformed to true and 0.0 to false.'
           type: string
         results_field:
-          description: The field that is added to incoming documents to contain the inference prediction. Defaults to
-            predicted_value.
+          description: The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.
           type: string
         top_classes_results_field:
           description: Specifies the field to which the top classes are written. Defaults to top_classes.
@@ -2870,8 +2847,7 @@ components:
         - type: object
           properties:
             compression:
-              description: Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling
-                control of memory usage and approximation error.
+              description: Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.
               type: number
     MinAggregation:
       allOf:
@@ -3059,9 +3035,8 @@ components:
               description: The minimum number of documents in a bucket on each shard for it to be returned.
               type: number
             shard_size:
-              description: >-
+              description: |-
                 The number of candidate terms produced by each shard.
-
                 By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.
               type: number
             show_term_doc_count_error:
@@ -3127,10 +3102,8 @@ components:
         - type: object
           properties:
             keyed:
-              description: >-
-                By default, the aggregation associates a unique string key with each bucket and returns the ranges as a
-                hash rather than an array.
-
+              description: |-
+                By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array.
                 Set to `false` to disable this behavior.
               type: boolean
             values:
@@ -3155,8 +3128,7 @@ components:
       type: object
       properties:
         compression:
-          description: Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling
-            control of memory usage and approximation error.
+          description: Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.
           type: number
     PercentilesAggregation:
       allOf:
@@ -3164,10 +3136,8 @@ components:
         - type: object
           properties:
             keyed:
-              description: >-
-                By default, the aggregation associates a unique string key with each bucket and returns the ranges as a
-                hash rather than an array.
-
+              description: |-
+                By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array.
                 Set to `false` to disable this behavior.
               type: boolean
             percents:
@@ -3209,8 +3179,7 @@ components:
             script:
               $ref: '_common.yaml#/components/schemas/Script'
             keyed:
-              description: Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than
-                an array.
+              description: Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.
               type: boolean
             format:
               type: string
@@ -3327,16 +3296,13 @@ components:
             script_heuristic:
               $ref: '#/components/schemas/ScriptedHeuristic'
             shard_min_doc_count:
-              description: >-
-                Regulates the certainty a shard has if the term should actually be added to the candidate list or not
-                with respect to the `min_doc_count`.
-
+              description: |-
+                Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`.
                 Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.
               type: number
             shard_size:
-              description: >-
+              description: |-
                 Can be used to control the volumes of candidate terms produced by each shard.
-
                 By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.
               type: number
             size:
@@ -3346,12 +3312,10 @@ components:
       type: object
       properties:
         background_is_superset:
-          description: Set to `false` if you defined a custom background filter that represents a different set of documents that
-            you want to compare to.
+          description: Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.
           type: boolean
         include_negatives:
-          description: Set to `false` to filter out the terms that appear less often in the subset than in documents outside the
-            subset.
+          description: Set to `false` to filter out the terms that appear less often in the subset than in documents outside the subset.
           type: boolean
       required:
         - background_is_superset
@@ -3367,19 +3331,16 @@ components:
       type: object
       properties:
         background_is_superset:
-          description: Set to `false` if you defined a custom background filter that represents a different set of documents that
-            you want to compare to.
+          description: Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.
           type: boolean
     MutualInformationHeuristic:
       type: object
       properties:
         background_is_superset:
-          description: Set to `false` if you defined a custom background filter that represents a different set of documents that
-            you want to compare to.
+          description: Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.
           type: boolean
         include_negatives:
-          description: Set to `false` to filter out the terms that appear less often in the subset than in documents outside the
-            subset.
+          description: Set to `false` to filter out the terms that appear less often in the subset than in documents outside the subset.
           type: boolean
     PercentageScoreHeuristic:
       type: object
@@ -3424,16 +3385,13 @@ components:
             script_heuristic:
               $ref: '#/components/schemas/ScriptedHeuristic'
             shard_min_doc_count:
-              description: >-
-                Regulates the certainty a shard has if the values should actually be added to the candidate list or not
-                with respect to the min_doc_count.
-
+              description: |-
+                Regulates the certainty a shard has if the values should actually be added to the candidate list or not with respect to the min_doc_count.
                 Values will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.
               type: number
             shard_size:
-              description: >-
+              description: |-
                 The number of candidate terms produced by each shard.
-
                 By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.
               type: number
             size:
@@ -3497,14 +3455,12 @@ components:
             script:
               $ref: '_common.yaml#/components/schemas/Script'
             shard_size:
-              description: >-
+              description: |-
                 The number of candidate terms produced by each shard.
-
                 By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.
               type: number
             show_term_doc_count_error:
-              description: Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the
-                `doc_count` returned by each shard.
+              description: Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.
               type: boolean
             size:
               description: The number of buckets returned out of the overall terms list.
@@ -3650,9 +3606,7 @@ components:
             Defaults to `buckets * 50`.
           type: number
         initial_buffer:
-          description: >-
-            Specifies the number of individual documents that will be stored in memory on a shard before the initial
-            bucketing algorithm is run.
-
+          description: |-
+            Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run.
             Defaults to `min(10 * shard_size, 50000)`.
           type: number

--- a/spec/schemas/_common.analysis.yaml
+++ b/spec/schemas/_common.analysis.yaml
@@ -73,11 +73,9 @@ components:
         - preserve_original
         - separator
     StopWords:
-      description: >-
+      description: |-
         Language value, such as _arabic_ or _thai_. Defaults to _english_.
-
         Each language value corresponds to a predefined list of stop words in Lucene. See Stop words by language for supported language values and their stop words.
-
         Also accepts an array of stop words.
       oneOf:
         - type: string

--- a/spec/schemas/_common.mapping.yaml
+++ b/spec/schemas/_common.mapping.yaml
@@ -429,9 +429,8 @@ components:
           enum:
             - match_only_text
         fields:
-          description: >-
+          description: |-
             Multi-fields allow the same string value to be indexed in multiple ways for different purposes, such as one
-
             field for search and a multi-field for sorting and aggregations, or the same string value analyzed by different analyzers.
           type: object
           additionalProperties:

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -175,9 +175,8 @@ components:
         span_within:
           $ref: '#/components/schemas/SpanWithinQuery'
         term:
-          description: >-
+          description: |-
             Returns documents that contain an exact term in a provided field.
-
             To return a document, the query term must exactly match the queried field's value, including whitespace and capitalization.
           type: object
           additionalProperties:
@@ -187,9 +186,8 @@ components:
         terms:
           $ref: '#/components/schemas/TermsQuery'
         terms_set:
-          description: >-
+          description: |-
             Returns documents that contain a minimum number of exact terms in a provided field.
-
             To return a document, a required number of terms must exactly match the field values, including whitespace and capitalization.
           type: object
           additionalProperties:
@@ -197,8 +195,7 @@ components:
           minProperties: 1
           maxProperties: 1
         text_expansion:
-          description: Uses a natural language processing model to convert the query text into a list of token-weight pairs which
-            are then used in a query against a sparse vector or rank features field.
+          description: Uses a natural language processing model to convert the query text into a list of token-weight pairs which are then used in a query against a sparse vector or rank features field.
           type: object
           additionalProperties:
             $ref: '#/components/schemas/TextExpansionQuery'
@@ -281,8 +278,7 @@ components:
         - type: object
           properties:
             negative_boost:
-              description: Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the
-                `negative` query.
+              description: Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.
               type: number
             negative:
               $ref: '#/components/schemas/QueryContainer'
@@ -317,8 +313,7 @@ components:
         - type: object
           properties:
             fields:
-              description: List of fields to search. Field wildcard patterns are allowed. Only `text` fields are supported, and they
-                must all have the same search `analyzer`.
+              description: List of fields to search. Field wildcard patterns are allowed. Only `text` fields are supported, and they must all have the same search `analyzer`.
               type: array
               items:
                 $ref: '_common.yaml#/components/schemas/Field'
@@ -372,8 +367,7 @@ components:
               items:
                 $ref: '#/components/schemas/QueryContainer'
             tie_breaker:
-              description: Floating point number between 0 and 1.0 used to increase the relevance scores of documents matching
-                multiple query clauses.
+              description: Floating point number between 0 and 1.0 used to increase the relevance scores of documents matching multiple query clauses.
               type: number
           required:
             - queries
@@ -666,10 +660,8 @@ components:
                 If the parent document exceeds this limit, it is excluded from the search results.
               type: number
             min_children:
-              description: >-
-                Minimum number of child documents that match the query required to match the query for a returned parent
-                document.
-
+              description: |-
+                Minimum number of child documents that match the query required to match the query for a returned parent document.
                 If the parent document does not meet this limit, it is excluded from the search results.
               type: number
             query:
@@ -912,8 +904,7 @@ components:
             fuzzy_rewrite:
               $ref: '_common.yaml#/components/schemas/MultiTermQueryRewrite'
             fuzzy_transpositions:
-              description: If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to
-                `ba`).
+              description: If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).
               type: boolean
             lenient:
               description: If `true`, format-based errors, such as providing a text query value for a numeric field, are ignored.
@@ -960,10 +951,8 @@ components:
             fuzzy_rewrite:
               $ref: '_common.yaml#/components/schemas/MultiTermQueryRewrite'
             fuzzy_transpositions:
-              description: >-
-                If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab`
-                to `ba`).
-
+              description: |-
+                If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).
                 Can be applied to the term subqueries constructed for all terms but the final term.
               type: boolean
             max_expansions:
@@ -1047,8 +1036,7 @@ components:
                 Defaults to deactivated (0).
               type: number
             fail_on_unsupported_field:
-              description: Controls whether the query should fail (throw an exception) if any of the specified fields are not of the
-                supported types (`text` or `keyword`).
+              description: Controls whether the query should fail (throw an exception) if any of the specified fields are not of the supported types (`text` or `keyword`).
               type: boolean
             fields:
               description: |-
@@ -1061,8 +1049,7 @@ components:
               description: Specifies whether the input documents should also be included in the search results returned.
               type: boolean
             like:
-              description: Specifies free form text and/or a single or multiple documents for which you want to find similar
-                documents.
+              description: Specifies free form text and/or a single or multiple documents for which you want to find similar documents.
               oneOf:
                 - $ref: '#/components/schemas/Like'
                 - type: array
@@ -1162,10 +1149,8 @@ components:
             fuzzy_rewrite:
               $ref: '_common.yaml#/components/schemas/MultiTermQueryRewrite'
             fuzzy_transpositions:
-              description: >-
-                If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab`
-                to `ba`).
-
+              description: |-
+                If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).
                 Can be applied to the term subqueries constructed for all terms but the final term.
               type: boolean
             lenient:
@@ -1316,9 +1301,8 @@ components:
               description: Beginning characters of terms you wish to find in the provided field.
               type: string
             case_insensitive:
-              description: >-
+              description: |-
                 Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`.
-
                 Default is `false` which means the case sensitivity of matching depends on the underlying field’s mapping.
               type: boolean
           required:
@@ -1365,8 +1349,7 @@ components:
             fuzzy_rewrite:
               $ref: '_common.yaml#/components/schemas/MultiTermQueryRewrite'
             fuzzy_transpositions:
-              description: If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to
-                `ba`).
+              description: If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).
               type: boolean
             lenient:
               description: If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.
@@ -1535,10 +1518,8 @@ components:
         - type: object
           properties:
             case_insensitive:
-              description: >-
-                Allows case insensitive matching of the regular expression value with the indexed field values when set
-                to `true`.
-
+              description: |-
+                Allows case insensitive matching of the regular expression value with the indexed field values when set to `true`.
                 When `false`, case sensitivity of matching depends on the underlying field’s mapping.
               type: boolean
             flags:
@@ -1635,8 +1616,7 @@ components:
               description: Number of beginning characters left unchanged for fuzzy matching.
               type: number
             fuzzy_transpositions:
-              description: If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to
-                `ba`).
+              description: If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).
               type: boolean
             lenient:
               description: If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.
@@ -1882,8 +1862,7 @@ components:
       type: object
       properties:
         tokens_freq_ratio_threshold:
-          description: Tokens whose frequency is more than this threshold times the average frequency of all tokens in the
-            specified field are considered outliers and pruned.
+          description: Tokens whose frequency is more than this threshold times the average frequency of all tokens in the specified field are considered outliers and pruned.
           type: number
         tokens_weight_threshold:
           description: Tokens whose weight is less than this threshold are considered nonsignificant and pruned.
@@ -1911,8 +1890,7 @@ components:
         - type: object
           properties:
             case_insensitive:
-              description: Allows case insensitive matching of the pattern with the indexed field values when set to true. Default is
-                false which means the case sensitivity of matching depends on the underlying field’s mapping.
+              description: Allows case insensitive matching of the pattern with the indexed field values when set to true. Default is false which means the case sensitivity of matching depends on the underlying field’s mapping.
               type: boolean
             rewrite:
               $ref: '_common.yaml#/components/schemas/MultiTermQueryRewrite'

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -124,10 +124,8 @@ components:
       description: Time unit for milliseconds
       type: number
     DurationLarge:
-      description: >-
-        A date histogram interval. Similar to `Duration` with additional units: `w` (week), `M` (month), `q` (quarter)
-        and
-
+      description: |-
+        A date histogram interval. Similar to `Duration` with additional units: `w` (week), `M` (month), `q` (quarter) and
         `y` (year)
       type: string
     FieldValue:
@@ -1019,8 +1017,7 @@ components:
         norms_memory:
           $ref: '#/components/schemas/ByteSize'
         norms_memory_in_bytes:
-          description: Total amount, in bytes, of memory used for normalization factors across all shards assigned to selected
-            nodes.
+          description: Total amount, in bytes, of memory used for normalization factors across all shards assigned to selected nodes.
           type: number
         points_memory:
           $ref: '#/components/schemas/ByteSize'
@@ -1072,15 +1069,13 @@ components:
         reserved:
           $ref: '#/components/schemas/ByteSize'
         reserved_in_bytes:
-          description: A prediction, in bytes, of how much larger the shard stores will eventually grow due to ongoing peer
-            recoveries, restoring snapshots, and similar activities.
+          description: A prediction, in bytes, of how much larger the shard stores will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities.
           type: number
         total_data_set_size:
           $ref: '#/components/schemas/ByteSize'
         total_data_set_size_in_bytes:
-          description: >-
+          description: |-
             Total data set size, in bytes, of all shards assigned to selected nodes.
-
             This includes the size of shards not stored fully on the nodes, such as the cache for partially mounted indices.
           type: number
       required:
@@ -1133,8 +1128,7 @@ components:
           description: Number of nodes that responded successfully to the request.
           type: number
         failed:
-          description: Number of nodes that rejected the request or failed to respond. If this value is not 0, a reason for the
-            rejection or failure is included in the response.
+          description: Number of nodes that rejected the request or failed to respond. If this value is not 0, a reason for the rejection or failure is included in the response.
           type: number
       required:
         - total

--- a/spec/schemas/_core.bulk.yaml
+++ b/spec/schemas/_core.bulk.yaml
@@ -29,23 +29,18 @@ components:
         - type: object
           properties:
             dynamic_templates:
-              description: >-
+              description: |-
                 A map from the full name of fields to the name of dynamic templates.
-
                 Defaults to an empty map.
-
                 If a name matches a dynamic template, then that template will be applied regardless of other match predicates defined in the template.
-
                 If a field is already defined in the mapping, then this parameter won’t be used.
               type: object
               additionalProperties:
                 type: string
             pipeline:
-              description: >-
+              description: |-
                 ID of the pipeline to use to preprocess incoming documents.
-
                 If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
-
                 If a final pipeline is configured it will always run, regardless of the value of this parameter.
               type: string
             require_alias:

--- a/spec/schemas/_core.mtermvectors.yaml
+++ b/spec/schemas/_core.mtermvectors.yaml
@@ -19,8 +19,7 @@ components:
         fields:
           $ref: '_common.yaml#/components/schemas/Fields'
         field_statistics:
-          description: If `true`, the response includes the document count, sum of document frequencies, and sum of total term
-            frequencies.
+          description: If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies.
           type: boolean
         filter:
           $ref: '_core.termvectors.yaml#/components/schemas/Filter'

--- a/spec/schemas/_core.rank_eval.yaml
+++ b/spec/schemas/_core.rank_eval.yaml
@@ -70,9 +70,7 @@ components:
         - type: object
           properties:
             ignore_unlabeled:
-              description: Controls how unlabeled documents in the search results are counted. If set to true, unlabeled documents are
-                ignored and neither count as relevant or irrelevant. Set to false (the default), they are treated as
-                irrelevant.
+              description: Controls how unlabeled documents in the search results are counted. If set to true, unlabeled documents are ignored and neither count as relevant or irrelevant. Set to false (the default), they are treated as irrelevant.
               type: boolean
     RankEvalMetricRatingTreshold:
       allOf:
@@ -86,8 +84,7 @@ components:
       type: object
       properties:
         k:
-          description: Sets the maximum number of documents retrieved per query. This value will act in place of the usual size
-            parameter in the query.
+          description: Sets the maximum number of documents retrieved per query. This value will act in place of the usual size parameter in the query.
           type: number
     RankEvalMetricRecall:
       allOf:
@@ -121,13 +118,10 @@ components:
       type: object
       properties:
         metric_score:
-          description: The metric_score in the details section shows the contribution of this query to the global quality metric
-            score
+          description: The metric_score in the details section shows the contribution of this query to the global quality metric score
           type: number
         unrated_docs:
-          description: The unrated_docs section contains an _index and _id entry for each document in the search result for this
-            query that didn’t have a ratings value. This can be used to ask the user to supply ratings for these
-            documents
+          description: The unrated_docs section contains an _index and _id entry for each document in the search result for this query that didn’t have a ratings value. This can be used to ask the user to supply ratings for these documents
           type: array
           items:
             $ref: '#/components/schemas/UnratedDocument'
@@ -137,9 +131,7 @@ components:
           items:
             $ref: '#/components/schemas/RankEvalHitItem'
         metric_details:
-          description: The metric_details give additional information about the calculated quality metric (e.g. how many of the
-            retrieved documents were relevant). The content varies for each metric but allows for better interpretation
-            of the results
+          description: The metric_details give additional information about the calculated quality metric (e.g. how many of the retrieved documents were relevant). The content varies for each metric but allows for better interpretation of the results
           type: object
           additionalProperties:
             type: object

--- a/spec/schemas/_core.reindex.yaml
+++ b/spec/schemas/_core.reindex.yaml
@@ -32,9 +32,8 @@ components:
         remote:
           $ref: '#/components/schemas/RemoteSource'
         size:
-          description: >-
+          description: |-
             The number of documents to index per batch.
-
             Use when indexing from remote to ensure that the batches fit within the on-heap buffer, which defaults to a maximum size of 100 MB.
           type: number
         slice:

--- a/spec/schemas/_core.reindex_rethrottle.yaml
+++ b/spec/schemas/_core.reindex_rethrottle.yaml
@@ -64,8 +64,7 @@ components:
           description: The number of documents that were successfully deleted.
           type: number
         noops:
-          description: The number of documents that were ignored because the script used for the reindex returned a `noop` value
-            for `ctx.op`.
+          description: The number of documents that were ignored because the script used for the reindex returned a `noop` value for `ctx.op`.
           type: number
         requests_per_second:
           description: The number of requests per second effectively executed during the reindex.
@@ -84,8 +83,7 @@ components:
           description: The number of documents that were successfully processed.
           type: number
         updated:
-          description: The number of documents that were successfully updated, for example, a document with same ID already
-            existed prior to reindex updating it.
+          description: The number of documents that were successfully updated, for example, a document with same ID already existed prior to reindex updating it.
           type: number
         version_conflicts:
           description: The number of version conflicts that reindex hits.

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -708,27 +708,20 @@ components:
         max_fragment_length:
           type: number
         max_analyzed_offset:
-          description: >-
+          description: |-
             If set to a non-negative value, highlighting stops at this defined maximum limit.
-
             The rest of the text is not processed, thus not highlighted and no error is returned
-
             The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.
           type: number
         no_match_size:
-          description: The amount of text you want to return from the beginning of the field if there are no matching fragments to
-            highlight.
+          description: The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.
           type: number
         number_of_fragments:
-          description: >-
+          description: |-
             The maximum number of fragments to return.
-
             If the number of fragments is set to `0`, no fragments are returned.
-
             Instead, the entire field contents are highlighted and returned.
-
             This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required.
-
             If `number_of_fragments` is `0`, `fragment_size` is ignored.
           type: number
         options:
@@ -738,13 +731,10 @@ components:
         order:
           $ref: '#/components/schemas/HighlighterOrder'
         phrase_limit:
-          description: >-
+          description: |-
             Controls the number of matching phrases in a document that are considered.
-
             Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory.
-
             When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory.
-
             Only supported by the `fvh` highlighter.
           type: number
         post_tags:

--- a/spec/schemas/cat.allocation.yaml
+++ b/spec/schemas/cat.allocation.yaml
@@ -13,22 +13,18 @@ components:
           description: Number of primary and replica shards assigned to the node.
           type: string
         disk.indices:
-          description: >-
+          description: |-
             Disk space used by the node’s shards. Does not include disk space for the translog or unassigned shards.
-
             IMPORTANT: This metric double-counts disk space for hard-linked files, such as those created when shrinking, splitting, or cloning an index.
           oneOf:
             - $ref: '_common.yaml#/components/schemas/ByteSize'
             - nullable: true
               type: string
         disk.used:
-          description: >-
+          description: |-
             Total disk space in use.
-
             Opensearch retrieves this metric from the node’s operating system (OS).
-
             The metric includes disk space for: Opensearch, including the translog and unassigned shards; the node’s operating system; any other applications or files on the node.
-
             Unlike `disk.indices`, this metric does not double-count disk space for hard-linked files.
           oneOf:
             - $ref: '_common.yaml#/components/schemas/ByteSize'

--- a/spec/schemas/cat.indices.yaml
+++ b/spec/schemas/cat.indices.yaml
@@ -364,12 +364,10 @@ components:
           description: memory used by version map
           type: string
         segments.fixed_bitset_memory:
-          description: memory used by fixed bit sets for nested object field types and export type filters for types referred in
-            _parent fields
+          description: memory used by fixed bit sets for nested object field types and export type filters for types referred in _parent fields
           type: string
         pri.segments.fixed_bitset_memory:
-          description: memory used by fixed bit sets for nested object field types and export type filters for types referred in
-            _parent fields
+          description: memory used by fixed bit sets for nested object field types and export type filters for types referred in _parent fields
           type: string
         warmer.current:
           description: current warmer ops

--- a/spec/schemas/cat.nodes.yaml
+++ b/spec/schemas/cat.nodes.yaml
@@ -85,9 +85,8 @@ components:
           description: The node uptime.
           type: string
         node.role:
-          description: >-
+          description: |-
             The roles of the node.
-
             Returned values include `c`(cold node), `d`(data node), `f`(frozen node), `h`(hot node), `i`(ingest node), `l`(machine learning node), `m` (master eligible node), `r`(remote cluster client node), `s`(content node), `t`(transform node), `v`(voting-only node), `w`(warm node),and `-`(coordinating node only).
           type: string
         master:
@@ -266,8 +265,7 @@ components:
           description: The memory used by the version map.
           type: string
         segments.fixed_bitset_memory:
-          description: The memory used by fixed bit sets for nested object field types and export type filters for types referred
-            in _parent fields.
+          description: The memory used by fixed bit sets for nested object field types and export type filters for types referred in _parent fields.
           type: string
         suggest.current:
           description: The number of current suggest operations.

--- a/spec/schemas/cat.segments.yaml
+++ b/spec/schemas/cat.segments.yaml
@@ -23,13 +23,11 @@ components:
         id:
           $ref: '_common.yaml#/components/schemas/NodeId'
         segment:
-          description: The segment name, which is derived from the segment generation and used internally to create file names in
-            the directory of the shard.
+          description: The segment name, which is derived from the segment generation and used internally to create file names in the directory of the shard.
           type: string
         generation:
-          description: >-
+          description: |-
             The segment generation number.
-
             Opensearch increments this generation number for each segment written then uses this number to derive the segment name.
           type: string
         docs.count:
@@ -39,14 +37,10 @@ components:
             It also excludes documents which were indexed recently and do not yet belong to a segment.
           type: string
         docs.deleted:
-          description: >-
-            The number of deleted documents in the segment, which might be higher or lower than the number of delete
-            operations you have performed.
-
+          description: |-
+            The number of deleted documents in the segment, which might be higher or lower than the number of delete operations you have performed.
             This number excludes deletes that were performed recently and do not yet belong to a segment.
-
             Deleted documents are cleaned up by the automatic merge process if it makes sense to do so.
-
             Also, Opensearch creates extra deleted documents to internally track the recent history of operations on a shard.
           type: string
         size:
@@ -54,11 +48,9 @@ components:
         size.memory:
           $ref: '_common.yaml#/components/schemas/ByteSize'
         committed:
-          description: >-
+          description: |-
             If `true`, the segment is synced to disk.
-
             Segments that are synced can survive a hard reboot.
-
             If `false`, the data from uncommitted segments is also stored in the transaction log so that Opensearch is able to replay changes on the next start.
           type: string
         searchable:

--- a/spec/schemas/cat.shards.yaml
+++ b/spec/schemas/cat.shards.yaml
@@ -58,45 +58,26 @@ components:
           description: The sync identifier.
           type: string
         unassigned.reason:
-          description: >-
+          description: |-
             The reason for the last change to the state of an unassigned shard.
-
             It does not explain why the shard is currently unassigned; use the cluster allocation explain API for that information.
-
             Returned values include:
-
             `ALLOCATION_FAILED`: Unassigned as a result of a failed allocation of the shard.
-
             `CLUSTER_RECOVERED`: Unassigned as a result of a full cluster recovery.
-
             `DANGLING_INDEX_IMPORTED`: Unassigned as a result of importing a dangling index.
-
             `EXISTING_INDEX_RESTORED`: Unassigned as a result of restoring into a closed index.
-
             `FORCED_EMPTY_PRIMARY`: The shard’s allocation was last modified by forcing an empty primary using the cluster reroute API.
-
             `INDEX_CLOSED`: Unassigned because the index was closed.
-
             `INDEX_CREATED`: Unassigned as a result of an API creation of an index.
-
             `INDEX_REOPENED`: Unassigned as a result of opening a closed index.
-
             `MANUAL_ALLOCATION`: The shard’s allocation was last modified by the cluster reroute API.
-
             `NEW_INDEX_RESTORED`: Unassigned as a result of restoring into a new index.
-
             `NODE_LEFT`: Unassigned as a result of the node hosting it leaving the cluster.
-
             `NODE_RESTARTING`: Similar to `NODE_LEFT`, except that the node was registered as restarting using the node shutdown API.
-
             `PRIMARY_FAILED`: The shard was initializing as a replica, but the primary shard failed before the initialization completed.
-
             `REALLOCATED_REPLICA`: A better replica location is identified and causes the existing replica allocation to be cancelled.
-
             `REINITIALIZED`: When a shard moves from started back to initializing.
-
             `REPLICA_ADDED`: Unassigned as a result of explicit addition of a replica.
-
             `REROUTE_CANCELLED`: Unassigned as a result of explicit cancel reroute command.
           type: string
         unassigned.at:
@@ -106,9 +87,8 @@ components:
           description: The time at which the shard was requested to be unassigned in Coordinated Universal Time (UTC).
           type: string
         unassigned.details:
-          description: >-
+          description: |-
             Additional details as to why the shard became unassigned.
-
             It does not explain why the shard is not assigned; use the cluster allocation explain API for that information.
           type: string
         recoverysource.type:
@@ -256,8 +236,7 @@ components:
           description: The memory used by the version map.
           type: string
         segments.fixed_bitset_memory:
-          description: The memory used by fixed bit sets for nested object field types and export type filters for types referred
-            in `_parent` fields.
+          description: The memory used by fixed bit sets for nested object field types and export type filters for types referred in `_parent` fields.
           type: string
         seq_no.max:
           description: The maximum sequence number.

--- a/spec/schemas/cluster.health.yaml
+++ b/spec/schemas/cluster.health.yaml
@@ -51,8 +51,7 @@ components:
         task_max_waiting_in_queue_millis:
           $ref: '_common.yaml#/components/schemas/DurationValueUnitMillis'
         timed_out:
-          description: If false the response returned within the period of time that is specified by the timeout parameter (30s by
-            default)
+          description: If false the response returned within the period of time that is specified by the timeout parameter (30s by default)
           type: boolean
         unassigned_shards:
           description: The number of shards that are not allocated.

--- a/spec/schemas/cluster.pending_tasks.yaml
+++ b/spec/schemas/cluster.pending_tasks.yaml
@@ -16,9 +16,8 @@ components:
           description: The number that represents when the task has been inserted into the task queue.
           type: number
         priority:
-          description: >-
+          description: |-
             The priority of the pending task.
-
             The valid priorities in descending priority order are: `IMMEDIATE` > `URGENT` > `HIGH` > `NORMAL` > `LOW` > `LANGUID`.
           type: string
         source:

--- a/spec/schemas/cluster.reroute.yaml
+++ b/spec/schemas/cluster.reroute.yaml
@@ -75,9 +75,7 @@ components:
         node:
           type: string
         accept_data_loss:
-          description: If a node which has a copy of the data rejoins the cluster later on, that data will be deleted. To ensure
-            that these implications are well-understood, this command requires the flag accept_data_loss to be
-            explicitly set to true
+          description: If a node which has a copy of the data rejoins the cluster later on, that data will be deleted. To ensure that these implications are well-understood, this command requires the flag accept_data_loss to be explicitly set to true
           type: boolean
       required:
         - index

--- a/spec/schemas/cluster.stats.yaml
+++ b/spec/schemas/cluster.stats.yaml
@@ -399,11 +399,9 @@ components:
       type: object
       properties:
         available_in_bytes:
-          description: >-
+          description: |-
             Total number of bytes available to JVM in file stores across all selected nodes.
-
             Depending on operating system or process-level restrictions, this number may be less than `nodes.fs.free_in_byes`.
-
             This is the actual amount of free disk space the selected Opensearch nodes can use.
           type: number
         free_in_bytes:
@@ -573,11 +571,9 @@ components:
       type: object
       properties:
         allocated_processors:
-          description: >-
+          description: |-
             Number of processors used to calculate thread pool size across all selected nodes.
-
             This number can be set with the processors setting of a node and defaults to the number of processors reported by the operating system.
-
             In both cases, this number will never be larger than 32.
           type: number
         architectures:
@@ -622,9 +618,7 @@ components:
       type: object
       properties:
         adjusted_total_in_bytes:
-          description: Total amount, in bytes, of memory across all selected nodes, but using the value specified using the
-            `es.total_memory_bytes` system property instead of measured total memory for those nodes where that system
-            property was set.
+          description: Total amount, in bytes, of memory across all selected nodes, but using the value specified using the `es.total_memory_bytes` system property instead of measured total memory for those nodes where that system property was set.
           type: number
         free_in_bytes:
           description: Amount, in bytes, of free physical memory across all selected nodes.

--- a/spec/schemas/indices._common.yaml
+++ b/spec/schemas/indices._common.yaml
@@ -339,34 +339,24 @@ components:
         indexing_complete:
           $ref: '_common.yaml#/components/schemas/Stringifiedboolean'
         origination_date:
-          description: >-
-            If specified, this is the timestamp used to calculate the index age for its phase transitions. Use this
-            setting
-
+          description: |-
+            If specified, this is the timestamp used to calculate the index age for its phase transitions. Use this setting
             if you create a new index that contains old data and want to use the original creation date to calculate the index
-
             age. Specified as a Unix epoch value in milliseconds.
           type: number
         parse_origination_date:
-          description: >-
-            Set to true to parse the origination date from the index name. This origination date is used to calculate
-            the index age
-
+          description: |-
+            Set to true to parse the origination date from the index name. This origination date is used to calculate the index age
             for its phase transitions. The index name must match the pattern ^.*-{date_format}-\\d+, where the date_format is
-
             yyyy.MM.dd and the trailing digits are optional. An index that was rolled over would normally match the full format,
-
             for example logs-2016.10.31-000002). If the index name doesn’t match the pattern, index creation fails.
           type: boolean
         step:
           $ref: '#/components/schemas/IndexSettingsLifecycleStep'
         rollover_alias:
-          description: >-
-            The index alias to update when the index rolls over. Specify when using a policy that contains a rollover
-            action.
-
+          description: |-
+            The index alias to update when the index rolls over. Specify when using a policy that contains a rollover action.
             When the index rolls over, the alias is updated to reflect that the index is no longer the write index. For more
-
             information about rolling indices, see Rollover.
           type: string
       required:
@@ -597,65 +587,51 @@ components:
       type: object
       properties:
         limit:
-          description: >-
-            The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards
-            this limit.
-
+          description: |-
+            The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.
             The limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance
-
             degradations and memory issues, especially in clusters with a high load or few resources.
           type: number
     MappingLimitSettingsDepth:
       type: object
       properties:
         limit:
-          description: >-
-            The maximum depth for a field, which is measured as the number of inner objects. For instance, if all fields
-            are defined
-
+          description: |-
+            The maximum depth for a field, which is measured as the number of inner objects. For instance, if all fields are defined
             at the root object level, then the depth is 1. If there is one object mapping, then the depth is 2, etc.
           type: number
     MappingLimitSettingsNestedFields:
       type: object
       properties:
         limit:
-          description: >-
-            The maximum number of distinct nested mappings in an index. The nested type should only be used in special
-            cases, when
-
+          description: |-
+            The maximum number of distinct nested mappings in an index. The nested type should only be used in special cases, when
             arrays of objects need to be queried independently of each other. To safeguard against poorly designed mappings, this
-
             setting limits the number of unique nested types per index.
           type: number
     MappingLimitSettingsNestedObjects:
       type: object
       properties:
         limit:
-          description: >-
-            The maximum number of nested JSON objects that a single document can contain across all nested types. This
-            limit helps
-
+          description: |-
+            The maximum number of nested JSON objects that a single document can contain across all nested types. This limit helps
             to prevent out of memory errors when a document contains too many nested objects.
           type: number
     MappingLimitSettingsFieldNameLength:
       type: object
       properties:
         limit:
-          description: >-
-            Setting for the maximum length of a field name. This setting isn’t really something that addresses mappings
-            explosion but
-
+          description: |-
+            Setting for the maximum length of a field name. This setting isn’t really something that addresses mappings explosion but
             might still be useful if you want to limit the field length. It usually shouldn’t be necessary to set this setting. The
-
             default is okay unless a user starts to add a huge number of fields with really long names. Default is `Long.MAX_VALUE` (no limit).
           type: number
     MappingLimitSettingsDimensionFields:
       type: object
       properties:
         limit:
-          description: >-
+          description: |-
             [preview] This functionality is in technical preview and may be changed or removed in a future release.
-
             Opensearch will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
           type: number
     IndexingSlowlogSettings:
@@ -685,12 +661,9 @@ components:
       type: object
       properties:
         limit:
-          description: >-
-            Number of outstanding bytes that may be consumed by indexing requests. When this limit is reached or
-            exceeded,
-
+          description: |-
+            Number of outstanding bytes that may be consumed by indexing requests. When this limit is reached or exceeded,
             the node will reject new coordinating and primary operations. When replica operations consume 1.5x this limit,
-
             the node will reject new replica operations. Defaults to 10% of the heap.
           type: number
     Storage:
@@ -699,14 +672,10 @@ components:
         type:
           $ref: '#/components/schemas/StorageType'
         allow_mmap:
-          description: >-
-            You can restrict the use of the mmapfs and the related hybridfs store type via the setting
-            node.store.allow_mmap.
-
+          description: |-
+            You can restrict the use of the mmapfs and the related hybridfs store type via the setting node.store.allow_mmap.
             This is a boolean setting indicating whether or not memory-mapping is allowed. The default is to allow it. This
-
             setting is useful, for example, if you are in an environment where you can not control the ability to create a lot
-
             of memory maps so you need disable the ability to use memory-mapping.
           type: boolean
       required:
@@ -880,8 +849,7 @@ components:
           description: If `true`, the data stream allows custom routing on write request.
           type: boolean
         generation:
-          description: Current generation for the data stream. This number acts as a cumulative count of the stream’s rollovers,
-            starting at 1.
+          description: Current generation for the data stream. This number acts as a cumulative count of the stream’s rollovers, starting at 1.
           type: number
         hidden:
           description: If `true`, the data stream is hidden.
@@ -905,14 +873,12 @@ components:
         name:
           $ref: '_common.yaml#/components/schemas/DataStreamName'
         replicated:
-          description: If `true`, the data stream is created and managed by cross-cluster replication and the local cluster can
-            not write into this data stream or change its mappings.
+          description: If `true`, the data stream is created and managed by cross-cluster replication and the local cluster can not write into this data stream or change its mappings.
           type: boolean
         status:
           $ref: '_common.yaml#/components/schemas/HealthStatus'
         system:
-          description: If `true`, the data stream is created and managed by an Opensearch stack component and cannot be modified
-            through normal user interaction.
+          description: If `true`, the data stream is created and managed by an Opensearch stack component and cannot be modified through normal user interaction.
           type: boolean
         template:
           $ref: '_common.yaml#/components/schemas/Name'
@@ -966,9 +932,8 @@ components:
         index_patterns:
           $ref: '_common.yaml#/components/schemas/Names'
         composed_of:
-          description: >-
+          description: |-
             An ordered list of component template names.
-
             Component templates are merged in the order specified, meaning that the last component template specified has the highest precedence.
           type: array
           items:

--- a/spec/schemas/ingest._common.yaml
+++ b/spec/schemas/ingest._common.yaml
@@ -121,9 +121,8 @@ components:
             indexed_chars_field:
               $ref: '_common.yaml#/components/schemas/Field'
             properties:
-              description: >-
+              description: |-
                 Array of properties to select to be stored.
-
                 Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`.
               type: array
               items:
@@ -131,9 +130,8 @@ components:
             target_field:
               $ref: '_common.yaml#/components/schemas/Field'
             resource_name:
-              description: >-
+              description: |-
                 Field containing the name of the resource to decode.
-
                 If specified, the processor passes this resource name to the underlying Tika library to enable Resource Name Based Detection.
               type: string
           required:
@@ -218,8 +216,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
             target_field:
               $ref: '_common.yaml#/components/schemas/Field'
@@ -299,12 +296,10 @@ components:
                 Supports template snippets.
               type: string
             locale:
-              description: The locale to use when parsing the date from the document being preprocessed, relevant when parsing month
-                names or week days.
+              description: The locale to use when parsing the date from the document being preprocessed, relevant when parsing month names or week days.
               type: string
             timezone:
-              description: The timezone to use when parsing the date and when date math index supports resolves expressions into
-                concrete index names.
+              description: The timezone to use when parsing the date and when date math index supports resolves expressions into concrete index names.
               type: string
           required:
             - date_formats
@@ -318,9 +313,8 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             path:
-              description: >-
+              description: |-
                 The field that contains the field to expand.
-
                 Only required if the field to expand is part another object field, because the `field` option can only understand leaf fields.
               type: string
           required:
@@ -336,11 +330,9 @@ components:
               description: If `true` and `field` does not exist, the processor quietly exits without modifying the document.
               type: boolean
             max_matches:
-              description: >-
+              description: |-
                 The maximum number of matched documents to include under the configured target field.
-
                 The `target_field` will be turned into a json array if `max_matches` is higher than 1, otherwise `target_field` will become a json object.
-
                 In order to avoid documents getting too large, the maximum allowed value is 128.
               type: number
             override:
@@ -429,9 +421,7 @@ components:
               items:
                 $ref: '#/components/schemas/UserAgentProperty'
             regex_file:
-              description: The name of the file in the `config/ingest-user-agent` directory containing the regular expressions for
-                parsing the user agent string. Both the directory and the file have to be created before starting
-                Opensearch. If not specified, ingest-user-agent will use the `regexes.yaml` from uap-core it ships with.
+              description: The name of the file in the `config/ingest-user-agent` directory containing the regular expressions for parsing the user agent string. Both the directory and the file have to be created before starting Opensearch. If not specified, ingest-user-agent will use the `regexes.yaml` from uap-core it ships with.
               type: string
             target_field:
               $ref: '_common.yaml#/components/schemas/Field'
@@ -466,8 +456,7 @@ components:
               description: Regex pattern to use for splitting key-value pairs.
               type: string
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
             include_keys:
               description: |-
@@ -503,8 +492,7 @@ components:
         - type: object
           properties:
             database_file:
-              description: The database filename referring to a database the module ships with (GeoLite2-City.mmdb,
-                GeoLite2-Country.mmdb, or GeoLite2-ASN.mmdb) or a custom database in the ingest-geoip config directory.
+              description: The database filename referring to a database the module ships with (GeoLite2-City.mmdb, GeoLite2-Country.mmdb, or GeoLite2-ASN.mmdb) or a custom database in the ingest-geoip config directory.
               type: string
             field:
               $ref: '_common.yaml#/components/schemas/Field'
@@ -531,8 +519,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
             pattern_definitions:
               description: |-
@@ -549,8 +536,7 @@ components:
               items:
                 type: string
             trace_match:
-              description: When `true`, `_ingest._grok_match_index` will be inserted into your matched document’s metadata with the
-                index into the pattern found in `patterns` that matched.
+              description: When `true`, `_ingest._grok_match_index` will be inserted into your matched document’s metadata with the index into the pattern found in `patterns` that matched.
               type: boolean
           required:
             - field
@@ -563,8 +549,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
             pattern:
               description: The pattern to be replaced.
@@ -601,8 +586,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
             target_field:
               $ref: '_common.yaml#/components/schemas/Field'
@@ -616,8 +600,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Fields'
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
           required:
             - field
@@ -646,8 +629,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             ignore_empty_value:
-              description: If `true` and `value` is a template snippet that evaluates to `null` or the empty string, the processor
-                quietly exits without modifying the document.
+              description: If `true` and `value` is a template snippet that evaluates to `null` or the empty string, the processor quietly exits without modifying the document.
               type: boolean
             media_type:
               description: |-
@@ -724,8 +706,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
             target_field:
               $ref: '_common.yaml#/components/schemas/Field'
@@ -739,8 +720,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
             target_field:
               $ref: '_common.yaml#/components/schemas/Field'
@@ -754,8 +734,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
             target_field:
               $ref: '_common.yaml#/components/schemas/Field'
@@ -772,8 +751,7 @@ components:
             field:
               $ref: '_common.yaml#/components/schemas/Field'
             ignore_missing:
-              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the
-                document.
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
               type: boolean
             pattern:
               description: The pattern to apply to the field.
@@ -817,8 +795,7 @@ components:
         - type: object
           properties:
             error_distance:
-              description: The difference between the resulting inscribed distance from center to side and the circle’s radius
-                (measured in meters for `geo_shape`, unit-less for `shape`).
+              description: The difference between the resulting inscribed distance from center to side and the circle’s radius (measured in meters for `geo_shape`, unit-less for `shape`).
               type: number
             field:
               $ref: '_common.yaml#/components/schemas/Field'

--- a/spec/schemas/nodes._common.yaml
+++ b/spec/schemas/nodes._common.yaml
@@ -16,9 +16,8 @@ components:
           description: Total number of HTTP connections opened for the node.
           type: number
         clients:
-          description: >-
+          description: |-
             Information on current and recently-closed HTTP client connections.
-
             Clients that have been closed longer than the `http.client_stats.closed_channels.max_age` setting will not be represented here.
           type: array
           items:
@@ -256,8 +255,7 @@ components:
         avg_response_time:
           $ref: '_common.yaml#/components/schemas/Duration'
         avg_response_time_ns:
-          description: The exponentially weighted moving average response time, in nanoseconds, of search requests on the keyed
-            node.
+          description: The exponentially weighted moving average response time, in nanoseconds, of search requests on the keyed node.
           type: number
         avg_service_time:
           $ref: '_common.yaml#/components/schemas/Duration'
@@ -383,9 +381,8 @@ components:
       type: object
       properties:
         devices:
-          description: >-
+          description: |-
             Array of disk metrics for each device that is backing an Opensearch data path.
-
             These disk metrics are probed periodically and averages between the last probe and the current probe are computed.
           type: array
           items:
@@ -589,10 +586,8 @@ components:
       type: object
       properties:
         adjusted_total_in_bytes:
-          description: >-
-            If the amount of physical memory has been overridden using the `es`.`total_memory_bytes` system property
-            then this reports the overridden value in bytes.
-
+          description: |-
+            If the amount of physical memory has been overridden using the `es`.`total_memory_bytes` system property then this reports the overridden value in bytes.
             Otherwise it reports the same value as `total_in_bytes`.
           type: number
         resident:
@@ -640,12 +635,10 @@ components:
           description: The `cpu` control group to which the Opensearch process belongs.
           type: string
         cfs_period_micros:
-          description: The period of time, in microseconds, for how regularly all tasks in the same cgroup as the Opensearch
-            process should have their access to CPU resources reallocated.
+          description: The period of time, in microseconds, for how regularly all tasks in the same cgroup as the Opensearch process should have their access to CPU resources reallocated.
           type: number
         cfs_quota_micros:
-          description: The total amount of time, in microseconds, for which all tasks in the same cgroup as the Opensearch process
-            can run during one period `cfs_period_micros`.
+          description: The total amount of time, in microseconds, for which all tasks in the same cgroup as the Opensearch process can run during one period `cfs_period_micros`.
           type: number
         stat:
           $ref: '#/components/schemas/CgroupCpuStat'
@@ -667,19 +660,14 @@ components:
           description: The `memory` control group to which the Opensearch process belongs.
           type: string
         limit_in_bytes:
-          description: >-
-            The maximum amount of user memory (including file cache) allowed for all tasks in the same cgroup as the
-            Opensearch process.
-
+          description: |-
+            The maximum amount of user memory (including file cache) allowed for all tasks in the same cgroup as the Opensearch process.
             This value can be too big to store in a `long`, so is returned as a string so that the value returned can exactly match what the underlying operating system interface returns.
-
             Any value that is too large to parse into a `long` almost certainly means no limit has been set for the cgroup.
           type: string
         usage_in_bytes:
-          description: >-
-            The total current memory usage by processes in the cgroup, in bytes, by all tasks in the same cgroup as the
-            Opensearch process.
-
+          description: |-
+            The total current memory usage by processes in the cgroup, in bytes, by all tasks in the same cgroup as the Opensearch process.
             This value is stored as a string for consistency with `limit_in_bytes`.
           type: string
     Process:
@@ -718,14 +706,12 @@ components:
       type: object
       properties:
         inbound_handling_time_histogram:
-          description: The distribution of the time spent handling each inbound message on a transport thread, represented as a
-            histogram.
+          description: The distribution of the time spent handling each inbound message on a transport thread, represented as a histogram.
           type: array
           items:
             $ref: '#/components/schemas/TransportHistogram'
         outbound_handling_time_histogram:
-          description: The distribution of the time spent sending each outbound transport message on a transport thread,
-            represented as a histogram.
+          description: The distribution of the time spent sending each outbound transport message on a transport thread, represented as a histogram.
           type: array
           items:
             $ref: '#/components/schemas/TransportHistogram'
@@ -760,8 +746,7 @@ components:
       type: object
       properties:
         count:
-          description: The number of times a transport thread took a period of time within the bounds of this bucket to handle an
-            inbound message.
+          description: The number of times a transport thread took a period of time within the bounds of this bucket to handle an inbound message.
           type: number
         lt_millis:
           description: |-
@@ -769,8 +754,7 @@ components:
             May be omitted on the last bucket if this bucket has no upper bound.
           type: number
         ge_millis:
-          description: The inclusive lower bound of the bucket in milliseconds. May be omitted on the first bucket if this bucket
-            has no lower bound.
+          description: The inclusive lower bound of the bucket in milliseconds. May be omitted on the first bucket if this bucket has no lower bound.
           type: number
     Discovery:
       type: object
@@ -780,14 +764,10 @@ components:
         published_cluster_states:
           $ref: '#/components/schemas/PublishedClusterStates'
         cluster_state_update:
-          description: >-
-            Contains low-level statistics about how long various activities took during cluster state updates while the
-            node was the elected master.
-
+          description: |-
+            Contains low-level statistics about how long various activities took during cluster state updates while the node was the elected master.
             Omitted if the node is not master-eligible.
-
             Every field whose name ends in `_time` within this object is also represented as a raw number of milliseconds in a field whose name ends in `_time_millis`.
-
             The human-readable fields with a `_time` suffix are only returned if requested with the `?human=true` query parameter.
           type: object
           additionalProperties:
@@ -924,9 +904,8 @@ components:
         combined_coordinating_and_primary:
           $ref: '_common.yaml#/components/schemas/ByteSize'
         combined_coordinating_and_primary_in_bytes:
-          description: >-
+          description: |-
             Memory consumed, in bytes, by indexing requests in the coordinating or primary stage.
-
             This value is not the sum of coordinating and primary as a node can reuse the coordinating memory if the primary stage is executed locally.
           type: number
         coordinating:

--- a/spec/schemas/nodes.info.yaml
+++ b/spec/schemas/nodes.info.yaml
@@ -63,8 +63,7 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/NodeThreadPoolInfo'
         total_indexing_buffer:
-          description: Total heap allowed to be used to hold recently indexed documents before they must be written to disk. This
-            size is a shared pool across all shards on this node, and is controlled by Indexing Buffer settings.
+          description: Total heap allowed to be used to hold recently indexed documents before they must be written to disk. This size is a shared pool across all shards on this node, and is controlled by Indexing Buffer settings.
           type: number
         total_indexing_buffer_in_bytes:
           $ref: '_common.yaml#/components/schemas/ByteSize'
@@ -221,8 +220,7 @@ components:
           description: Number of processors available to the Java virtual machine
           type: number
         allocated_processors:
-          description: The number of processors actually used to calculate thread pool size. This number can be set with the
-            node.processors setting of a node and defaults to the number of processors reported by the OS.
+          description: The number of processors actually used to calculate thread pool size. This number can be set with the node.processors setting of a node and defaults to the number of processors reported by the OS.
           type: number
         name:
           $ref: '_common.yaml#/components/schemas/Name'


### PR DESCRIPTION
When splitting and converting the spec from single JSON to multiple YAML file, I wasn't aware that some line-wrap was added by the YAML encoder by default(e.g. a 120-char-per-line limit was accidentally added). This PR is removing that limit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
