### PR TITLE
Specify charset returned from OpenSearch.

### DIFF
--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2110,7 +2110,7 @@ components:
   requestBodies:
     bulk:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -2122,7 +2122,7 @@ components:
       required: true
     clear_scroll:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2131,7 +2131,7 @@ components:
             description: Comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter
     count:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2140,14 +2140,14 @@ components:
             description: Query to restrict the results specified with the Query DSL (optional)
     create:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             description: The document
       required: true
     delete_by_query:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2162,7 +2162,7 @@ components:
       required: true
     delete_pit:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             description: The point-in-time ids to be deleted
@@ -2175,7 +2175,7 @@ components:
               - pit_id
     explain:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2184,7 +2184,7 @@ components:
             description: The query definition using the Query DSL
     field_caps:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2197,14 +2197,14 @@ components:
             description: An index filter specified with the Query DSL
     index:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             description: The document
       required: true
     mget:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2219,7 +2219,7 @@ components:
       required: true
     msearch:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -2228,7 +2228,7 @@ components:
       required: true
     msearch_template:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -2237,7 +2237,7 @@ components:
       required: true
     mtermvectors:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2254,7 +2254,7 @@ components:
             description: Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.
     put_script:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2266,7 +2266,7 @@ components:
       required: true
     rank_eval:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2283,7 +2283,7 @@ components:
       required: true
     reindex:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2307,7 +2307,7 @@ components:
       required: true
     render_search_template:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2331,7 +2331,7 @@ components:
             description: The search definition template and its params
     scripts_painless_execute:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2345,7 +2345,7 @@ components:
             description: The script to execute
     scroll:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2358,7 +2358,7 @@ components:
             description: The scroll ID if not passed by URL or query parameter.
     search:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2503,7 +2503,7 @@ components:
             description: The search definition using the Query DSL
     search_template:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2533,7 +2533,7 @@ components:
       required: true
     termvectors:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2550,7 +2550,7 @@ components:
             description: Define parameters and or supply a document to get termvectors for. See documentation.
     update:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2581,7 +2581,7 @@ components:
       required: true
     update_by_query:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2601,7 +2601,7 @@ components:
     bulk@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2626,7 +2626,7 @@ components:
     clear_scroll@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2640,7 +2640,7 @@ components:
     count@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2654,13 +2654,13 @@ components:
     create@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
     create_pit@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2674,13 +2674,13 @@ components:
     delete@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
     delete_all_pits@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2691,7 +2691,7 @@ components:
     delete_by_query@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2732,13 +2732,13 @@ components:
     delete_by_query_rethrottle@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/tasks._common.yaml#/components/schemas/TaskListResponseBase'
     delete_pit@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2749,21 +2749,21 @@ components:
     delete_script@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     exists@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     exists_source@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     explain@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2784,7 +2784,7 @@ components:
     field_caps@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2802,13 +2802,13 @@ components:
     get@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_core.get.yaml#/components/schemas/GetResult'
     get_all_pits@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2819,7 +2819,7 @@ components:
     get_script@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2835,7 +2835,7 @@ components:
     get_script_context@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2848,7 +2848,7 @@ components:
     get_script_languages@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2866,19 +2866,19 @@ components:
     get_source@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
     index@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
     info@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2901,7 +2901,7 @@ components:
     mget@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2914,19 +2914,19 @@ components:
     msearch@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_core.msearch.yaml#/components/schemas/MultiSearchResult'
     msearch_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_core.msearch.yaml#/components/schemas/MultiSearchResult'
     mtermvectors@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2939,17 +2939,17 @@ components:
     ping@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     put_script@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     rank_eval@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2972,7 +2972,7 @@ components:
     reindex@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -3013,7 +3013,7 @@ components:
     reindex_rethrottle@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -3026,7 +3026,7 @@ components:
     render_search_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -3039,7 +3039,7 @@ components:
     scripts_painless_execute@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -3050,19 +3050,19 @@ components:
     scroll@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/ResponseBody'
     search@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/ResponseBody'
     search_shards@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -3087,7 +3087,7 @@ components:
     search_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -3135,7 +3135,7 @@ components:
     termvectors@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -3162,13 +3162,13 @@ components:
     update@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_core.update.yaml#/components/schemas/UpdateWriteResponseBase'
     update_by_query@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -3209,7 +3209,7 @@ components:
     update_by_query_rethrottle@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -778,7 +778,7 @@ components:
   requestBodies:
     cat.pit_segments:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -792,7 +792,7 @@ components:
     cat.aliases@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -800,7 +800,7 @@ components:
     cat.all_pit_segments@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -808,7 +808,7 @@ components:
     cat.allocation@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -818,7 +818,7 @@ components:
     cat.count@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -826,7 +826,7 @@ components:
     cat.fielddata@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -834,7 +834,7 @@ components:
     cat.health@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -842,7 +842,7 @@ components:
     cat.help@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -850,7 +850,7 @@ components:
     cat.indices@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -858,7 +858,7 @@ components:
     cat.master@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -866,7 +866,7 @@ components:
     cat.nodeattrs@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -874,7 +874,7 @@ components:
     cat.nodes@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -882,7 +882,7 @@ components:
     cat.pending_tasks@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -890,7 +890,7 @@ components:
     cat.pit_segments@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -898,7 +898,7 @@ components:
     cat.plugins@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -906,7 +906,7 @@ components:
     cat.recovery@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -914,7 +914,7 @@ components:
     cat.repositories@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -922,7 +922,7 @@ components:
     cat.segment_replication@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -930,7 +930,7 @@ components:
     cat.segments@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -938,7 +938,7 @@ components:
     cat.shards@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -946,7 +946,7 @@ components:
     cat.snapshots@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -954,7 +954,7 @@ components:
     cat.tasks@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -962,7 +962,7 @@ components:
     cat.templates@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:
@@ -970,7 +970,7 @@ components:
     cat.thread_pool@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: array
             items:

--- a/spec/namespaces/cluster.yaml
+++ b/spec/namespaces/cluster.yaml
@@ -467,7 +467,7 @@ components:
   requestBodies:
     cluster.allocation_explain:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -485,7 +485,7 @@ components:
             description: The index, shard, and primary flag to explain. Empty means 'explain the first unassigned shard'
     cluster.put_component_template:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -508,7 +508,7 @@ components:
       required: true
     cluster.put_settings:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -524,7 +524,7 @@ components:
       required: true
     cluster.reroute:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -538,7 +538,7 @@ components:
     cluster.allocation_explain@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -606,7 +606,7 @@ components:
     cluster.delete_component_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     cluster.delete_decommission_awareness@200:
@@ -614,17 +614,17 @@ components:
     cluster.delete_voting_config_exclusions@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     cluster.delete_weighted_routing@200:
       description: ''
     cluster.exists_component_template@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     cluster.get_component_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -639,7 +639,7 @@ components:
     cluster.get_settings@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -663,13 +663,13 @@ components:
     cluster.health@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/cluster.health.yaml#/components/schemas/HealthResponseBody'
     cluster.pending_tasks@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -682,11 +682,11 @@ components:
     cluster.post_voting_config_exclusions@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     cluster.put_component_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     cluster.put_decommission_awareness@200:
@@ -694,7 +694,7 @@ components:
     cluster.put_settings@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -717,7 +717,7 @@ components:
     cluster.remote_info@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -725,7 +725,7 @@ components:
     cluster.reroute@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -746,13 +746,13 @@ components:
     cluster.state@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
     cluster.stats@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/cluster.stats.yaml#/components/schemas/StatsResponseBase'
   parameters:

--- a/spec/namespaces/dangling_indices.yaml
+++ b/spec/namespaces/dangling_indices.yaml
@@ -55,19 +55,19 @@ components:
     dangling_indices.delete_dangling_index@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     dangling_indices.import_dangling_index@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     dangling_indices.list_dangling_indices@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -1756,7 +1756,7 @@ components:
   requestBodies:
     indices.analyze:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1795,7 +1795,7 @@ components:
             description: Define analyzer/tokenizer parameters and the text on which the analysis should be performed
     indices.clone:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1812,7 +1812,7 @@ components:
             description: The configuration for the target index (`settings` and `aliases`)
     indices.create:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1828,13 +1828,13 @@ components:
             description: The configuration for the index (`settings` and `mappings`)
     indices.create_data_stream:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             description: The data stream definition
     indices.put_alias:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1856,7 +1856,7 @@ components:
             description: The settings for the alias, such as `routing` or `filter`
     indices.put_index_template:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1888,7 +1888,7 @@ components:
       required: true
     indices.put_mapping:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1943,13 +1943,13 @@ components:
       required: true
     indices.put_settings:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/indices._common.yaml#/components/schemas/IndexSettings'
       required: true
     indices.put_template:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1988,7 +1988,7 @@ components:
       required: true
     indices.rollover:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2013,7 +2013,7 @@ components:
             description: The conditions that needs to be met for executing rollover
     indices.shrink:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2032,7 +2032,7 @@ components:
             description: The configuration for the target index (`settings` and `aliases`)
     indices.simulate_index_template:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2069,12 +2069,12 @@ components:
             description: New index template definition, which will be included in the simulation, as if it already exists in the system
     indices.simulate_template:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/indices._common.yaml#/components/schemas/IndexTemplate'
     indices.split:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2091,7 +2091,7 @@ components:
             description: The configuration for the target index (`settings` and `aliases`)
     indices.update_aliases:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2104,7 +2104,7 @@ components:
       required: true
     indices.validate_query:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2115,7 +2115,7 @@ components:
     indices.add_block@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2134,7 +2134,7 @@ components:
     indices.analyze@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2147,13 +2147,13 @@ components:
     indices.clear_cache@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/ShardsOperationResponseBase'
     indices.clone@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2170,7 +2170,7 @@ components:
     indices.close@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2189,7 +2189,7 @@ components:
     indices.create@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2206,13 +2206,13 @@ components:
     indices.create_data_stream@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.data_streams_stats@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2243,59 +2243,59 @@ components:
     indices.delete@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/IndicesResponseBase'
     indices.delete_alias@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.delete_data_stream@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.delete_index_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.delete_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.exists@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     indices.exists_alias@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     indices.exists_index_template@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     indices.exists_template@200:
       description: ''
       content:
-        application/json: {}
+        application/json; charset=utf-8: {}
     indices.flush@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/ShardsOperationResponseBase'
     indices.forcemerge@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             allOf:
               - $ref: '../schemas/_common.yaml#/components/schemas/ShardsOperationResponseBase'
@@ -2309,7 +2309,7 @@ components:
     indices.get@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -2317,7 +2317,7 @@ components:
     indices.get_alias@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -2325,7 +2325,7 @@ components:
     indices.get_data_stream@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2338,7 +2338,7 @@ components:
     indices.get_field_mapping@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -2346,7 +2346,7 @@ components:
     indices.get_index_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2359,7 +2359,7 @@ components:
     indices.get_mapping@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -2367,7 +2367,7 @@ components:
     indices.get_settings@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -2375,7 +2375,7 @@ components:
     indices.get_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -2385,7 +2385,7 @@ components:
     indices.open@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2399,37 +2399,37 @@ components:
     indices.put_alias@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.put_index_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.put_mapping@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/IndicesResponseBase'
     indices.put_settings@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.put_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.recovery@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -2437,13 +2437,13 @@ components:
     indices.refresh@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/ShardsOperationResponseBase'
     indices.resolve_index@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2466,7 +2466,7 @@ components:
     indices.rollover@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2497,7 +2497,7 @@ components:
     indices.segments@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2513,7 +2513,7 @@ components:
     indices.shard_stores@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2526,7 +2526,7 @@ components:
     indices.shrink@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2543,13 +2543,13 @@ components:
     indices.simulate_index_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
     indices.simulate_template@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2564,7 +2564,7 @@ components:
     indices.split@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2581,7 +2581,7 @@ components:
     indices.stats@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -2599,7 +2599,7 @@ components:
     indices.update_aliases@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.upgrade@200:
@@ -2607,7 +2607,7 @@ components:
     indices.validate_query@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:

--- a/spec/namespaces/ingest.yaml
+++ b/spec/namespaces/ingest.yaml
@@ -141,7 +141,7 @@ components:
   requestBodies:
     ingest.put_pipeline:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -166,7 +166,7 @@ components:
       required: true
     ingest.simulate:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -183,13 +183,13 @@ components:
     ingest.delete_pipeline@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     ingest.get_pipeline@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -197,7 +197,7 @@ components:
     ingest.processor_grok@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -210,13 +210,13 @@ components:
     ingest.put_pipeline@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     ingest.simulate@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:

--- a/spec/namespaces/knn.yaml
+++ b/spec/namespaces/knn.yaml
@@ -244,12 +244,12 @@ components:
   requestBodies:
     knn.search_models:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
     knn.train_model:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:

--- a/spec/namespaces/nodes.yaml
+++ b/spec/namespaces/nodes.yaml
@@ -456,7 +456,7 @@ components:
   requestBodies:
     nodes.reload_secure_settings:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -469,25 +469,25 @@ components:
     nodes.info@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/nodes.info.yaml#/components/schemas/ResponseBase'
     nodes.reload_secure_settings@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/nodes.reload_secure_settings.yaml#/components/schemas/ResponseBase'
     nodes.stats@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/nodes.stats.yaml#/components/schemas/ResponseBase'
     nodes.usage@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/nodes.usage.yaml#/components/schemas/ResponseBase'
   parameters:

--- a/spec/namespaces/notifications.yaml
+++ b/spec/namespaces/notifications.yaml
@@ -172,13 +172,13 @@ components:
   requestBodies:
     notifications.create_config:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/notifications._common.yaml#/components/schemas/NotificationsConfig'
       required: true
     notifications.get_configs:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -198,7 +198,7 @@ components:
                 format: int32
     notifications.update_config:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/notifications._common.yaml#/components/schemas/NotificationsConfig'
       required: true
@@ -206,7 +206,7 @@ components:
     notifications.create_config@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -215,31 +215,31 @@ components:
     notifications.delete_config@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/notifications._common.yaml#/components/schemas/DeleteConfigsResponse'
     notifications.delete_configs@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/notifications._common.yaml#/components/schemas/DeleteConfigsResponse'
     notifications.get_config@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/notifications._common.yaml#/components/schemas/GetConfigsResponse'
     notifications.get_configs@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/notifications._common.yaml#/components/schemas/GetConfigsResponse'
     notifications.list_channels@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -258,7 +258,7 @@ components:
     notifications.list_features@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -271,7 +271,7 @@ components:
     notifications.send_test@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -284,7 +284,7 @@ components:
     notifications.update_config@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:

--- a/spec/namespaces/remote_store.yaml
+++ b/spec/namespaces/remote_store.yaml
@@ -24,7 +24,7 @@ components:
   requestBodies:
     remote_store.restore:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             description: Comma-separated list of index IDs
@@ -47,7 +47,7 @@ components:
     remote_store.restore@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:

--- a/spec/namespaces/search_pipeline.yaml
+++ b/spec/namespaces/search_pipeline.yaml
@@ -59,7 +59,7 @@ components:
   requestBodies:
     search_pipeline.put:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/search_pipeline._common.yaml#/components/schemas/SearchPipelineStructure'
       required: true
@@ -67,7 +67,7 @@ components:
     search_pipeline.put@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -76,7 +76,7 @@ components:
     search_pipeline.delete@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -85,7 +85,7 @@ components:
     search_pipeline.get@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/search_pipeline._common.yaml#/components/schemas/SearchPipelineMap'
   parameters:

--- a/spec/namespaces/security.yaml
+++ b/spec/namespaces/security.yaml
@@ -601,43 +601,43 @@ components:
   requestBodies:
     security.change_password:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/ChangePasswordRequestContent'
       required: true
     security.create_action_group:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/ActionGroup'
       required: true
     security.create_role:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/Role'
       required: true
     security.create_role_mapping:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/RoleMapping'
       required: true
     security.create_tenant:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/CreateTenantParams'
       required: true
     security.create_user:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/User'
       required: true
     security.patch_action_group:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -645,7 +645,7 @@ components:
       required: true
     security.patch_action_groups:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -653,7 +653,7 @@ components:
       required: true
     security.patch_audit_configuration:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -661,7 +661,7 @@ components:
       required: true
     security.patch_configuration:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -669,7 +669,7 @@ components:
       required: true
     security.patch_distinguished_names:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -677,7 +677,7 @@ components:
       required: true
     security.patch_role:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -685,7 +685,7 @@ components:
       required: true
     security.patch_role_mapping:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -693,7 +693,7 @@ components:
       required: true
     security.patch_role_mappings:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -701,7 +701,7 @@ components:
       required: true
     security.patch_roles:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -709,7 +709,7 @@ components:
       required: true
     security.patch_tenant:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -717,7 +717,7 @@ components:
       required: true
     security.patch_tenants:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -725,7 +725,7 @@ components:
       required: true
     security.patch_user:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -733,7 +733,7 @@ components:
       required: true
     security.patch_users:
       content:
-        application/x-ndjson:
+        application/x-ndjson; charset=utf-8:
           schema:
             type: array
             items:
@@ -741,26 +741,26 @@ components:
       required: true
     security.update_audit_configuration:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/AuditConfig'
       required: true
     security.update_configuration:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/DynamicConfig'
       required: true
     security.update_distinguished_names:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/DistinguishedNames'
   responses:
     security.change_password@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -773,7 +773,7 @@ components:
     security.create_action_group@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -786,7 +786,7 @@ components:
     security.create_role@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -799,7 +799,7 @@ components:
     security.create_role_mapping@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -812,7 +812,7 @@ components:
     security.create_tenant@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -825,7 +825,7 @@ components:
     security.create_user@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -838,7 +838,7 @@ components:
     security.delete_action_group@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -851,7 +851,7 @@ components:
     security.delete_distinguished_names@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -864,7 +864,7 @@ components:
     security.delete_role@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -877,7 +877,7 @@ components:
     security.delete_role_mapping@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -890,7 +890,7 @@ components:
     security.delete_tenant@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -903,7 +903,7 @@ components:
     security.delete_user@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -916,7 +916,7 @@ components:
     security.flush_cache@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -929,31 +929,31 @@ components:
     security.get_account_details@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/AccountDetails'
     security.get_action_group@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/ActionGroupsMap'
     security.get_action_groups@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/ActionGroupsMap'
     security.get_audit_configuration@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/AuditConfigWithReadOnly'
     security.get_certificates@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -968,67 +968,67 @@ components:
     security.get_configuration@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/DynamicConfig'
     security.get_distinguished_names@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/DistinguishedNamesMap'
     security.get_role@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/RolesMap'
     security.get_role_mapping@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/RoleMappings'
     security.get_role_mappings@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/RoleMappings'
     security.get_roles@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/RolesMap'
     security.get_tenant@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/TenantsMap'
     security.get_tenants@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/TenantsMap'
     security.get_user@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/UsersMap'
     security.get_users@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/UsersMap'
     security.health@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1041,7 +1041,7 @@ components:
     security.patch_action_group@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1054,7 +1054,7 @@ components:
     security.patch_action_groups@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1069,7 +1069,7 @@ components:
     security.patch_configuration@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1082,7 +1082,7 @@ components:
     security.patch_distinguished_names@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1095,7 +1095,7 @@ components:
     security.patch_role@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1108,7 +1108,7 @@ components:
     security.patch_role_mapping@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1121,7 +1121,7 @@ components:
     security.patch_role_mappings@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1134,7 +1134,7 @@ components:
     security.patch_roles@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1147,7 +1147,7 @@ components:
     security.patch_tenant@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1160,7 +1160,7 @@ components:
     security.patch_tenants@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1173,7 +1173,7 @@ components:
     security.patch_user@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1186,7 +1186,7 @@ components:
     security.patch_users@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1199,7 +1199,7 @@ components:
     security.reload_http_certificates@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1212,7 +1212,7 @@ components:
     security.reload_transport_certificates@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1225,7 +1225,7 @@ components:
     security.update_audit_configuration@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1238,7 +1238,7 @@ components:
     security.update_configuration@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -1251,7 +1251,7 @@ components:
     security.update_distinguished_names@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -277,7 +277,7 @@ components:
   requestBodies:
     snapshot.clone:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -289,7 +289,7 @@ components:
       required: true
     snapshot.create:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -314,7 +314,7 @@ components:
             description: The snapshot definition
     snapshot.create_repository:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -331,7 +331,7 @@ components:
       required: true
     snapshot.restore:
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -364,7 +364,7 @@ components:
     snapshot.cleanup_repository@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -375,13 +375,13 @@ components:
     snapshot.clone@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     snapshot.create@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -393,25 +393,25 @@ components:
     snapshot.create_repository@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     snapshot.delete@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     snapshot.delete_repository@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     snapshot.get@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -435,7 +435,7 @@ components:
     snapshot.get_repository@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             additionalProperties:
@@ -443,7 +443,7 @@ components:
     snapshot.restore@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -454,7 +454,7 @@ components:
     snapshot.status@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -467,7 +467,7 @@ components:
     snapshot.verify_repository@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:

--- a/spec/namespaces/tasks.yaml
+++ b/spec/namespaces/tasks.yaml
@@ -77,13 +77,13 @@ components:
     tasks.cancel@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/tasks._common.yaml#/components/schemas/TaskListResponseBase'
     tasks.get@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object
             properties:
@@ -101,7 +101,7 @@ components:
     tasks.list@200:
       description: ''
       content:
-        application/json:
+        application/json; charset=utf-8:
           schema:
             $ref: '../schemas/tasks._common.yaml#/components/schemas/TaskListResponseBase'
   parameters:

--- a/tools/test/merger/fixtures/expected.yaml
+++ b/tools/test/merger/fixtures/expected.yaml
@@ -84,12 +84,12 @@ components:
   responses:
     adopt@200:
       description: ''
-      application/json:
+      application/json; charset=utf-8:
         schema:
           type: object
     indices.create@200:
       description: ''
-      application/json:
+      application/json; charset=utf-8:
         schema:
           type: object
   schemas:

--- a/tools/test/merger/fixtures/spec/namespaces/indices.yaml
+++ b/tools/test/merger/fixtures/spec/namespaces/indices.yaml
@@ -30,6 +30,6 @@ components:
     responses:
         indices.create@200:
             description: ''
-            application/json:
+            application/json; charset=utf-8:
               schema:
                 type: object

--- a/tools/test/merger/fixtures/spec/namespaces/shelter.yaml
+++ b/tools/test/merger/fixtures/spec/namespaces/shelter.yaml
@@ -40,6 +40,6 @@ components:
     responses:
       adopt@200:
         description: ''
-        application/json:
+        application/json; charset=utf-8:
           schema:
             type: object


### PR DESCRIPTION
### Description

Coming from https://github.com/opensearch-project/opensearch-api-specification/pull/286 where I started running dredd against the spec. It fails with the following.

```
fail: headers: At '/content-type' No enum match for: "application/json; charset=utf-8"

expected: 
headers: 
    Content-Type: application/json

actual: 
statusCode: 200
headers: 
    content-type: application/json; charset=UTF-8
```

In this PR we match the charset correctly in the spec.

I *think* this is right, but I am not sure.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
