### PR TITLE
Renaming parameters and adding command line tests.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ export default [
           allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false
         }
       ],
+      '@typescript-eslint/no-extraneous-class': 'off',
       'array-callback-return': 'off',
       'new-cap': 'off',
       'no-return-assign': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,7 +48,6 @@ export default [
           allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false
         }
       ],
-      '@typescript-eslint/no-extraneous-class': 'off',
       'array-callback-return': 'off',
       'new-cap': 'off',
       'no-return-assign': 'error',

--- a/tools/src/tester/Ansi.ts
+++ b/tools/src/tester/Ansi.ts
@@ -1,0 +1,14 @@
+export function b (text: string): string { return `\x1b[1m${text}\x1b[0m` }
+export function i (text: string): string { return `\x1b[3m${text}\x1b[0m` }
+
+export function padding (text: string, length: number, prefix: number = 0): string {
+  const spaces = length - text.length > 0 ? ' '.repeat(length - text.length) : ''
+  return `${' '.repeat(prefix)}${text}${spaces}`
+}
+
+export function green (text: string): string { return `\x1b[32m${text}\x1b[0m` }
+export function red (text: string): string { return `\x1b[31m${text}\x1b[0m` }
+export function yellow (text: string): string { return `\x1b[33m${text}\x1b[0m` }
+export function cyan (text: string): string { return `\x1b[36m${text}\x1b[0m` }
+export function gray (text: string): string { return `\x1b[90m${text}\x1b[0m` }
+export function magenta (text: string): string { return `\x1b[35m${text}\x1b[0m` }

--- a/tools/src/tester/ResultsDisplayer.ts
+++ b/tools/src/tester/ResultsDisplayer.ts
@@ -19,20 +19,20 @@ export class Ansi {
 }
 
 export interface DisplayOptions {
-  tab_size?: number
+  tab_width?: number
   verbose?: boolean
 }
 
 export default class ResultsDisplayer {
   evaluation: StoryEvaluation
   skip_components: boolean
-  tab_size: number
+  tab_width: number
   verbose: boolean
 
   constructor (evaluation: StoryEvaluation, opts: DisplayOptions) {
     this.evaluation = evaluation
     this.skip_components = [Result.PASSED, Result.SKIPPED].includes(evaluation.result)
-    this.tab_size = opts.tab_size ?? 4
+    this.tab_width = opts.tab_width ?? 4
     this.verbose = opts.verbose ?? false
   }
 
@@ -54,13 +54,13 @@ export default class ResultsDisplayer {
   #display_chapters (evaluations: ChapterEvaluation[], title: string): void {
     if (this.skip_components || evaluations.length === 0) return
     const result = overall_result(evaluations.map(e => e.overall))
-    this.#display_evaluation({ result }, title, this.tab_size)
+    this.#display_evaluation({ result }, title, this.tab_width)
     if (result === Result.PASSED) return
     for (const evaluation of evaluations) this.#display_chapter(evaluation)
   }
 
   #display_chapter (chapter: ChapterEvaluation): void {
-    this.#display_evaluation(chapter.overall, Ansi.i(chapter.title), this.tab_size * 2)
+    this.#display_evaluation(chapter.overall, Ansi.i(chapter.title), this.tab_width * 2)
     if (chapter.overall.result === Result.PASSED || chapter.overall.result === Result.SKIPPED) return
 
     this.#display_parameters(chapter.request?.parameters ?? {})
@@ -72,26 +72,26 @@ export default class ResultsDisplayer {
   #display_parameters (parameters: Record<string, Evaluation>): void {
     if (Object.keys(parameters).length === 0) return
     const result = overall_result(Object.values(parameters))
-    this.#display_evaluation({ result }, 'PARAMETERS', this.tab_size * 3)
+    this.#display_evaluation({ result }, 'PARAMETERS', this.tab_width * 3)
     if (result === Result.PASSED) return
     for (const [name, evaluation] of Object.entries(parameters)) {
-      this.#display_evaluation(evaluation, name, this.tab_size * 4)
+      this.#display_evaluation(evaluation, name, this.tab_width * 4)
     }
   }
 
   #display_request_body (evaluation: Evaluation | undefined): void {
     if (evaluation == null) return
-    this.#display_evaluation(evaluation, 'REQUEST BODY', this.tab_size * 3)
+    this.#display_evaluation(evaluation, 'REQUEST BODY', this.tab_width * 3)
   }
 
   #display_status (evaluation: Evaluation | undefined): void {
     if (evaluation == null) return
-    this.#display_evaluation(evaluation, 'RESPONSE STATUS', this.tab_size * 3)
+    this.#display_evaluation(evaluation, 'RESPONSE STATUS', this.tab_width * 3)
   }
 
   #display_payload (evaluation: Evaluation | undefined): void {
     if (evaluation == null) return
-    this.#display_evaluation(evaluation, 'RESPONSE PAYLOAD', this.tab_size * 3)
+    this.#display_evaluation(evaluation, 'RESPONSE PAYLOAD', this.tab_width * 3)
   }
 
   #display_evaluation (evaluation: Evaluation, title: string, prefix: number = 0): void {

--- a/tools/src/tester/ResultsDisplayer.ts
+++ b/tools/src/tester/ResultsDisplayer.ts
@@ -1,22 +1,6 @@
 import { type ChapterEvaluation, type Evaluation, Result, type StoryEvaluation } from './types/eval.types'
 import { overall_result } from './helpers'
-
-export class Ansi {
-  static b (text: string): string { return `\x1b[1m${text}\x1b[0m` }
-  static i (text: string): string { return `\x1b[3m${text}\x1b[0m` }
-
-  static padding (text: string, length: number, prefix: number = 0): string {
-    const spaces = length - text.length > 0 ? ' '.repeat(length - text.length) : ''
-    return `${' '.repeat(prefix)}${text}${spaces}`
-  }
-
-  static green (text: string): string { return `\x1b[32m${text}\x1b[0m` }
-  static red (text: string): string { return `\x1b[31m${text}\x1b[0m` }
-  static yellow (text: string): string { return `\x1b[33m${text}\x1b[0m` }
-  static cyan (text: string): string { return `\x1b[36m${text}\x1b[0m` }
-  static gray (text: string): string { return `\x1b[90m${text}\x1b[0m` }
-  static magenta (text: string): string { return `\x1b[35m${text}\x1b[0m` }
-}
+import * as ansi from './Ansi'
 
 export interface DisplayOptions {
   tab_width?: number
@@ -47,7 +31,7 @@ export default class ResultsDisplayer {
   #display_story (): void {
     const result = this.evaluation.result
     const message = this.evaluation.full_path
-    const title = Ansi.cyan(Ansi.b(this.evaluation.display_path))
+    const title = ansi.cyan(ansi.b(this.evaluation.display_path))
     this.#display_evaluation({ result, message }, title)
   }
 
@@ -60,7 +44,7 @@ export default class ResultsDisplayer {
   }
 
   #display_chapter (chapter: ChapterEvaluation): void {
-    this.#display_evaluation(chapter.overall, Ansi.i(chapter.title), this.tab_width * 2)
+    this.#display_evaluation(chapter.overall, ansi.i(chapter.title), this.tab_width * 2)
     if (chapter.overall.result === Result.PASSED || chapter.overall.result === Result.SKIPPED) return
 
     this.#display_parameters(chapter.request?.parameters ?? {})
@@ -95,8 +79,8 @@ export default class ResultsDisplayer {
   }
 
   #display_evaluation (evaluation: Evaluation, title: string, prefix: number = 0): void {
-    const result = Ansi.padding(this.#result(evaluation.result), 0, prefix)
-    const message = evaluation.message != null ? `${Ansi.gray('(' + evaluation.message + ')')}` : ''
+    const result = ansi.padding(this.#result(evaluation.result), 0, prefix)
+    const message = evaluation.message != null ? `${ansi.gray('(' + evaluation.message + ')')}` : ''
     console.log(`${result} ${title} ${message}`)
     if (evaluation.error && this.verbose) {
       console.log('-'.repeat(100))
@@ -106,13 +90,13 @@ export default class ResultsDisplayer {
   }
 
   #result (r: Result): string {
-    const text = Ansi.padding(r, 7)
+    const text = ansi.padding(r, 7)
     switch (r) {
-      case Result.PASSED: return Ansi.green(text)
-      case Result.SKIPPED: return Ansi.yellow(text)
-      case Result.FAILED: return Ansi.magenta(text)
-      case Result.ERROR: return Ansi.red(text)
-      default: return Ansi.gray(text)
+      case Result.PASSED: return ansi.green(text)
+      case Result.SKIPPED: return ansi.yellow(text)
+      case Result.FAILED: return ansi.magenta(text)
+      case Result.ERROR: return ansi.red(text)
+      default: return ansi.gray(text)
     }
   }
 }

--- a/tools/src/tester/ResultsDisplayer.ts
+++ b/tools/src/tester/ResultsDisplayer.ts
@@ -1,20 +1,22 @@
 import { type ChapterEvaluation, type Evaluation, Result, type StoryEvaluation } from './types/eval.types'
 import { overall_result } from './helpers'
 
-function b (text: string): string { return `\x1b[1m${text}\x1b[0m` }
-function i (text: string): string { return `\x1b[3m${text}\x1b[0m` }
+export class Ansi {
+  static b (text: string): string { return `\x1b[1m${text}\x1b[0m` }
+  static i (text: string): string { return `\x1b[3m${text}\x1b[0m` }
 
-function padding (text: string, length: number, prefix: number = 0): string {
-  const spaces = length - text.length > 0 ? ' '.repeat(length - text.length) : ''
-  return `${' '.repeat(prefix)}${text}${spaces}`
+  static padding (text: string, length: number, prefix: number = 0): string {
+    const spaces = length - text.length > 0 ? ' '.repeat(length - text.length) : ''
+    return `${' '.repeat(prefix)}${text}${spaces}`
+  }
+
+  static green (text: string): string { return `\x1b[32m${text}\x1b[0m` }
+  static red (text: string): string { return `\x1b[31m${text}\x1b[0m` }
+  static yellow (text: string): string { return `\x1b[33m${text}\x1b[0m` }
+  static cyan (text: string): string { return `\x1b[36m${text}\x1b[0m` }
+  static gray (text: string): string { return `\x1b[90m${text}\x1b[0m` }
+  static magenta (text: string): string { return `\x1b[35m${text}\x1b[0m` }
 }
-
-function green (text: string): string { return `\x1b[32m${text}\x1b[0m` }
-function red (text: string): string { return `\x1b[31m${text}\x1b[0m` }
-function yellow (text: string): string { return `\x1b[33m${text}\x1b[0m` }
-function cyan (text: string): string { return `\x1b[36m${text}\x1b[0m` }
-function gray (text: string): string { return `\x1b[90m${text}\x1b[0m` }
-function magenta (text: string): string { return `\x1b[35m${text}\x1b[0m` }
 
 export interface DisplayOptions {
   tab_size?: number
@@ -45,7 +47,7 @@ export default class ResultsDisplayer {
   #display_story (): void {
     const result = this.evaluation.result
     const message = this.evaluation.full_path
-    const title = cyan(b(this.evaluation.display_path))
+    const title = Ansi.cyan(Ansi.b(this.evaluation.display_path))
     this.#display_evaluation({ result, message }, title)
   }
 
@@ -58,7 +60,7 @@ export default class ResultsDisplayer {
   }
 
   #display_chapter (chapter: ChapterEvaluation): void {
-    this.#display_evaluation(chapter.overall, i(chapter.title), this.tab_size * 2)
+    this.#display_evaluation(chapter.overall, Ansi.i(chapter.title), this.tab_size * 2)
     if (chapter.overall.result === Result.PASSED || chapter.overall.result === Result.SKIPPED) return
 
     this.#display_parameters(chapter.request?.parameters ?? {})
@@ -93,8 +95,8 @@ export default class ResultsDisplayer {
   }
 
   #display_evaluation (evaluation: Evaluation, title: string, prefix: number = 0): void {
-    const result = padding(this.#result(evaluation.result), 0, prefix)
-    const message = evaluation.message != null ? `${gray('(' + evaluation.message + ')')}` : ''
+    const result = Ansi.padding(this.#result(evaluation.result), 0, prefix)
+    const message = evaluation.message != null ? `${Ansi.gray('(' + evaluation.message + ')')}` : ''
     console.log(`${result} ${title} ${message}`)
     if (evaluation.error && this.verbose) {
       console.log('-'.repeat(100))
@@ -104,13 +106,13 @@ export default class ResultsDisplayer {
   }
 
   #result (r: Result): string {
-    const text = padding(r, 7)
+    const text = Ansi.padding(r, 7)
     switch (r) {
-      case Result.PASSED: return green(text)
-      case Result.SKIPPED: return yellow(text)
-      case Result.FAILED: return magenta(text)
-      case Result.ERROR: return red(text)
-      default: return gray(text)
+      case Result.PASSED: return Ansi.green(text)
+      case Result.SKIPPED: return Ansi.yellow(text)
+      case Result.FAILED: return Ansi.magenta(text)
+      case Result.ERROR: return Ansi.red(text)
+      default: return Ansi.gray(text)
     }
   }
 }

--- a/tools/src/tester/start.ts
+++ b/tools/src/tester/start.ts
@@ -6,9 +6,9 @@ import _ from 'lodash'
 
 const command = new Command()
   .description('Run test stories against the OpenSearch spec.')
-  .addOption(new Option('--spec, --spec_path <path>', 'path to the root folder of the multi-file spec').default('./spec'))
-  .addOption(new Option('--tests, --tests_path <path>', 'path to the root folder of the tests').default('./tests'))
-  .addOption(new Option('--tab_size <size>', 'tab size for displayed results').default('4'))
+  .addOption(new Option('--spec, --spec-path <path>', 'path to the root folder of the multi-file spec').default('./spec'))
+  .addOption(new Option('--tests, --tests-path <path>', 'path to the root folder of the tests').default('./tests'))
+  .addOption(new Option('--tab-size <size>', 'tab size for displayed results').default('4'))
   .addOption(new Option('--verbose', 'whether to print the full stack trace of errors'))
   .allowExcessArguments(false)
   .parse()
@@ -16,8 +16,8 @@ const command = new Command()
 const opts = command.opts()
 const display_options = {
   verbose: opts.verbose ?? false,
-  tab_size: Number.parseInt(opts.tab_size)
+  tab_size: Number.parseInt(opts.tabSize)
 }
-const spec = (new OpenApiMerger(opts.spec_path, LogLevel.error)).merge()
-const runner = new TestsRunner(spec, opts.tests_path, display_options)
+const spec = (new OpenApiMerger(opts.specPath, LogLevel.error)).merge()
+const runner = new TestsRunner(spec, opts.testsPath, display_options)
 void runner.run().then(() => { _.noop() })

--- a/tools/src/tester/start.ts
+++ b/tools/src/tester/start.ts
@@ -8,7 +8,7 @@ const command = new Command()
   .description('Run test stories against the OpenSearch spec.')
   .addOption(new Option('--spec, --spec-path <path>', 'path to the root folder of the multi-file spec').default('./spec'))
   .addOption(new Option('--tests, --tests-path <path>', 'path to the root folder of the tests').default('./tests'))
-  .addOption(new Option('--tab-size <size>', 'tab size for displayed results').default('4'))
+  .addOption(new Option('--tab-width <size>', 'tab width for displayed results').default('4'))
   .addOption(new Option('--verbose', 'whether to print the full stack trace of errors'))
   .allowExcessArguments(false)
   .parse()
@@ -16,7 +16,7 @@ const command = new Command()
 const opts = command.opts()
 const display_options = {
   verbose: opts.verbose ?? false,
-  tab_size: Number.parseInt(opts.tabSize)
+  tab_width: Number.parseInt(opts.tabWidth)
 }
 const spec = (new OpenApiMerger(opts.specPath, LogLevel.error)).merge()
 const runner = new TestsRunner(spec, opts.testsPath, display_options)

--- a/tools/tests/tester/ansi.test.ts
+++ b/tools/tests/tester/ansi.test.ts
@@ -1,0 +1,17 @@
+import * as ansi from '../../src/tester/Ansi'
+
+test('b', async () => {
+  expect(ansi.b('xyz')).toEqual('\x1b[1mxyz\x1b[0m')
+})
+
+test('i', async () => {
+  expect(ansi.i('xyz')).toEqual('\x1b[3mxyz\x1b[0m')
+})
+
+test.todo('padding')
+test.todo('green')
+test.todo('red')
+test.todo('yellow')
+test.todo('cyan')
+test.todo('gray')
+test.todo('magenta')

--- a/tools/tests/tester/fixtures/empty.yaml
+++ b/tools/tests/tester/fixtures/empty.yaml
@@ -1,0 +1,3 @@
+$schema: ../json_schemas/test_story.schema.yaml
+
+chapters: []

--- a/tools/tests/tester/start.test.ts
+++ b/tools/tests/tester/start.test.ts
@@ -25,6 +25,6 @@ test('--tests', async () => {
   )
 })
 
-test.todo('--tab-size')
+test.todo('--tab-width')
 test.todo('--verbose')
 test.todo('--spec')

--- a/tools/tests/tester/start.test.ts
+++ b/tools/tests/tester/start.test.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from 'child_process'
+import { Ansi } from '../../src/tester/ResultsDisplayer'
+
+const spec = (args: string[]): any => {
+  const start = spawnSync('ts-node', ['tools/src/tester/start.ts'].concat(args), {
+    env: { ...process.env, OPENSEARCH_PASSWORD: 'password' }
+  })
+  return {
+    stdout: start.stdout?.toString(),
+    stderr: start.stderr?.toString()
+  }
+}
+
+test('--help', async () => {
+  expect(spec(['--help']).stdout).toContain('Usage: start [options]')
+})
+
+test('--invalid', async () => {
+  expect(spec(['--invalid']).stderr).toContain("error: unknown option '--invalid'")
+})
+
+test('--tests', async () => {
+  expect(spec(['--tests', 'tools/tests/tester/fixtures']).stdout).toContain(
+    `${Ansi.green('PASSED ')} ${Ansi.cyan(Ansi.b('empty.yaml'))}`
+  )
+})
+
+test.todo('--tab-size')
+test.todo('--verbose')
+test.todo('--spec')

--- a/tools/tests/tester/start.test.ts
+++ b/tools/tests/tester/start.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process'
-import { Ansi } from '../../src/tester/ResultsDisplayer'
+import * as ansi from '../../src/tester/Ansi'
 
 const spec = (args: string[]): any => {
   const start = spawnSync('ts-node', ['tools/src/tester/start.ts'].concat(args), {
@@ -21,7 +21,7 @@ test('--invalid', async () => {
 
 test('--tests', async () => {
   expect(spec(['--tests', 'tools/tests/tester/fixtures']).stdout).toContain(
-    `${Ansi.green('PASSED ')} ${Ansi.cyan(Ansi.b('empty.yaml'))}`
+    `${ansi.green('PASSED ')} ${ansi.cyan(ansi.b('empty.yaml'))}`
   )
 })
 


### PR DESCRIPTION
### Description

1. Renames `parameters_like_this` to `parameters-like-this` (from @Xtansia's comment in #299) .
2. Renamed tab size to tab width.
3. Adds tests for some of the command line parameters (the others are harder).
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
