### PR TITLE
Test GET /, server info.

### DIFF
--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -1810,7 +1810,6 @@ components:
           type: string
       required:
         - build_date
-        - build_flavor
         - build_hash
         - build_snapshot
         - build_type

--- a/tests/index.yaml
+++ b/tests/index.yaml
@@ -1,7 +1,7 @@
 $schema: ../json_schemas/test_story.schema.yaml
 
 skip: false
-description: This story tests all endpoints relevant the lifecycle of an index, from creation to deletion.
+description: Test endpoints relevant the lifecycle of an index, from creation to deletion.
 epilogues:
   - path: /books
     method: DELETE

--- a/tests/info.yaml
+++ b/tests/info.yaml
@@ -1,0 +1,18 @@
+
+$schema: ../json_schemas/test_story.schema.yaml
+
+skip: false
+description: Test root endpoint.
+chapters:
+  - synopsis: Get server info.
+    path: /
+    method: GET
+    response:
+      status: 200
+  - synopsis: Get server info (pretty=false).
+    path: /
+    method: GET
+    parameters:
+      pretty: false
+    response:
+      status: 200


### PR DESCRIPTION
### Description

- Adds tests for `GET /`.
- Makes `build_flavor` optional. It was deprecated during the fork and removed in 2.x AFAIK. The added test trips on this. Yay tests.
- Renames `index_lifecycle` to `index`, I think we should stick to naming that closely matches the API.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
