### PR TITLE
Fix: var -> const.

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -26,7 +26,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            var data = JSON.parse(fs.readFileSync('./coverage.json'));
+            const data = JSON.parse(fs.readFileSync('./coverage.json'));
             console.log(data);
             await github.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
### Description

Coming from https://github.com/opensearch-project/opensearch-api-specification/pull/251#discussion_r1573103478, replaced `var` with `const`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
