### PR TITLE
Rename release tag to avoid refname conflict.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ steps.branch.outputs.name }}
+          automatic_release_tag: ${{ steps.branch.outputs.name }}-latest
           prerelease: true
           title: OpenSearch OpenAPI Spec (${{ steps.branch.outputs.name }})
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Replaced Smithy with a native OpenAPI spec ([#189](https://github.com/opensearch-project/opensearch-api-specification/issues/189))
 - Refactored spec tester internals to improve reusability ([#302](https://github.com/opensearch-project/opensearch-api-specification/pull/302))
+- Renamed `main` release tag to `main-latest` ([#321](https://github.com/opensearch-project/opensearch-api-specification/pull/321))
 
 ### Deprecated
 


### PR DESCRIPTION
### Description

Renames the auto-release tag to avoid refname conflict.

Open to `main-latest` (this PR), `latest-main` or `spec-main` if anyone has strong opinions.

Will need updating in clients that pull the spec, too, will do after merge.

### Issues Resolved

Closes #300.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
