### PR TITLE
Fix: get output value

### DIFF
--- a/tools/src/tester/StoryOutputs.ts
+++ b/tools/src/tester/StoryOutputs.ts
@@ -31,7 +31,8 @@ export class StoryOutputs {
   }
 
   get_output_value (chapter_id: string, output_name: string): any {
-    return this.outputs[chapter_id].get_output(output_name)
+    const output = this.outputs[chapter_id]
+    return output !== undefined ? output.get_output(output_name) : undefined
   }
 
   resolve_params (parameters: Record<string, Parameter>): Record<string, Parameter> {

--- a/tools/tests/tester/story_outputs.test.ts
+++ b/tools/tests/tester/story_outputs.test.ts
@@ -19,6 +19,7 @@ const story_outputs = new StoryOutputs({
 
 test('resolve_string', () => {
   expect(story_outputs.resolve_string('${chapter_id.x}')).toEqual(1)
+  expect(story_outputs.resolve_string('${invalid_id.x}')).toBeUndefined()
   expect(story_outputs.resolve_string('some_str')).toEqual('some_str')
 })
 


### PR DESCRIPTION
### Description

On top of https://github.com/opensearch-project/opensearch-api-specification/pull/333.

This bug shows up if you reference output that doesn't exist, or if a chapter fails and is referenced in an epilogue.

To reproduce:

1. Manually create the model in tests/ml/model_groups.yaml.
2. Run.

```
/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/StoryOutputs.ts:34
    return this.outputs[chapter_id].get_output(output_name)
                                    ^
TypeError: Cannot read properties of undefined (reading 'get_output')
    at StoryOutputs.get_output_value (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/StoryOutputs.ts:34:37)
    at StoryOutputs.resolve_string (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/StoryOutputs.ts:52:19)
    at StoryOutputs.resolve_params (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/StoryOutputs.ts:41:44)
    at ChapterReader.read (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/ChapterReader.ts:24:43)
    at SupplementalChapterEvaluator.evaluate (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/SupplementalChapterEvaluator.ts:26:53)
    at StoryEvaluator.#evaluate_supplemental_chapters (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/StoryEvaluator.ts:88:93)
    at StoryEvaluator.evaluate (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/StoryEvaluator.ts:50:82)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async TestRunner.run (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/TestRunner.ts:33:26)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
