### PR TITLE
Code coverage nits.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1%

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  moduleDirectories: ['node_modules', './tools/src']
+  moduleDirectories: ['node_modules', './tools/src'],
+  collectCoverageFrom: ['tools/src/**']
 }


### PR DESCRIPTION
### Description

1. We currently collect coverage from the tests themselves, which isn't a thing.
  <img width="1337" alt="Screenshot 2024-06-10 at 2 43 57 PM" src="https://github.com/opensearch-project/opensearch-api-specification/assets/542335/2a946f7d-8d80-48ea-8183-2d1a08f0bf91">

2. Adjust coverage threshold to avoid false negatives such as in the last commit to HEAD.
  <img width="976" alt="Screenshot 2024-06-10 at 2 53 35 PM" src="https://github.com/opensearch-project/opensearch-api-specification/assets/542335/ac5b7cd7-f47b-4992-8935-7769bc8f67b7">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
