### PR TITLE
Added license headers to TypeScript files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added workflow to determine API changes ([#297](https://github.com/opensearch-project/opensearch-api-specification/pull/297))
 - Added link checking ([#269](https://github.com/opensearch-project/opensearch-api-specification/pull/269))
 - Added API coverage ([#210](https://github.com/opensearch-project/opensearch-api-specification/pull/210))
+- Added license headers to TypeScript code ([#311](https://github.com/opensearch-project/opensearch-api-specification/pull/311))
   
 ### Changed
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { FlatCompat } from '@eslint/eslintrc'
 import pluginJs from '@eslint/js'
+import licenseHeader from 'eslint-plugin-license-header'
 
 // mimic CommonJS variables -- not needed if using CommonJS
 const _filename = fileURLToPath(import.meta.url)
@@ -13,6 +14,9 @@ export default [
   ...compat.extends('standard-with-typescript'),
   {
     files: ['**/*.{js,ts}'],
+    plugins: {
+      'license-header': licenseHeader
+    },
     rules: {
       '@typescript-eslint/consistent-indexed-object-style': 'error',
       '@typescript-eslint/consistent-type-assertions': 'error',
@@ -51,7 +55,20 @@ export default [
       'array-callback-return': 'off',
       'new-cap': 'off',
       'no-return-assign': 'error',
-      'object-shorthand': 'error'
+      'object-shorthand': 'error',
+      'license-header/header': [
+        'error',
+        [
+          '/*',
+          '* Copyright OpenSearch Contributors',
+          '* SPDX-License-Identifier: Apache-2.0',
+          '*',
+          '* The OpenSearch Contributors require contributions made to',
+          '* this file be licensed under the Apache-2.0 license or a',
+          '* compatible open source license.',
+          '*/'
+        ]
+      ]
     }
   }
 ]

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint": "^8.57.0",
         "eslint-config-standard-with-typescript": "^43.0.1",
         "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-license-header": "^0.6.1",
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
         "globals": "^15.0.0",
@@ -3403,6 +3404,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-license-header": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-license-header/-/eslint-plugin-license-header-0.6.1.tgz",
+      "integrity": "sha512-9aIz8q3OaMr1/uQmCGCWySjTs5nEXUJexNegz/8lluNcZbEl82Ag1Vyr1Hu3oIveRW1NbXDPs6nu4zu9mbrmWA==",
+      "dev": true,
+      "dependencies": {
+        "requireindex": "^1.2.0"
+      }
+    },
     "node_modules/eslint-plugin-n": {
       "version": "16.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.6.2.tgz",
@@ -6589,6 +6599,15 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint": "^8.57.0",
     "eslint-config-standard-with-typescript": "^43.0.1",
     "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-license-header": "^0.6.1",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
     "globals": "^15.0.0",

--- a/tools/helpers.ts
+++ b/tools/helpers.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import fs from 'fs'
 import path from 'path'
 import YAML from 'yaml'

--- a/tools/src/Logger.ts
+++ b/tools/src/Logger.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 export enum LogLevel {
   error = 1,
   warn = 2,

--- a/tools/src/coverage/CoverageCalculator.ts
+++ b/tools/src/coverage/CoverageCalculator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OpenAPIV3 } from 'openapi-types'
 import { HTTP_METHODS, read_yaml, write_json } from '../../helpers'
 

--- a/tools/src/coverage/coverage.ts
+++ b/tools/src/coverage/coverage.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { Command, Option } from '@commander-js/extra-typings'
 import CoverageCalculator from './CoverageCalculator'
 import { resolve } from 'path'

--- a/tools/src/dump-cluster-spec/dump-cluster-spec.ts
+++ b/tools/src/dump-cluster-spec/dump-cluster-spec.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { Command, Option } from '@commander-js/extra-typings'
 import { resolve } from 'path'
 import axios from 'axios'

--- a/tools/src/linter/InlineObjectSchemaValidator.ts
+++ b/tools/src/linter/InlineObjectSchemaValidator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import type NamespacesFolder from './components/NamespacesFolder'
 import type SchemasFolder from './components/SchemasFolder'
 import { type ValidationError } from 'types'

--- a/tools/src/linter/SchemaRefsValidator.ts
+++ b/tools/src/linter/SchemaRefsValidator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import type NamespacesFolder from './components/NamespacesFolder'
 import type SchemasFolder from './components/SchemasFolder'
 import { type ValidationError } from 'types'

--- a/tools/src/linter/SchemasValidator.ts
+++ b/tools/src/linter/SchemasValidator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import AJV from 'ajv'
 import addFormats from 'ajv-formats'
 import OpenApiMerger from '../merger/OpenApiMerger'

--- a/tools/src/linter/SpecValidator.ts
+++ b/tools/src/linter/SpecValidator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import SchemasFolder from './components/SchemasFolder'
 import NamespacesFolder from './components/NamespacesFolder'
 import { type ValidationError } from 'types'

--- a/tools/src/linter/components/InfoFile.ts
+++ b/tools/src/linter/components/InfoFile.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import FileValidator from './base/FileValidator'
 
 export default class InfoFile extends FileValidator {

--- a/tools/src/linter/components/NamespaceFile.ts
+++ b/tools/src/linter/components/NamespaceFile.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OpenAPIV3 } from 'openapi-types'
 import { type OperationSpec, type ValidationError } from 'types'
 import OperationGroup from './OperationGroup'

--- a/tools/src/linter/components/NamespacesFolder.ts
+++ b/tools/src/linter/components/NamespacesFolder.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import NamespaceFile from './NamespaceFile'
 import { type ValidationError } from 'types'
 import FolderValidator from './base/FolderValidator'

--- a/tools/src/linter/components/Operation.ts
+++ b/tools/src/linter/components/Operation.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OperationSpec, type ValidationError } from 'types'
 import _ from 'lodash'
 import ValidatorBase from './base/ValidatorBase'

--- a/tools/src/linter/components/OperationGroup.ts
+++ b/tools/src/linter/components/OperationGroup.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import type Operation from './Operation'
 import { type ValidationError } from 'types'
 import ValidatorBase from './base/ValidatorBase'

--- a/tools/src/linter/components/Schema.ts
+++ b/tools/src/linter/components/Schema.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import ValidatorBase from './base/ValidatorBase'
 import { type OpenAPIV3 } from 'openapi-types'
 import { type ValidationError } from 'types'

--- a/tools/src/linter/components/SchemaFile.ts
+++ b/tools/src/linter/components/SchemaFile.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import FileValidator from './base/FileValidator'
 import { type ValidationError } from 'types'
 import Schema from './Schema'

--- a/tools/src/linter/components/SchemasFolder.ts
+++ b/tools/src/linter/components/SchemasFolder.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import SchemaFile from './SchemaFile'
 import FolderValidator from './base/FolderValidator'
 import { type ValidationError } from 'types'

--- a/tools/src/linter/components/SupersededOperationsFile.ts
+++ b/tools/src/linter/components/SupersededOperationsFile.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import FileValidator from './base/FileValidator'
 
 export default class SupersededOperationsFile extends FileValidator {

--- a/tools/src/linter/components/base/FileValidator.ts
+++ b/tools/src/linter/components/base/FileValidator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import ValidatorBase from './ValidatorBase'
 import { type ValidationError } from 'types'
 import { type OpenAPIV3 } from 'openapi-types'

--- a/tools/src/linter/components/base/FolderValidator.ts
+++ b/tools/src/linter/components/base/FolderValidator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import fs from 'fs'
 import ValidatorBase from './ValidatorBase'
 import type FileValidator from './FileValidator'

--- a/tools/src/linter/components/base/ValidatorBase.ts
+++ b/tools/src/linter/components/base/ValidatorBase.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type ValidationError } from 'types'
 export default class ValidatorBase {
   file: string

--- a/tools/src/linter/lint.ts
+++ b/tools/src/linter/lint.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { Command, Option } from '@commander-js/extra-typings'
 import SpecValidator from './SpecValidator'
 import { resolve } from 'path'

--- a/tools/src/linter/utils/SpecificationVisitor.ts
+++ b/tools/src/linter/utils/SpecificationVisitor.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { is_array_schema, is_ref, type KeysMatching, type MaybeRef, type SpecificationContext } from './index'
 import { OpenAPIV3 } from 'openapi-types'
 

--- a/tools/src/linter/utils/index.ts
+++ b/tools/src/linter/utils/index.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OpenAPIV3 } from 'openapi-types'
 import { type ValidationError } from 'types'
 

--- a/tools/src/merger/GlobalParamsGenerator.ts
+++ b/tools/src/merger/GlobalParamsGenerator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OpenAPIV3 } from 'openapi-types'
 import _ from 'lodash'
 import { read_yaml } from '../../helpers'

--- a/tools/src/merger/OpenApiMerger.ts
+++ b/tools/src/merger/OpenApiMerger.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OpenAPIV3 } from 'openapi-types'
 import fs from 'fs'
 import _ from 'lodash'

--- a/tools/src/merger/OpenDistro.ts
+++ b/tools/src/merger/OpenDistro.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type HttpVerb, type OperationPath, type SupersededOperationMap } from 'types'
 import { read_yaml, write_yaml } from '../../helpers'
 

--- a/tools/src/merger/SupersededOpsGenerator.ts
+++ b/tools/src/merger/SupersededOpsGenerator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OperationSpec, type SupersededOperationMap } from 'types'
 import _ from 'lodash'
 import { read_yaml } from '../../helpers'

--- a/tools/src/merger/merge.ts
+++ b/tools/src/merger/merge.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { Command, Option } from '@commander-js/extra-typings'
 import OpenApiMerger from './OpenApiMerger'
 import { resolve } from 'path'

--- a/tools/src/tester/Ansi.ts
+++ b/tools/src/tester/Ansi.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 export function b (text: string): string { return `\x1b[1m${text}\x1b[0m` }
 export function i (text: string): string { return `\x1b[3m${text}\x1b[0m` }
 

--- a/tools/src/tester/ChapterEvaluator.ts
+++ b/tools/src/tester/ChapterEvaluator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type Chapter, type ActualResponse } from './types/story.types'
 import { type ChapterEvaluation, type Evaluation, Result } from './types/eval.types'
 import { type ParsedOperation } from './types/spec.types'

--- a/tools/src/tester/ChapterReader.ts
+++ b/tools/src/tester/ChapterReader.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import axios from 'axios'
 import { type ChapterRequest, type ActualResponse, type Parameter } from './types/story.types'
 import { Agent } from 'https'

--- a/tools/src/tester/ResultsDisplayer.ts
+++ b/tools/src/tester/ResultsDisplayer.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type ChapterEvaluation, type Evaluation, Result, type StoryEvaluation } from './types/eval.types'
 import { overall_result } from './helpers'
 import * as ansi from './Ansi'

--- a/tools/src/tester/SchemaValidator.ts
+++ b/tools/src/tester/SchemaValidator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import AJV from 'ajv'
 import addFormats from 'ajv-formats'
 import { type OpenAPIV3 } from 'openapi-types'

--- a/tools/src/tester/SharedResources.ts
+++ b/tools/src/tester/SharedResources.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import type ChapterReader from './ChapterReader'
 import type SchemaValidator from './SchemaValidator'
 import type SpecParser from './SpecParser'

--- a/tools/src/tester/SpecParser.ts
+++ b/tools/src/tester/SpecParser.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OpenAPIV3 } from 'openapi-types'
 import { resolve_ref } from '../../helpers'
 import { type Chapter } from './types/story.types'

--- a/tools/src/tester/StoryEvaluator.ts
+++ b/tools/src/tester/StoryEvaluator.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type Chapter, type Story, type SupplementalChapter } from './types/story.types'
 import { type ChapterEvaluation, Result, type StoryEvaluation } from './types/eval.types'
 import ChapterEvaluator from './ChapterEvaluator'

--- a/tools/src/tester/TestsRunner.ts
+++ b/tools/src/tester/TestsRunner.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OpenAPIV3 } from 'openapi-types'
 import SpecParser from './SpecParser'
 import ChapterReader from './ChapterReader'

--- a/tools/src/tester/_generate_story_types.ts
+++ b/tools/src/tester/_generate_story_types.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import * as js2ts from 'json-schema-to-typescript'
 import fs from 'fs'
 import { read_yaml } from '../../helpers'

--- a/tools/src/tester/helpers.ts
+++ b/tools/src/tester/helpers.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type Evaluation, Result } from './types/eval.types'
 
 export function overall_result (evaluations: Evaluation[]): Result {

--- a/tools/src/tester/start.ts
+++ b/tools/src/tester/start.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import OpenApiMerger from '../merger/OpenApiMerger'
 import { LogLevel } from '../Logger'
 import TestsRunner from './TestsRunner'

--- a/tools/src/tester/types/eval.types.ts
+++ b/tools/src/tester/types/eval.types.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 export type LibraryEvaluation = StoryEvaluation[]
 
 export interface StoryEvaluation {

--- a/tools/src/tester/types/spec.types.ts
+++ b/tools/src/tester/types/spec.types.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OpenAPIV3 } from 'openapi-types'
 
 export type ParsedOperation = OpenAPIV3.OperationObject & {

--- a/tools/src/types.ts
+++ b/tools/src/types.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { type OpenAPIV3 } from 'openapi-types'
 
 export interface OperationSpec extends OpenAPIV3.OperationObject {

--- a/tools/tests/linter/InfoFile.test.ts
+++ b/tools/tests/linter/InfoFile.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import InfoFile from 'linter/components/InfoFile'
 
 test('validate()', () => {

--- a/tools/tests/linter/InlineObjectSchemaValidator.test.ts
+++ b/tools/tests/linter/InlineObjectSchemaValidator.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import SchemasFolder from 'linter/components/SchemasFolder'
 import NamespacesFolder from 'linter/components/NamespacesFolder'
 import InlineObjectSchemaValidator from 'linter/InlineObjectSchemaValidator'

--- a/tools/tests/linter/NamespaceFile.test.ts
+++ b/tools/tests/linter/NamespaceFile.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { mocked_namespace_file, namespace_file } from './factories/namespace_file'
 
 test('constructor()', () => {

--- a/tools/tests/linter/NamespacesFolder.test.ts
+++ b/tools/tests/linter/NamespacesFolder.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import NamespacesFolder from 'linter/components/NamespacesFolder'
 
 test('validate() - When there invalid files', () => {

--- a/tools/tests/linter/Operation.test.ts
+++ b/tools/tests/linter/Operation.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { mocked_operation, operation } from './factories/operation'
 
 test('validate_group()', () => {

--- a/tools/tests/linter/OperationGroup.test.ts
+++ b/tools/tests/linter/OperationGroup.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { mocked_operation_group, operation_group } from './factories/operation_group'
 
 test('validate_description()', () => {

--- a/tools/tests/linter/Schema.test.ts
+++ b/tools/tests/linter/Schema.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { schema } from './factories/schema'
 
 test('validate_name()', () => {

--- a/tools/tests/linter/SchemaFile.test.ts
+++ b/tools/tests/linter/SchemaFile.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { mocked_schema_file, schema_file } from './factories/schema_file'
 
 test('validate_category()', () => {

--- a/tools/tests/linter/SchemaRefsValidator.test.ts
+++ b/tools/tests/linter/SchemaRefsValidator.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import SchemasFolder from 'linter/components/SchemasFolder'
 import NamespacesFolder from 'linter/components/NamespacesFolder'
 import SchemaRefsValidator from 'linter/SchemaRefsValidator'

--- a/tools/tests/linter/SchemasValidator.test.ts
+++ b/tools/tests/linter/SchemasValidator.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import SchemasValidator from '../../src/linter/SchemasValidator'
 
 test('validate() - named_schemas', () => {

--- a/tools/tests/linter/SpecValidator.test.ts
+++ b/tools/tests/linter/SpecValidator.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import SpecValidator from 'linter/SpecValidator'
 
 test('validate()', () => {

--- a/tools/tests/linter/SupersededOperationsFile.test.ts
+++ b/tools/tests/linter/SupersededOperationsFile.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import SupersededOperationsFile from 'linter/components/SupersededOperationsFile'
 
 test('validate()', () => {

--- a/tools/tests/linter/factories/namespace_file.ts
+++ b/tools/tests/linter/factories/namespace_file.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import NamespaceFile from 'linter/components/NamespaceFile'
 import { type OpenAPIV3 } from 'openapi-types'
 import { mocked_operation_group } from './operation_group'

--- a/tools/tests/linter/factories/operation.ts
+++ b/tools/tests/linter/factories/operation.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import Operation from 'linter/components/Operation'
 import { type OperationSpec } from 'types'
 

--- a/tools/tests/linter/factories/operation_group.ts
+++ b/tools/tests/linter/factories/operation_group.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import OperationGroup from 'linter/components/OperationGroup'
 import { operation, mocked_operation } from './operation'
 

--- a/tools/tests/linter/factories/schema.ts
+++ b/tools/tests/linter/factories/schema.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import Schema from 'linter/components/Schema'
 import { type OpenAPIV3 } from 'openapi-types'
 

--- a/tools/tests/linter/factories/schema_file.ts
+++ b/tools/tests/linter/factories/schema_file.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { mocked_schema } from './schema'
 import SchemaFile from 'linter/components/SchemaFile'
 

--- a/tools/tests/merger/OpenApiMerger.test.ts
+++ b/tools/tests/merger/OpenApiMerger.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import OpenApiMerger from 'merger/OpenApiMerger'
 import fs from 'fs'
 import { LogLevel } from '../../src/Logger'

--- a/tools/tests/tester/ansi.test.ts
+++ b/tools/tests/tester/ansi.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import * as ansi from '../../src/tester/Ansi'
 
 test('b', async () => {

--- a/tools/tests/tester/start.test.ts
+++ b/tools/tests/tester/start.test.ts
@@ -1,3 +1,12 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
 import { spawnSync } from 'child_process'
 import * as ansi from '../../src/tester/Ansi'
 


### PR DESCRIPTION
### Description

Uses https://www.npmjs.com/package/eslint-plugin-license-header to add license headers to all TypeScript code. 

### Issues Resolved

Part of #259.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
