### PR TITLE
Turn on @typescript-eslint/require-await.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,6 +52,7 @@ export default [
           allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false
         }
       ],
+      '@typescript-eslint/require-await': 'error',
       'array-callback-return': 'off',
       'new-cap': 'off',
       'no-return-assign': 'error',

--- a/tools/tests/merger/OpenApiMerger.test.ts
+++ b/tools/tests/merger/OpenApiMerger.test.ts
@@ -11,7 +11,7 @@ import OpenApiMerger from 'merger/OpenApiMerger'
 import fs from 'fs'
 import { LogLevel } from '../../src/Logger'
 
-test('merge()', async () => {
+test('merge()', () => {
   const merger = new OpenApiMerger('./tools/tests/merger/fixtures/spec/', LogLevel.error)
   merger.merge('./tools/tests/merger/opensearch-openapi.yaml')
   expect(fs.readFileSync('./tools/tests/merger/fixtures/expected.yaml', 'utf8'))

--- a/tools/tests/tester/StoryEvaluator.test.ts
+++ b/tools/tests/tester/StoryEvaluator.test.ts
@@ -16,36 +16,36 @@ create_shared_resources(spec as OpenAPIV3.Document)
 
 test('passed', async () => {
   const actual = await load_actual_evaluation('passed')
-  const expected = await load_expected_evaluation('passed')
+  const expected = load_expected_evaluation('passed')
   expect(actual).toEqual(expected)
 })
 
 test('skipped', async () => {
   const actual = await load_actual_evaluation('skipped')
-  const expected = await load_expected_evaluation('skipped')
+  const expected = load_expected_evaluation('skipped')
   expect(actual).toEqual(expected)
 })
 
 test('failed/not_found', async () => {
   const actual = await load_actual_evaluation('failed/not_found')
-  const expected = await load_expected_evaluation('failed/not_found')
+  const expected = load_expected_evaluation('failed/not_found')
   expect(actual).toEqual(expected)
 })
 
 test('failed/invalid_data', async () => {
   const actual = await load_actual_evaluation('failed/invalid_data')
-  const expected = await load_expected_evaluation('failed/invalid_data')
+  const expected = load_expected_evaluation('failed/invalid_data')
   expect(actual).toEqual(expected)
 })
 
 test('error/prologue_error', async () => {
   const actual = await load_actual_evaluation('error/prologue_error')
-  const expected = await load_expected_evaluation('error/prologue_error')
+  const expected = load_expected_evaluation('error/prologue_error')
   expect(actual).toEqual(expected)
 })
 
 test('error/chapter_error', async () => {
   const actual = await load_actual_evaluation('error/chapter_error')
-  const expected = await load_expected_evaluation('error/chapter_error')
+  const expected = load_expected_evaluation('error/chapter_error')
   expect(actual).toEqual(expected)
 })

--- a/tools/tests/tester/TestsRunner.test.ts
+++ b/tools/tests/tester/TestsRunner.test.ts
@@ -24,12 +24,12 @@ test('stories folder', async () => {
     delete evaluation.full_path
   }
 
-  const skipped = await load_expected_evaluation('skipped', true)
-  const passed = await load_expected_evaluation('passed', true)
-  const not_found = await load_expected_evaluation('failed/not_found', true)
-  const invalid_data = await load_expected_evaluation('failed/invalid_data', true)
-  const chapter_error = await load_expected_evaluation('error/chapter_error', true)
-  const prologue_error = await load_expected_evaluation('error/prologue_error', true)
+  const skipped = load_expected_evaluation('skipped', true)
+  const passed = load_expected_evaluation('passed', true)
+  const not_found = load_expected_evaluation('failed/not_found', true)
+  const invalid_data = load_expected_evaluation('failed/invalid_data', true)
+  const chapter_error = load_expected_evaluation('error/chapter_error', true)
+  const prologue_error = load_expected_evaluation('error/prologue_error', true)
 
   const expected_evaluations = [passed, skipped, chapter_error, prologue_error, invalid_data, not_found]
   expect(actual_evaluations).toEqual(expected_evaluations)

--- a/tools/tests/tester/helpers.ts
+++ b/tools/tests/tester/helpers.ts
@@ -39,7 +39,7 @@ export function scrub_errors (obj: any): void {
   }
 }
 
-export async function load_expected_evaluation (name: string, exclude_full_path: boolean = false): Promise<any> {
+export function load_expected_evaluation (name: string, exclude_full_path: boolean = false): Record<string, any> {
   const expected = read_yaml(`tools/tests/tester/fixtures/evals/${name}.yaml`)
   if (exclude_full_path) delete expected.full_path
   return expected

--- a/tools/tests/tester/start.test.ts
+++ b/tools/tests/tester/start.test.ts
@@ -21,21 +21,21 @@ const spec = (args: string[]): any => {
   }
 }
 
-test('--help', async () => {
+test('--help', () => {
   expect(spec(['--help']).stdout).toContain('Usage: start [options]')
 })
 
-test('--invalid', async () => {
+test('--invalid', () => {
   expect(spec(['--invalid']).stderr).toContain("error: unknown option '--invalid'")
 })
 
-test('displays story filename', async () => {
+test('displays story filename', () => {
   expect(spec(['--tests', 'tools/tests/tester/fixtures/empty_story']).stdout).toContain(
     `${ansi.green('PASSED ')} ${ansi.cyan(ansi.b('empty.yaml'))}`
   )
 })
 
-test('displays story description', async () => {
+test('displays story description', () => {
   expect(spec(['--tests', 'tools/tests/tester/fixtures/empty_with_description.yaml']).stdout).toContain(
     `${ansi.green('PASSED ')} ${ansi.cyan(ansi.b('A story with no beginning or end.'))}`
   )
@@ -43,14 +43,14 @@ test('displays story description', async () => {
 
 test.todo('--tab-width')
 
-test('--dry-run', async () => {
+test('--dry-run', () => {
   const test_yaml = 'tools/tests/tester/fixtures/empty_with_all_the_parts.yaml'
   const s = spec(['--dry-run', '--tests', test_yaml]).stdout
   const full_path = path.join(__dirname, '../../../' + test_yaml)
   expect(s).toEqual(`${ansi.yellow('SKIPPED')} ${ansi.cyan(ansi.b('A story with all its parts.'))} ${ansi.gray('(' + full_path + ')')}\n\n\n`)
 })
 
-test('--dry-run --verbose', async () => {
+test('--dry-run --verbose', () => {
   const s = spec(['--dry-run', '--verbose', '--tests', 'tools/tests/tester/fixtures/empty_with_all_the_parts.yaml']).stdout
   expect(s).toContain(`${ansi.yellow('SKIPPED')} ${ansi.cyan(ansi.b('A story with all its parts.'))}`)
   expect(s).toContain(`${ansi.yellow('SKIPPED')} CHAPTERS`)


### PR DESCRIPTION
### Description

Turn on @typescript-eslint/require-await.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
