### PR TITLE
Add `distribution` field to `OpenSearchVersionInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added linter to validate order of spec operations ([#325](https://github.com/opensearch-project/opensearch-api-specification/pull/326)) ([#326](https://github.com/opensearch-project/opensearch-api-specification/pull/326))
 - Added support to read outputs from requests in tests([#324](https://github.com/opensearch-project/opensearch-api-specification/pull/324))
 - Added `eslint-plugin-eslint-comments` ([#333](https://github.com/opensearch-project/opensearch-api-specification/pull/333))
- 
+- Added `distribution` field to `OpenSearchVersionInfo` ([#336](https://github.com/opensearch-project/opensearch-api-specification/pull/336)) 
+
 ### Changed
 
 - Replaced Smithy with a native OpenAPI spec ([#189](https://github.com/opensearch-project/opensearch-api-specification/issues/189))

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -1800,6 +1800,8 @@ components:
           type: boolean
         build_type:
           type: string
+        distribution:
+          type: string
         lucene_version:
           $ref: '#/components/schemas/VersionString'
         minimum_index_compatibility_version:
@@ -1813,6 +1815,7 @@ components:
         - build_hash
         - build_snapshot
         - build_type
+        - distribution
         - lucene_version
         - minimum_index_compatibility_version
         - minimum_wire_compatibility_version

--- a/tools/src/OpenSearchHttpClient.ts
+++ b/tools/src/OpenSearchHttpClient.ts
@@ -59,6 +59,7 @@ export interface OpenSearchInfo {
     build_hash: string
     build_snapshot: boolean
     build_type: string
+    distribution: string
     lucene_version: string
     minimum_index_compatibility_version: string
     minimum_wire_compatibility_version: string


### PR DESCRIPTION
### Description
Adds missing `distribution` field to `OpenSearchVersionInfo`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
