### PR TITLE
Added CHANGELOG.

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,17 @@
+name: Verify Changelog
+on:
+  pull_request:
+    types: [opened, edited, review_requested, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  verify-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: "autocut, skip-changelog"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# CHANGELOG
+
+Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [Unreleased]
+
+### Added
+
+- Added CHANGELOG ([#309](https://github.com/opensearch-project/opensearch-api-specification/pull/309))
+- Added a spec test framework ([#299](https://github.com/opensearch-project/opensearch-api-specification/pull/299))
+- Added workflow to determine API changes ([#297](https://github.com/opensearch-project/opensearch-api-specification/pull/297))
+- Added link checking ([#269](https://github.com/opensearch-project/opensearch-api-specification/pull/269))
+- Added API coverage ([#210](https://github.com/opensearch-project/opensearch-api-specification/pull/210))
+  
+### Changed
+
+- Replaced Smithy with a native OpenAPI spec ([#189](https://github.com/opensearch-project/opensearch-api-specification/issues/189))
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Fixed GitHub pages ([#215](https://github.com/opensearch-project/opensearch-api-specification/pull/215))
+
+### Security
+
+[Unreleased]: https://github.com/opensearch-project/opensearch-api-specification/commits/main/


### PR DESCRIPTION
### Description

Adds a CHANGELOG and a workflow to ensure CHANGELOG is updated with every PR. Can be skipped with `skip-changelog` label (created).

### Issues Resolved

Closes #261.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
