### PR TITLE
Downgrade TypeScript version to remove eslint warning.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "commander": "^12.0.0",
         "lodash": "^4.17.21",
         "ts-node": "^10.9.1",
-        "typescript": "^5.4.5",
+        "typescript": "<5.4.0",
         "yaml": "^2.3.4"
       },
       "devDependencies": {
@@ -7172,9 +7172,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "commander": "^12.0.0",
     "lodash": "^4.17.21",
     "ts-node": "^10.9.1",
-    "typescript": "^5.4.5",
+    "typescript": "<5.4.0",
     "yaml": "^2.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Currently you see

```
> eslint . --report-unused-disable-directives

=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=4.3.5 <5.4.0

YOUR TYPESCRIPT VERSION: 5.4.5

Please only submit bug reports when using the officially supported version.

=============
```

I wasn't able to find a set of compatible libraries that upgrade eslint, but downgrading by one seems harmless.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
