### PR TITLE
Parse command line arguments in merger and linter.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,7 @@ jobs:
         run: |-
           mkdir -p ../build
           npm install
-          export ROOT_PATH=../spec
-          export OUTPUT_PATH=../build/opensearch-openapi.yaml
-          npm run merge -- $ROOT_PATH $OUTPUT_PATH
+          npm run merge -- --source ../spec --output ../build/opensearch-openapi.yaml
 
       - name: Extract Branch Name
         id: branch

--- a/.github/workflows/coverage-gather.yml
+++ b/.github/workflows/coverage-gather.yml
@@ -19,9 +19,7 @@ jobs:
         run: |-
           mkdir -p ../build
           npm install
-          export ROOT_PATH=../spec
-          export OUTPUT_PATH=../build/opensearch-openapi.yaml
-          npm run merge -- $ROOT_PATH $OUTPUT_PATH
+          npm run merge -- --source ../spec --output ../build/opensearch-openapi.yaml
       - name: Build and Run Docker Container
         run: |
           docker build coverage --tag opensearch-with-api-plugin

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
           node-version: 20.10.0
       - run: npm install
       - run: |
-          npm run lint:spec -- ../spec
+          npm run lint:spec -- --source ../spec

--- a/_plugins/openapi.rb
+++ b/_plugins/openapi.rb
@@ -4,7 +4,7 @@ module OpenAPI
 
     Dir.chdir('tools') do
       system 'npm install'
-      system 'npm run merge -- ../spec ../_site/opensearch-openapi.yaml'
+      system 'npm run merge -- --source ../spec --output ../_site/opensearch-openapi.yaml'
     end
 
     @generated = true

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,34 +12,36 @@ This folder contains tools for the repo:
 
 ## Merger
 
-The merger tool merges the multi-file OpenSearch spec into a single file for programmatic use. It takes 2 parameters:
+The merger tool merges the multi-file OpenSearch spec into a single file for programmatic use. 
 
-- the path to the root folder of the multi-file spec
-- the path to the output file
+It requires a path to the root folder of the multi-file spec (`--source`) and a path to the output file (`--output`).
 
 Example:
 
 ```bash
 mkdir -p ../build
-export ROOT_PATH=../spec
-export OUTPUT_PATH=../build/opensearch-openapi.yaml
-npm run merge -- $ROOT_PATH $OUTPUT_PATH
+npm run merge -- --source ../spec --output ../build/opensearch-openapi.yaml
 ```
 
 As a shortcut, if those parameters are not provided, the tool will use the default values:
+
 - `../spec` as the root path (i.e. the repo's [spec folder](../spec))
-- `../opensearch-openapi.yaml` as the output path
+- `../build/opensearch-openapi.yaml` as the output path
 
 ```bash
 npm run merge
 ```
 
+Run `npm run merge -- --help` for all options.
+
 ## Spec Linter
 
-The linter tool validates the OpenSearch spec files in the `spec` folder:
+The linter tool validates the OpenSearch multi-file spec, and will print out all the errors and warnings in it.
+
+It requires a path to the root folder of the multi-file spec (`--source`).
 
 ```bash
-npm run lint:spec
+npm run lint:spec -- --source ../spec
 ```
 
-It will print out all the errors and warnings in the spec files.
+Run `npm run lint:spec -- --help` for all options.

--- a/tools/linter/lint.ts
+++ b/tools/linter/lint.ts
@@ -1,7 +1,16 @@
+import { Command, Option } from '@commander-js/extra-typings'
 import SpecValidator from './SpecValidator'
+import { resolve } from 'path'
 
-const root_folder = process.argv[2] ?? '../spec'
-const validator = new SpecValidator(root_folder)
+const command = new Command()
+  .description('Validate the OpenSearch multi-file spec.')
+  .addOption(new Option('-s, --source <path>', 'path to the root folder of the multi-file spec').default(resolve(__dirname, '../../spec')))
+  .allowExcessArguments(false)
+  .parse()
+
+const opts = command.opts()
+console.log(`Validating ${opts.source} ...`)
+const validator = new SpecValidator(opts.source)
 const errors = validator.validate()
 
 if (errors.length === 0) {

--- a/tools/merger/merge.ts
+++ b/tools/merger/merge.ts
@@ -1,6 +1,16 @@
+import { Command, Option } from '@commander-js/extra-typings'
 import OpenApiMerger from './OpenApiMerger'
+import { resolve } from 'path'
 
-const root_path: string = process.argv[2] || '../spec'
-const output_path: string = process.argv[3] || '../opensearch-openapi.yaml'
-const merger = new OpenApiMerger(root_path)
-merger.merge(output_path)
+const command = new Command()
+  .description('Merges the multi-file OpenSearch spec into a single file for programmatic use.')
+  .addOption(new Option('-s, --source <path>', 'path to the root folder of the multi-file spec').default(resolve(__dirname, '../../spec')))
+  .addOption(new Option('-o, --output <path>', 'output file name').default(resolve(__dirname, '../../build/opensearch-openapi.yaml')))
+  .allowExcessArguments(false)
+  .parse()
+
+const opts = command.opts()
+const merger = new OpenApiMerger(opts.source)
+console.log(`Merging ${opts.source} into ${opts.output} ...`)
+merger.merge(opts.output)
+console.log('Done.')

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -10,10 +10,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",
+        "@commander-js/extra-typings": "^12.0.1",
         "@types/lodash": "^4.14.202",
         "@types/node": "^20.10.3",
         "ajv": "^8.13.0",
         "ajv-formats": "^3.0.1",
+        "commander": "^12.0.0",
         "lodash": "^4.17.21",
         "ts-node": "^10.9.1",
         "typescript": "^5.4.5",
@@ -726,6 +728,14 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@commander-js/extra-typings": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-12.0.1.tgz",
+      "integrity": "sha512-OvkMobb1eMqOCuJdbuSin/KJkkZr7n24/UNV+Lcz/0Dhepf3r2p9PaGwpRpAWej7A+gQnny4h8mGhpFl4giKkg==",
+      "peerDependencies": {
+        "commander": "~12.0.0"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2454,6 +2464,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/tools/package.json
+++ b/tools/package.json
@@ -12,10 +12,12 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
+    "@commander-js/extra-typings": "^12.0.1",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.10.3",
     "ajv": "^8.13.0",
     "ajv-formats": "^3.0.1",
+    "commander": "^12.0.0",
     "lodash": "^4.17.21",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.5",


### PR DESCRIPTION
### Description

This PR turns the merger and linter into proper command line tools with argument parsing, which will let us add more switches and options, such as `--verbose` described in https://github.com/opensearch-project/opensearch-api-specification/issues/285 or `--with-examples-only` that I plan to add for #286 to generate a spec that only contains paths with examples. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
