### PR TITLE
Replace pull_request_target workflow with two workflows that upload/download an artifact.

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -14,28 +14,11 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download Coverage Report
-        uses: actions/github-script@v3.1.0
+        uses: actions/download-artifact@v4
         with:
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "coverage"
-            })[0];
-            var download = await github.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/coverage.zip', Buffer.from(download.data));
-      - run: |
-            unzip coverage.zip
-            cat coverage.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: coverage
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: 'Comment on PR'
         uses: actions/github-script@v3

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,53 @@
+name: Comment with API Coverage
+
+on:
+  workflow_run:
+    workflows: ["Gather API Coverage"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download Coverage Report
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "coverage"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/coverage.zip', Buffer.from(download.data));
+      - run: |
+            unzip coverage.zip
+            cat coverage.json
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            var data = JSON.parse(fs.readFileSync('./coverage.json'));
+            console.log(data);
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: data.pull_request,
+              body: `API specs implemented for ${data.current}/${data.total} (${data.percent}%) APIs.`
+            });

--- a/.github/workflows/coverage-gather.yml
+++ b/.github/workflows/coverage-gather.yml
@@ -1,6 +1,6 @@
-name: API Coverage
+name: Gather API Coverage
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 env:
   JAVA_VERSION: 11
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-        with:
-           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build Spec
         working-directory: ./tools
         run: |-
@@ -50,14 +48,15 @@ jobs:
           total=`jq -r '.paths | keys | length' build/local-openapi.json`
           percent=$((current * 100 / total))
           echo "API specs implemented for $current/$total ($percent%) APIs."
-          cat >>"$GITHUB_OUTPUT" <<EOL
-          current=$current
-          total=$total
-          percent=$percent
+          cat >>"coverage.json" <<EOL
+          {
+            "pull_request":${{ github.event.number }},
+            "current":$current,
+            "total":$total,
+            "percent":$percent
+          }
           EOL
-      - uses: peter-evans/create-or-update-comment@v4
-        if: github.event_name == 'pull_request_target'
+      - uses: actions/upload-artifact@v2
         with:
-          issue-number: ${{ github.event.number }}
-          body: |
-            API specs implemented for ${{ steps.coverage.outputs.current }}/${{ steps.coverage.outputs.total }} (${{ steps.coverage.outputs.percent }}%) APIs.
+          name: coverage
+          path: coverage.json

--- a/.github/workflows/coverage-gather.yml
+++ b/.github/workflows/coverage-gather.yml
@@ -56,7 +56,7 @@ jobs:
             "percent":$percent
           }
           EOL
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage.json


### PR DESCRIPTION
### Description

When we use `pull_request_target` we check out code that has potentially been modified by the requester, which isn't safe. This PR replaces the workflow with something inspired by https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ - a gather step and a comment step that use an artifact to pass information between them.

Here's a a gather workflow that produces the artifact: https://github.com/dblock/opensearch-api-specification/actions/runs/8740901986
Here's a comment workflow that uses it: https://github.com/dblock/opensearch-api-specification/actions/runs/8740884453


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
