### PR TITLE
Adds a YAML eslint linter.

### DIFF
--- a/.github/opensearch-cluster/docker-compose.yml
+++ b/.github/opensearch-cluster/docker-compose.yml
@@ -7,5 +7,5 @@ services:
       - "9200:9200"
       - "9600:9600"
     environment:
-      - "discovery.type=single-node"
+      - discovery.type=single-node
       - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_PASSWORD:-myStrongPassword123!}"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,8 +1,6 @@
 name: Check Links
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   check:

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -35,7 +35,7 @@ jobs:
           COMMENT_IDENTIFIER=$(jq -r '.comment_identifier' ./pr-comment.json)
           TEMPLATE_NAME=$(jq -r '.template_name' ./pr-comment.json)
           TEMPLATE_DATA=$(jq -c '.template_data' ./pr-comment.json)
-        
+          
           vars=(
             PR_NUMBER
             COMMENT_IDENTIFIER

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -2,19 +2,19 @@ name: Test Spec
 
 on:
   push:
-   branches: [ '**' ]
-   paths:
-     - 'package*.json'
-     - 'tsconfig.json'
-     - 'tools/src/tester/**'
-     - 'spec/**'
+    branches: ['**']
+    paths:
+      - 'package*.json'
+      - tsconfig.json
+      - 'tools/src/tester/**'
+      - 'spec/**'
   pull_request:
-   branches: [ '**' ]
-   paths:
-     - 'package*.json'
-     - 'tsconfig.json'
-     - 'tools/src/tester/**'
-     - 'spec/**'
+    branches: ['**']
+    paths:
+      - 'package*.json'
+      - tsconfig.json
+      - 'tools/src/tester/**'
+      - 'spec/**'
 
 jobs:
   test-opensearch-spec:

--- a/.github/workflows/test-tools-integ.yml
+++ b/.github/workflows/test-tools-integ.yml
@@ -5,18 +5,18 @@ on:
     branches: ['**']
     paths:
       - 'package*.json'
-      - 'eslint.config.mjs'
-      - 'jest.config.js'
-      - 'tsconfig.json'
+      - eslint.config.mjs
+      - jest.config.js
+      - tsconfig.json
       - 'tools/**'
       - '.github/workflows/test-tools*.yml'
   pull_request:
     branches: ['**']
     paths:
       - 'package*.json'
-      - 'eslint.config.mjs'
-      - 'jest.config.js'
-      - 'tsconfig.json'
+      - eslint.config.mjs
+      - jest.config.js
+      - tsconfig.json
       - 'tools/**'
       - '.github/workflows/test-tools*.yml'
 
@@ -52,4 +52,4 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
-            token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `npm run test:spec -- --dry-run --verbose` ([#303](https://github.com/opensearch-project/opensearch-api-specification/pull/303))
 - Added `npm run test:unit` and `test:integ` ([#320](https://github.com/opensearch-project/opensearch-api-specification/pull/320))
 - Added code coverage to tools' tests ([#323](https://github.com/opensearch-project/opensearch-api-specification/pull/323))
-
+- Added a YAML linter ([#312](https://github.com/opensearch-project/opensearch-api-specification/pull/312))
+ 
 ### Changed
 
 - Replaced Smithy with a native OpenAPI spec ([#189](https://github.com/opensearch-project/opensearch-api-specification/issues/189))

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -388,7 +388,7 @@ The test suite contains unit tests and integration tests. Integration tests, suc
 
 #### Lints
 
-All code is linted using [ESLint](https://eslint.org/) in combination with [typescript-eslint](https://typescript-eslint.io/). Linting can be run via:
+All TypeScript code and YAML files are linted using [ESLint](https://eslint.org/), [typescript-eslint](https://typescript-eslint.io/), and [eslint-plugin-yml](https://ota-meshi.github.io/eslint-plugin-yml/). Linting can be run via:
 ```bash
 npm run lint
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See [CLIENT_GENERATOR_GUIDE](CLIENT_GENERATOR_GUIDE.md).
 
 OpenSearch API Specs are hosted at https://opensearch-project.github.io/opensearch-api-specification/. See [PUBLISHING_SPECS](PUBLISHING_SPECS.md) for more information.
 
-Click [here](https://github.com/opensearch-project/opensearch-api-specification/releases/download/main/opensearch-openapi.yaml) to download the latest OpenSearch OpenAPI yaml file.
+Click [here](https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml) to download the latest OpenSearch OpenAPI yaml file.
 
 
 ## Security

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,23 +1,32 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
-import { FlatCompat } from '@eslint/eslintrc'
 import pluginJs from '@eslint/js'
+import pluginTs from '@typescript-eslint/eslint-plugin'
+import parserTs from '@typescript-eslint/parser'
+import eslintPluginYml from 'eslint-plugin-yml'
+import parserYml from "yaml-eslint-parser"
+import globals from 'globals'
 import licenseHeader from 'eslint-plugin-license-header'
-
-// mimic CommonJS variables -- not needed if using CommonJS
-const _filename = fileURLToPath(import.meta.url)
-const _dirname = path.dirname(_filename)
-const compat = new FlatCompat({ baseDirectory: _dirname, recommendedConfig: pluginJs.configs.recommended })
 
 export default [
   pluginJs.configs.recommended,
-  ...compat.extends('standard-with-typescript'),
   {
     files: ['**/*.{js,ts}'],
+    languageOptions: {
+      parser: parserTs,
+      parserOptions: {
+        project: './tsconfig.json'
+      },
+      globals: {
+        ...globals.jest,
+        ...globals.node,
+      },
+    },
     plugins: {
+      '@typescript-eslint': pluginTs,
       'license-header': licenseHeader
     },
     rules: {
+      ...pluginJs.configs.recommended.rules,
+      ...pluginTs.configs["recommended-type-checked"].rules,
       '@typescript-eslint/consistent-indexed-object-style': 'error',
       '@typescript-eslint/consistent-type-assertions': 'error',
       '@typescript-eslint/dot-notation': 'error',
@@ -71,6 +80,20 @@ export default [
           '*/'
         ]
       ]
+    }
+  },
+  ...eslintPluginYml.configs['flat/standard'],
+  {
+    files: ["**/*.yaml", "**/*.yml"],
+    languageOptions: {
+      parser: parserYml
+    },
+    plugins: {
+      yml: eslintPluginYml
+    },
+    rules: {
+      'yml/no-empty-document': 'off',
+      'yml/quotes': ['error', { prefer: 'single' }]
     }
   }
 ]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,11 @@ export default [
     rules: {
       ...pluginJs.configs.recommended.rules,
       ...pluginTs.configs["recommended-type-checked"].rules,
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/consistent-indexed-object-style': 'error',
       '@typescript-eslint/consistent-type-assertions': 'error',
       '@typescript-eslint/dot-notation': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,7 @@ export default [
       'new-cap': 'off',
       'no-return-assign': 'error',
       'object-shorthand': 'error',
+      'no-constant-condition': 'off',
       'license-header/header': [
         'error',
         [
@@ -98,7 +99,8 @@ export default [
     },
     rules: {
       'yml/no-empty-document': 'off',
-      'yml/quotes': ['error', { prefer: 'single' }]
+      'yml/quotes': 'off',
+      'yml/plain-scalar': 'off'
     }
   }
 ]

--- a/json_schemas/test_story.schema.yaml
+++ b/json_schemas/test_story.schema.yaml
@@ -23,7 +23,7 @@ properties:
     items:
       $ref: '#/definitions/Chapter'
     minItems: 1
-required: [ description, chapters]
+required: [description, chapters]
 additionalProperties: false
 
 definitions:
@@ -37,7 +37,7 @@ definitions:
             description: A brief description of the chapter.
           response:
             $ref: '#/definitions/ExpectedResponse'
-        required: [ synopsis ]
+        required: [synopsis]
         additionalProperties: false
 
   ReadChapter:
@@ -47,7 +47,7 @@ definitions:
         properties:
           response:
             $ref: '#/definitions/ActualResponse'
-        required: [ response ]
+        required: [response]
         additionalProperties: false
 
   SupplementalChapter:
@@ -70,14 +70,14 @@ definitions:
         type: string
       method:
         type: string
-        enum: [ GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS ]
+        enum: [GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS]
       parameters:
         type: object
         additionalProperties:
           $ref: '#/definitions/Parameter'
       request_body:
         $ref: '#/definitions/RequestBody'
-    required: [ path, method ]
+    required: [path, method]
     additionalProperties: false
 
 
@@ -89,7 +89,7 @@ definitions:
         default: application/json
       payload:
         $ref: '#/definitions/Payload'
-    required: [ payload ]
+    required: [payload]
     additionalProperties: false
 
   ExpectedResponse:
@@ -104,7 +104,7 @@ definitions:
         default: application/json
       payload:
         $ref: '#/definitions/Payload'
-    required: [ status ]
+    required: [status]
     additionalProperties: false
 
   ActualResponse:
@@ -122,7 +122,7 @@ definitions:
       error:
         type: object
         description: Error object.
-    required: [ status, content_type, payload ]
+    required: [status, content_type, payload]
     additionalProperties: false
 
   Payload:

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-plugin-license-header": "^0.6.1",
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.1.1",
+        "eslint-plugin-yml": "^1.14.0",
         "globals": "^15.0.0",
         "jest": "^29.7.0",
         "json-schema-to-typescript": "^14.0.4",
@@ -3336,6 +3337,28 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-yml": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-1.14.0.tgz",
+      "integrity": "sha512-ESUpgYPOcAYQO9czugcX5OqRvn/ydDVwGCPXY4YjPqc09rHaUVUA6IE6HLQys4rXk/S+qx3EwTd1wHCwam/OWQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.2",
+        "eslint-compat-utils": "^0.5.0",
+        "lodash": "^4.17.21",
+        "natural-compare": "^1.4.0",
+        "yaml-eslint-parser": "^1.2.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -7364,6 +7387,23 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yaml-eslint-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.2.3.tgz",
+      "integrity": "sha512-4wZWvE398hCP7O8n3nXKu/vdq1HcH01ixYlCREaJL5NUMwQ0g3MaGFUBNSlmBtKmhbtVG/Cm6lyYmSVTEVil8A==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.0.0",
+        "lodash": "^4.17.21",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-license-header": "^0.6.1",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.1.1",
+    "eslint-plugin-yml": "^1.14.0",
     "globals": "^15.0.0",
     "jest": "^29.7.0",
     "json-schema-to-typescript": "^14.0.4",

--- a/tools/tests/linter/NamespacesFolder.test.ts
+++ b/tools/tests/linter/NamespacesFolder.test.ts
@@ -7,56 +7,80 @@
 * compatible open source license.
 */
 
+import path from 'path'
+import os from 'os'
+import fs from 'fs'
 import NamespacesFolder from 'linter/components/NamespacesFolder'
 
-test('validate() - When there invalid files', () => {
-  const validator = new NamespacesFolder('./tools/tests/linter/fixtures/folder_validators/namespaces/invalid_files')
-  expect(validator.validate()).toEqual([
-    {
-      file: 'invalid_files/indices.txt',
-      location: 'File Extension',
-      message: "Invalid file extension. Only '.yaml' files are allowed."
-    },
-    {
-      file: 'invalid_files/invalid_spec.yaml',
-      location: 'Operation: GET /{index}/_doc/{id}',
-      message: 'Missing description property.'
-    },
-    {
-      file: 'invalid_files/invalid_spec.yaml',
-      location: 'Operation: GET /{index}/_doc/{id}',
-      message: "Every parameter must be a reference object to '#/components/parameters/{x-operation-group}::{path|query}.{parameter_name}'."
-    },
-    {
-      file: 'invalid_files/invalid_spec.yaml',
-      location: 'Operation: GET /{index}/_doc/{id}',
-      message: 'Path parameters must match the parameters in the path: {id}, {index}.'
-    },
-    {
-      file: 'invalid_files/invalid_spec.yaml',
-      location: 'Operation: GET /{index}/_doc/{id}',
-      message: "The 200 response must be a reference object to '#/components/responses/invalid_spec.fetch@200'."
-    },
-    {
-      file: 'invalid_files/invalid_yaml.yaml',
-      location: 'File Content',
-      message: 'Unable to read or parse YAML.'
-    }
-  ])
-})
+describe('validate()', () => {
+  test('when there invalid files', () => {
+    const validator = new NamespacesFolder('./tools/tests/linter/fixtures/folder_validators/namespaces/invalid_files')
+    expect(validator.validate()).toEqual([
+      {
+        file: 'invalid_files/indices.txt',
+        location: 'File Extension',
+        message: "Invalid file extension. Only '.yaml' files are allowed."
+      },
+      {
+        file: 'invalid_files/invalid_spec.yaml',
+        location: 'Operation: GET /{index}/_doc/{id}',
+        message: 'Missing description property.'
+      },
+      {
+        file: 'invalid_files/invalid_spec.yaml',
+        location: 'Operation: GET /{index}/_doc/{id}',
+        message: "Every parameter must be a reference object to '#/components/parameters/{x-operation-group}::{path|query}.{parameter_name}'."
+      },
+      {
+        file: 'invalid_files/invalid_spec.yaml',
+        location: 'Operation: GET /{index}/_doc/{id}',
+        message: 'Path parameters must match the parameters in the path: {id}, {index}.'
+      },
+      {
+        file: 'invalid_files/invalid_spec.yaml',
+        location: 'Operation: GET /{index}/_doc/{id}',
+        message: "The 200 response must be a reference object to '#/components/responses/invalid_spec.fetch@200'."
+      }
+    ])
+  })
 
-test('validate() - When the files are valid but the folder is not', () => {
-  const validator = new NamespacesFolder('./tools/tests/linter/fixtures/folder_validators/namespaces/invalid_folder')
-  expect(validator.validate()).toEqual([
-    {
-      file: 'invalid_folder/',
-      location: 'Folder',
-      message: "Duplicate path '/{index}' found in namespaces: dup_path_a, dup_path_c."
-    },
-    {
-      file: 'invalid_folder/',
-      location: 'Folder',
-      message: "Duplicate path '/{index}/_rollover' found in namespaces: dup_path_a, dup_path_b, dup_path_c."
-    }
-  ])
+  test('when the files are valid but the folder is not', () => {
+    const validator = new NamespacesFolder('./tools/tests/linter/fixtures/folder_validators/namespaces/invalid_folder')
+    expect(validator.validate()).toEqual([
+      {
+        file: 'invalid_folder/',
+        location: 'Folder',
+        message: "Duplicate path '/{index}' found in namespaces: dup_path_a, dup_path_c."
+      },
+      {
+        file: 'invalid_folder/',
+        location: 'Folder',
+        message: "Duplicate path '/{index}/_rollover' found in namespaces: dup_path_a, dup_path_b, dup_path_c."
+      }
+    ])
+  })
+
+  describe('with invalid YAML', () => {
+    const invalid_yaml_path = path.join(os.tmpdir(), 'invalid_yaml')
+
+    beforeAll(() => {
+      fs.mkdirSync(invalid_yaml_path)
+      fs.writeFileSync(`${invalid_yaml_path}/invalid_yaml.yaml`, "```\nInvalid YAML file\n```")
+    })
+
+    afterAll(() => {
+      fs.rmdirSync(invalid_yaml_path, { recursive: true })
+    })
+
+    test('fails unable to parse YAML', () => {
+      const validator = new NamespacesFolder(invalid_yaml_path)
+      expect(validator.validate()).toEqual([
+        {
+          file: 'invalid_yaml/invalid_yaml.yaml',
+          location: 'File Content',
+          message: 'Unable to read or parse YAML.'
+        }
+      ])
+    })
+  })
 })

--- a/tools/tests/linter/fixtures/folder_validators/namespaces/invalid_files/invalid_yaml.yaml
+++ b/tools/tests/linter/fixtures/folder_validators/namespaces/invalid_files/invalid_yaml.yaml
@@ -1,3 +1,0 @@
-```
-Invalid YAML file
-```

--- a/tools/tests/linter/fixtures/schemas_validator/anonymous_schemas/namespaces/shelter.yaml
+++ b/tools/tests/linter/fixtures/schemas_validator/anonymous_schemas/namespaces/shelter.yaml
@@ -24,31 +24,31 @@ paths:
         '200':
           $ref: '#/components/responses/adopt@200'
 components:
-    requestBodies:
-      adopt: {
-        content: {
-          application/json: {
-            schema: {
-              type: object2
-            }
-          }
-        }
-      }
-    parameters:
-      adopt::path.animal:
-        name: animal
-        in: path
-        schema:
-          $ref: '../schemas/animals.yaml#/components/schemas/Animal'
-      adopt::path.docket:
-        name: docket
-        in: path
-        schema:
-          type: number2
-    responses:
-      adopt@200:
-        description: ''
-        content:
-          application/json:
-            schema:
-              type: object2
+  requestBodies:
+    adopt: 
+      content: 
+        application/json: 
+          schema: 
+            type: object2
+          
+        
+      
+    
+  parameters:
+    adopt::path.animal:
+      name: animal
+      in: path
+      schema:
+        $ref: '../schemas/animals.yaml#/components/schemas/Animal'
+    adopt::path.docket:
+      name: docket
+      in: path
+      schema:
+        type: number2
+  responses:
+    adopt@200:
+      description: ''
+      content:
+        application/json:
+          schema:
+            type: object2

--- a/tools/tests/linter/fixtures/schemas_validator/anonymous_schemas/schemas/actions.yaml
+++ b/tools/tests/linter/fixtures/schemas_validator/anonymous_schemas/schemas/actions.yaml
@@ -4,8 +4,8 @@ info:
   description: OpenSearch API
   version: 1.0.0
 components:
-    schemas:
-      Bark:
-        type: string
-      Meow:
-        type: string
+  schemas:
+    Bark:
+      type: string
+    Meow:
+      type: string

--- a/tools/tests/linter/fixtures/schemas_validator/anonymous_schemas/schemas/animals.yaml
+++ b/tools/tests/linter/fixtures/schemas_validator/anonymous_schemas/schemas/animals.yaml
@@ -10,12 +10,12 @@ components:
         - $ref: '#/components/schemas/Dog'
         - $ref: '#/components/schemas/Cat'
     Dog:
-        type: object
-        properties:
-          bark:
-            $ref: 'actions.yaml#/components/schemas/Bark'
+      type: object
+      properties:
+        bark:
+          $ref: 'actions.yaml#/components/schemas/Bark'
     Cat:
-        type: object
-        properties:
-          meow:
-            $ref: 'actions.yaml#/components/schemas/Meow'
+      type: object
+      properties:
+        meow:
+          $ref: 'actions.yaml#/components/schemas/Meow'

--- a/tools/tests/linter/fixtures/schemas_validator/named_schemas/namespaces/shelter.yaml
+++ b/tools/tests/linter/fixtures/schemas_validator/named_schemas/namespaces/shelter.yaml
@@ -24,22 +24,22 @@ paths:
         '200':
           $ref: '#/components/responses/adopt@200'
 components:
-    requestBodies:
-      adopt: {}
-    parameters:
-      adopt::path.animal:
-        name: animal
-        in: path
+  requestBodies:
+    adopt: {}
+  parameters:
+    adopt::path.animal:
+      name: animal
+      in: path
+      schema:
+        $ref: '../schemas/animals.yaml#/components/schemas/Animal'
+    adopt::path.docket:
+      name: docket
+      in: path
+      schema:
+        type: number
+  responses:
+    adopt@200:
+      description: ''
+      application/json:
         schema:
-          $ref: '../schemas/animals.yaml#/components/schemas/Animal'
-      adopt::path.docket:
-        name: docket
-        in: path
-        schema:
-          type: number
-    responses:
-      adopt@200:
-        description: ''
-        application/json:
-          schema:
-            type: object
+          type: object

--- a/tools/tests/linter/fixtures/schemas_validator/named_schemas/schemas/actions.yaml
+++ b/tools/tests/linter/fixtures/schemas_validator/named_schemas/schemas/actions.yaml
@@ -4,8 +4,8 @@ info:
   description: OpenSearch API
   version: 1.0.0
 components:
-    schemas:
-      Bark:
-        type: bogus
-      Meow:
-        type: string
+  schemas:
+    Bark:
+      type: bogus
+    Meow:
+      type: string

--- a/tools/tests/linter/fixtures/schemas_validator/named_schemas/schemas/animals.yaml
+++ b/tools/tests/linter/fixtures/schemas_validator/named_schemas/schemas/animals.yaml
@@ -10,12 +10,12 @@ components:
         - $ref: '#/components/schemas/Dog'
         - $ref: '#/components/schemas/Cat'
     Dog:
-        type: bogus
-        properties:
-          bark:
-            $ref: 'actions.yaml#/components/schemas/Bark'
+      type: bogus
+      properties:
+        bark:
+          $ref: 'actions.yaml#/components/schemas/Bark'
     Cat:
-        type: object
-        properties:
-          meow:
-            $ref: 'actions.yaml#/components/schemas/Meow'
+      type: object
+      properties:
+        meow:
+          $ref: 'actions.yaml#/components/schemas/Meow'

--- a/tools/tests/linter/lint.test.ts
+++ b/tools/tests/linter/lint.test.ts
@@ -18,5 +18,7 @@ const spec = (args: string[]): any => {
 }
 
 test('--help', () => {
-  expect(spec(['--help']).stdout).toContain('Usage: lint [options]')
+  const output = spec(['--help']) 
+  expect(output.stderr).toEqual('')
+  expect(output.stdout).toContain('Usage: lint [options]')
 })

--- a/tools/tests/merger/fixtures/spec/namespaces/indices.yaml
+++ b/tools/tests/merger/fixtures/spec/namespaces/indices.yaml
@@ -3,33 +3,33 @@ info:
   title: Ignored
   version: 1.0.0
 paths:
-    '/{index}':
-        post:
-          parameters:
-              - $ref: '#/components/parameters/indices.create::path.index'
-              - $ref: '#/components/parameters/indices.create::query.pretty'
-          requestBody:
-              $ref: '#/components/requestBodies/indices.create'
-          responses:
-            '200':
-              $ref: '#/components/responses/indices.create@200'
+  '/{index}':
+    post:
+      parameters:
+        - $ref: '#/components/parameters/indices.create::path.index'
+        - $ref: '#/components/parameters/indices.create::query.pretty'
+      requestBody:
+        $ref: '#/components/requestBodies/indices.create'
+      responses:
+        '200':
+          $ref: '#/components/responses/indices.create@200'
 components:
-    requestBodies:
-        indices.create: {}
-    parameters:
-      indices.create::path.index:
-        name: index
-        in: path
+  requestBodies:
+    indices.create: {}
+  parameters:
+    indices.create::path.index:
+      name: index
+      in: path
+      schema:
+        type: string
+    indices.create::query.pretty:
+      name: pretty
+      in: query
+      schema:
+        type: boolean
+  responses:
+    indices.create@200:
+      description: ''
+      application/json:
         schema:
-          type: string
-      indices.create::query.pretty:
-        name: pretty
-        in: query
-        schema:
-          type: boolean
-    responses:
-        indices.create@200:
-            description: ''
-            application/json:
-              schema:
-                type: object
+          type: object

--- a/tools/tests/merger/fixtures/spec/namespaces/shelter.yaml
+++ b/tools/tests/merger/fixtures/spec/namespaces/shelter.yaml
@@ -24,22 +24,22 @@ paths:
         '200':
           $ref: '#/components/responses/adopt@200'
 components:
-    requestBodies:
-      adopt: {}
-    parameters:
-      adopt::path.animal:
-        name: animal
-        in: path
+  requestBodies:
+    adopt: {}
+  parameters:
+    adopt::path.animal:
+      name: animal
+      in: path
+      schema:
+        $ref: '../schemas/animals.yaml#/components/schemas/Animal'
+    adopt::path.docket:
+      name: docket
+      in: path
+      schema:
+        type: number
+  responses:
+    adopt@200:
+      description: ''
+      application/json:
         schema:
-          $ref: '../schemas/animals.yaml#/components/schemas/Animal'
-      adopt::path.docket:
-        name: docket
-        in: path
-        schema:
-          type: number
-    responses:
-      adopt@200:
-        description: ''
-        application/json:
-          schema:
-            type: object
+          type: object

--- a/tools/tests/merger/fixtures/spec/schemas/actions.yaml
+++ b/tools/tests/merger/fixtures/spec/schemas/actions.yaml
@@ -4,8 +4,8 @@ info:
   description: OpenSearch API
   version: 1.0.0
 components:
-    schemas:
-      Bark:
-        type: string
-      Meow:
-        type: string
+  schemas:
+    Bark:
+      type: string
+    Meow:
+      type: string

--- a/tools/tests/merger/fixtures/spec/schemas/animals.yaml
+++ b/tools/tests/merger/fixtures/spec/schemas/animals.yaml
@@ -10,12 +10,12 @@ components:
         - $ref: '#/components/schemas/Dog'
         - $ref: '#/components/schemas/Cat'
     Dog:
-        type: object
-        properties:
-          bark:
-            $ref: 'actions.yaml#/components/schemas/Bark'
+      type: object
+      properties:
+        bark:
+          $ref: 'actions.yaml#/components/schemas/Bark'
     Cat:
-        type: object
-        properties:
-          meow:
-            $ref: 'actions.yaml#/components/schemas/Meow'
+      type: object
+      properties:
+        meow:
+          $ref: 'actions.yaml#/components/schemas/Meow'

--- a/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
+++ b/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
@@ -25,7 +25,7 @@ chapters:
       status:
         result: ERROR
         message: 'Expected status 200, but received 404: application/json. no such index
-            [undefined]'
+          [undefined]'
         error: Request failed with status code 404
       payload:
         result: SKIPPED


### PR DESCRIPTION
### Description

Lints YAML using a formatting linter. Fixes things like spaces, preferring single/double quotes, etc.

We have a [spec linter](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md#spec-linter) that is about the spec itself in which we could implement some of these rules too, but feels easier. That one probably could have been (still can be) a generic eslint linter, too. 

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/issues/266.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
