### PR TITLE
Added --dry-run and merged --verbose.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added link checking ([#269](https://github.com/opensearch-project/opensearch-api-specification/pull/269))
 - Added API coverage ([#210](https://github.com/opensearch-project/opensearch-api-specification/pull/210))
 - Added license headers to TypeScript code ([#311](https://github.com/opensearch-project/opensearch-api-specification/pull/311))
-  
+- Added `npm run test:spec -- --dry-run --verbose` ([#303](https://github.com/opensearch-project/opensearch-api-specification/pull/303))
+
 ### Changed
 
 - Replaced Smithy with a native OpenAPI spec ([#189](https://github.com/opensearch-project/opensearch-api-specification/issues/189))

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -380,6 +380,11 @@ All tools should have tests added in [tools/tests](tools/tests), tests are imple
 npm run test
 ```
 
+Specify the test path to run tests for one of the tools:
+```bash
+npm run test -- tools/tests/tester/
+```
+
 #### Lints
 
 All code is linted using [ESLint](https://eslint.org/) in combination with [typescript-eslint](https://typescript-eslint.io/). Linting can be run via:

--- a/tools/src/tester/TestsRunner.ts
+++ b/tools/src/tester/TestsRunner.ts
@@ -16,11 +16,11 @@ import fs from 'fs'
 import { type Story } from './types/story.types'
 import { read_yaml } from '../../helpers'
 import { Result, type StoryEvaluation } from './types/eval.types'
-import ResultsDisplayer, { type DisplayOptions } from './ResultsDisplayer'
+import ResultsDisplayer, { type TestRunOptions, type DisplayOptions } from './ResultsDisplayer'
 import SharedResources from './SharedResources'
 import { resolve, basename } from 'path'
 
-type TestsRunnerOptions = DisplayOptions & Record<string, any>
+type TestsRunnerOptions = TestRunOptions & DisplayOptions & Record<string, any>
 
 export default class TestsRunner {
   path: string // Path to a story file or a directory containing story files
@@ -41,7 +41,7 @@ export default class TestsRunner {
     const story_files = this.#collect_story_files(this.path, '', '')
     const evaluations: StoryEvaluation[] = []
     for (const story_file of this.#sort_story_files(story_files)) {
-      const evaluator = new StoryEvaluator(story_file)
+      const evaluator = new StoryEvaluator(story_file, this.opts.dry_run)
       const evaluation = await evaluator.evaluate()
       const displayer = new ResultsDisplayer(evaluation, this.opts)
       if (debug) evaluations.push(evaluation)

--- a/tools/src/tester/start.ts
+++ b/tools/src/tester/start.ts
@@ -19,17 +19,19 @@ const command = new Command()
   .addOption(new Option('--tests, --tests-path <path>', 'path to the root folder of the tests').default('./tests'))
   .addOption(new Option('--tab-width <size>', 'tab width for displayed results').default('4'))
   .addOption(new Option('--verbose', 'whether to print the full stack trace of errors'))
+  .addOption(new Option('--dry-run', 'dry run only, do not make HTTP requests'))
   .allowExcessArguments(false)
   .parse()
 
 const opts = command.opts()
-const display_options = {
+const options = {
   verbose: opts.verbose ?? false,
-  tab_width: Number.parseInt(opts.tabWidth)
+  tab_width: Number.parseInt(opts.tabWidth),
+  dry_run: opts.dryRun ?? false
 }
 
 // The fallback password must match the default password specified in .github/opensearch-cluster/docker-compose.yml
 process.env.OPENSEARCH_PASSWORD = process.env.OPENSEARCH_PASSWORD ?? 'myStrongPassword123!'
 const spec = (new OpenApiMerger(opts.specPath, LogLevel.error)).merge()
-const runner = new TestsRunner(spec, opts.testsPath, display_options)
+const runner = new TestsRunner(spec, opts.testsPath, options)
 void runner.run().then(() => { _.noop() })

--- a/tools/tests/tester/fixtures/empty_with_all_the_parts.yaml
+++ b/tools/tests/tester/fixtures/empty_with_all_the_parts.yaml
@@ -1,0 +1,46 @@
+$schema: ../json_schemas/test_story.schema.yaml
+
+skip: false
+
+description: A story with all its parts.
+
+prologues:
+  - path: /things
+    method: DELETE
+    status: [200, 404]
+
+epilogues: 
+  - path: /things/one
+    method: DELETE
+    status: [200, 404]
+
+chapters:
+  - synopsis: A PUT method.
+    path: /{index}
+    method: PUT
+    parameters:
+      index: one
+
+  - synopsis: A HEAD method.
+    path: /{index}
+    method: HEAD
+    parameters:
+      index: one
+
+  - synopsis: A GET method.
+    path: /{index}
+    method: GET
+    parameters:
+      index: one
+
+  - synopsis: A POST method.
+    path: /{index}/_doc
+    method: POST
+    parameters:
+      index: one
+
+  - synopsis: A DELETE method.
+    path: /{index}
+    method: DELETE
+    parameters:
+      index: one

--- a/tools/tests/tester/fixtures/empty_with_description.yaml
+++ b/tools/tests/tester/fixtures/empty_with_description.yaml
@@ -1,0 +1,5 @@
+$schema: ../json_schemas/test_story.schema.yaml
+
+description: A story with no beginning or end.
+
+chapters: []

--- a/tools/tests/tester/start.test.ts
+++ b/tools/tests/tester/start.test.ts
@@ -9,6 +9,7 @@
 
 import { spawnSync } from 'child_process'
 import * as ansi from '../../src/tester/Ansi'
+import * as path from 'path'
 
 const spec = (args: string[]): any => {
   const start = spawnSync('ts-node', ['tools/src/tester/start.ts'].concat(args), {
@@ -28,12 +29,34 @@ test('--invalid', async () => {
   expect(spec(['--invalid']).stderr).toContain("error: unknown option '--invalid'")
 })
 
-test('--tests', async () => {
+test('displays story filename', async () => {
   expect(spec(['--tests', 'tools/tests/tester/fixtures/empty_story']).stdout).toContain(
     `${ansi.green('PASSED ')} ${ansi.cyan(ansi.b('empty.yaml'))}`
   )
 })
 
+test('displays story description', async () => {
+  expect(spec(['--tests', 'tools/tests/tester/fixtures/empty_with_description.yaml']).stdout).toContain(
+    `${ansi.green('PASSED ')} ${ansi.cyan(ansi.b('A story with no beginning or end.'))}`
+  )
+})
+
 test.todo('--tab-width')
-test.todo('--verbose')
+
+test('--dry-run', async () => {
+  const test_yaml = 'tools/tests/tester/fixtures/empty_with_all_the_parts.yaml'
+  const s = spec(['--dry-run', '--tests', test_yaml]).stdout
+  const full_path = path.join(__dirname, '../../../' + test_yaml)
+  expect(s).toEqual(`${ansi.yellow('SKIPPED')} ${ansi.cyan(ansi.b('A story with all its parts.'))} ${ansi.gray('(' + full_path + ')')}\n\n\n`)
+})
+
+test('--dry-run --verbose', async () => {
+  const s = spec(['--dry-run', '--verbose', '--tests', 'tools/tests/tester/fixtures/empty_with_all_the_parts.yaml']).stdout
+  expect(s).toContain(`${ansi.yellow('SKIPPED')} ${ansi.cyan(ansi.b('A story with all its parts.'))}`)
+  expect(s).toContain(`${ansi.yellow('SKIPPED')} CHAPTERS`)
+  expect(s).toContain(`${ansi.yellow('SKIPPED')} EPILOGUES`)
+  expect(s).toContain(`${ansi.yellow('SKIPPED')} PROLOGUES`)
+  expect(s).toContain(`${ansi.yellow('SKIPPED')} ${ansi.i('A PUT method.')} ${ansi.gray('(Dry Run)')}`)
+})
+
 test.todo('--spec')


### PR DESCRIPTION
### Description

#### Expanded the meaning of `--verbose`.

By default the test runner only outputs the story line.

```
$ npm run test:spec

PASSED  This story tests all endpoints relevant to the lifecycle of an index, from creation to deletion. (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tests/index_lifecycle.yaml)
```

With `--verbose` you now get the full detail in addition to the old behavior of dumping the HTTP responses. This makes `skip_components` unnecessary.

```
$ npm run test:spec -- --verbose

PASSED  This story tests all endpoints relevant to the lifecycle of an index, from creation to deletion. (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tests/index_lifecycle.yaml)
    PASSED  CHAPTERS 
        PASSED  Create an index named `books` with mappings and settings. 
            PASSED  PARAMETERS 
                PASSED  index 
            PASSED  REQUEST BODY 
            PASSED  RESPONSE STATUS 
            PASSED  RESPONSE PAYLOAD 
  ....
```

#### Added --dry-run

Added `--dry-run` that evaluates chapters but skips execution. This is particularly useful for tests.

```
$ npm run test:spec -- --dry-run

SKIPPED This story tests all endpoints relevant to the lifecycle of an index, from creation to deletion. (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tests/index_lifecycle.yaml)
```

Or to see everything that would be run.

```
$ npm run test:spec -- --dry-run --verbose

SKIPPED This story tests all endpoints relevant to the lifecycle of an index, from creation to deletion. (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tests/index_lifecycle.yaml)
    SKIPPED CHAPTERS 
        SKIPPED Create an index named `books` with mappings and settings. (Dry Run)
        SKIPPED Create an index named `games` with default settings, (Dry Run)
        SKIPPED Check if the index `books` exists. It should. (Dry Run)
        SKIPPED Check if the index `movies` exists. It should not. (Dry Run)
        SKIPPED Retrieve the mappings and settings of the `books` and `games` indices. (Dry Run)
        SKIPPED Close the `books` index. (Dry Run)
        SKIPPED Open the `books` index. (Dry Run)
        SKIPPED Delete the `books` and `games` indices. (Dry Run)
    SKIPPED EPILOGUES 
        SKIPPED DELETE /books (Dry Run)
        SKIPPED DELETE /games (Dry Run)

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
