### PR TITLE
Add text embedding processor

### DIFF
--- a/spec/schemas/ingest._common.yaml
+++ b/spec/schemas/ingest._common.yaml
@@ -101,6 +101,8 @@ components:
           $ref: '#/components/schemas/CircleProcessor'
         inference:
           $ref: '#/components/schemas/InferenceProcessor'
+        text_embedding:
+          $ref: '#/components/schemas/TextEmbeddingProcessor'
       minProperties: 1
       maxProperties: 1
     AttachmentProcessor:
@@ -870,3 +872,22 @@ components:
             Specifies the type of the predicted field to write.
             Valid values are: `string`, `number`, `boolean`.
           type: string
+    TextEmbeddingProcessor:
+      allOf:
+        - $ref: '#/components/schemas/ProcessorBase'
+        - type: object
+          properties:
+            model_id:
+              $ref: '_common.yaml#/components/schemas/Id'
+            field_map:
+              description: |-
+                Contains key-value pairs that specify the mapping of a text field to a vector field.
+              type: object
+              additionalProperties:
+                type: string
+            description:
+              type: string
+              description: A brief description of the processor.
+          required:
+            - model_id
+            - field_map

--- a/spec/schemas/ingest._common.yaml
+++ b/spec/schemas/ingest._common.yaml
@@ -28,8 +28,6 @@ components:
           $ref: '_common.yaml#/components/schemas/VersionNumber'
         _meta:
           $ref: '_common.yaml#/components/schemas/Metadata'
-      required:
-        - _meta
     ProcessorContainer:
       type: object
       properties:

--- a/tests/text_embedding_processor.yaml
+++ b/tests/text_embedding_processor.yaml
@@ -1,0 +1,32 @@
+$schema: ../json_schemas/test_story.schema.yaml
+
+skip: false
+description: This story tests that you can create 
+epilogues:
+  - path: /_ingest/pipeline/books_pipeline
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create ingest pipeline for text embedding
+    path: /_ingest/pipeline/{id}
+    method: PUT
+    parameters:
+      id: books_pipeline
+    request_body:
+      payload:
+        description: "Extracts text from field and embeds it"
+        processors:
+          - text_embedding:
+              model_id: "text-embedding-model"
+              field_map:
+                text: "passage_embedding"
+    response:
+      status: 200
+  - synopsis: Query created pipeline
+    path: /_ingest/pipeline/{id}
+    method: GET
+    parameters:
+      id: books_pipeline
+    response:
+      status: 200
+      

--- a/tests/text_embedding_processor.yaml
+++ b/tests/text_embedding_processor.yaml
@@ -1,7 +1,9 @@
 $schema: ../json_schemas/test_story.schema.yaml
 
 skip: false
-description: This story tests that you can create 
+description: |
+  This test story checks that we can create an ingest pipeline with a text 
+  embedding processor
 epilogues:
   - path: /_ingest/pipeline/books_pipeline
     method: DELETE
@@ -22,6 +24,8 @@ chapters:
                 text: "passage_embedding"
     response:
       status: 200
+      payload:
+        acknowledged: true
   - synopsis: Query created pipeline
     path: /_ingest/pipeline/{id}
     method: GET
@@ -29,4 +33,3 @@ chapters:
       id: books_pipeline
     response:
       status: 200
-      


### PR DESCRIPTION
Signed-off-by: miguel-vila <miguelvilag@gmail.com>

### Description
Adds a definition for the text embedding processor: https://opensearch.org/docs/latest/ingest-pipelines/processors/text-embedding/

Please confirm whether the `field_map` definition makes sense

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
