### PR TITLE
Check response payload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `distribution` field to `OpenSearchVersionInfo` ([#336](https://github.com/opensearch-project/opensearch-api-specification/pull/336)) 
 - Added `created_time` and `last_updated_time` to `ml.get_model_group@200` ([#342](https://github.com/opensearch-project/opensearch-api-specification/pull/342))
 - Added spellcheck linter ([#341](https://github.com/opensearch-project/opensearch-api-specification/pull/341))
+- Added tests for response payload ([#347](https://github.com/opensearch-project/opensearch-api-specification/pull/347))
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-plugin-yml": "^1.14.0",
         "globals": "^15.0.0",
         "jest": "^29.7.0",
+        "json-diff-ts": "^4.0.1",
         "json-schema-to-typescript": "^14.0.4",
         "ts-jest": "^29.1.2"
       }
@@ -6108,6 +6109,15 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
+    },
+    "node_modules/json-diff-ts": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/json-diff-ts/-/json-diff-ts-4.0.1.tgz",
+      "integrity": "sha512-FEuq+gv4DXI+nL7oF/trBQIBQYDVcJe5Kqe3mYUZAkDtHBY/cdWmVZpV9BLZFp+wThMClajYp0fmNVmB81FsmA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "4.x"
+      }
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-yml": "^1.14.0",
     "globals": "^15.0.0",
     "jest": "^29.7.0",
+    "json-diff-ts": "^4.0.1",
     "json-schema-to-typescript": "^14.0.4",
     "ts-jest": "^29.1.2"
   }

--- a/tests/_core/info.yaml
+++ b/tests/_core/info.yaml
@@ -16,3 +16,7 @@ chapters:
       pretty: false
     response:
       status: 200
+      payload:
+        version:
+          distribution: opensearch
+        tagline: 'The OpenSearch Project: https://opensearch.org/'

--- a/tools/src/tester/ResultLogger.ts
+++ b/tools/src/tester/ResultLogger.ts
@@ -53,7 +53,8 @@ export class ConsoleResultLogger implements ResultLogger {
     this.#log_parameters(chapter.request?.parameters ?? {})
     this.#log_request_body(chapter.request?.request_body)
     this.#log_status(chapter.response?.status)
-    this.#log_payload(chapter.response?.payload)
+    this.#log_payload_body(chapter.response?.payload_body)
+    this.#log_payload_schema(chapter.response?.payload_schema)
   }
 
   #log_parameters (parameters: Record<string, Evaluation>): void {
@@ -75,9 +76,14 @@ export class ConsoleResultLogger implements ResultLogger {
     this.#log_evaluation(evaluation, 'RESPONSE STATUS', this._tab_width * 3)
   }
 
-  #log_payload (evaluation: Evaluation | undefined): void {
+  #log_payload_body (evaluation: Evaluation | undefined): void {
     if (evaluation == null) return
-    this.#log_evaluation(evaluation, 'RESPONSE PAYLOAD', this._tab_width * 3)
+    this.#log_evaluation(evaluation, 'RESPONSE PAYLOAD BODY', this._tab_width * 3)
+  }
+
+  #log_payload_schema (evaluation: Evaluation | undefined): void {
+    if (evaluation == null) return
+    this.#log_evaluation(evaluation, 'RESPONSE PAYLOAD SCHEMA', this._tab_width * 3)
   }
 
   #log_evaluation (evaluation: Evaluation, title: string, prefix: number = 0): void {

--- a/tools/src/tester/types/eval.types.ts
+++ b/tools/src/tester/types/eval.types.ts
@@ -32,7 +32,8 @@ export interface ChapterEvaluation {
   }
   response?: {
     status: Evaluation
-    payload: Evaluation
+    payload_body: Evaluation,
+    payload_schema: Evaluation
   }
   output_values?: EvaluationWithOutput
 }

--- a/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
+++ b/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
@@ -27,7 +27,9 @@ chapters:
         message: 'Expected status 200, but received 404: application/json. no such index
           [undefined]'
         error: Request failed with status code 404
-      payload:
+      payload_body:
+        result: SKIPPED
+      payload_schema:
         result: SKIPPED
   - title: This chapter should be skipped.
     overall:

--- a/tools/tests/tester/fixtures/evals/failed/invalid_data.yaml
+++ b/tools/tests/tester/fixtures/evals/failed/invalid_data.yaml
@@ -20,7 +20,9 @@ chapters:
     response:
       status:
         result: PASSED
-      payload:
+      payload_body:
+        result: PASSED
+      payload_schema:
         result: PASSED
   - title: This chapter should fail because the request body is invalid.
     overall:
@@ -35,9 +37,11 @@ chapters:
     response:
       status:
         result: PASSED
-      payload:
+      payload_body:
         result: PASSED
-  - title: This chapter should fail because the response is invalid.
+      payload_schema:
+        result: PASSED
+  - title: This chapter should fail because the response data and schema are invalid.
     overall:
       result: FAILED
     request:
@@ -49,7 +53,10 @@ chapters:
     response:
       status:
         result: PASSED
-      payload:
+      payload_body:
+        result: FAILED
+        message: expected acknowledged='false', got 'true', missing shards_acknowledged='true'
+      payload_schema:
         result: FAILED
         message: data must NOT have additional properties
 

--- a/tools/tests/tester/fixtures/evals/failed/not_found.yaml
+++ b/tools/tests/tester/fixtures/evals/failed/not_found.yaml
@@ -26,7 +26,9 @@ chapters:
     response:
       status:
         result: PASSED
-      payload:
+      payload_body:
+        result: PASSED
+      payload_schema:
         result: PASSED
   - title: This chapter should fail because the request body is not defined in the spec.
     overall:
@@ -41,7 +43,9 @@ chapters:
     response:
       status:
         result: PASSED
-      payload:
+      payload_body:
+        result: PASSED
+      payload_schema:
         result: PASSED
   - title: This chapter should fail because the response is not defined in the spec.
     overall:
@@ -55,7 +59,9 @@ chapters:
     response:
       status:
         result: PASSED
-      payload:
+      payload_body:
+        result: PASSED
+      payload_schema:
         result: FAILED
         message: 'Schema for "404: application/json" response not found in the spec.'
 

--- a/tools/tests/tester/fixtures/evals/passed.yaml
+++ b/tools/tests/tester/fixtures/evals/passed.yaml
@@ -19,7 +19,9 @@ chapters:
     response:
       status:
         result: PASSED
-      payload:
+      payload_body:
+        result: PASSED
+      payload_schema:
         result: PASSED
 
 epilogues:

--- a/tools/tests/tester/fixtures/stories/failed/invalid_data.yaml
+++ b/tools/tests/tester/fixtures/stories/failed/invalid_data.yaml
@@ -22,7 +22,7 @@ chapters:
     request_body:
       payload:
         aliases: {}
-  - synopsis: This chapter should fail because the response is invalid.
+  - synopsis: This chapter should fail because the response data and schema are invalid.
     path: /{index}
     method: DELETE
     parameters:
@@ -30,4 +30,5 @@ chapters:
     response:
       status: 200
       payload:
+        acknowledged: false
         shards_acknowledged: true

--- a/tools/tests/tester/helpers.ts
+++ b/tools/tests/tester/helpers.ts
@@ -90,7 +90,8 @@ export function flatten_errors (evaluation: StoryEvaluation): StoryEvaluation {
       response: c.response !== undefined
         ? {
           status: flatten(c.response.status),
-          payload: flatten(c.response.payload)
+          payload_body: flatten(c.response.payload_body),
+          payload_schema: flatten(c.response.payload_schema)
         }
         : undefined
     })) as T


### PR DESCRIPTION
### Description

We already specify a payload in some tests, but we don't check the values, only the schema.

```
  - synopsis: Get server info (pretty=false).
    path: /
    method: GET
    parameters:
      pretty: false
    response:
      status: 200
      payload:
        version:
          distribution: opensearchX
        tagline: 'The OpenSearch Project: https://opensearch.org/.'
        x: y
```

The above will fail as follows.

```
FAILED  Test root endpoint. (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tests/_core/info.yaml)
    FAILED  CHAPTERS 
        PASSED  Get server info. 
            PASSED  REQUEST BODY 
            PASSED  RESPONSE STATUS 
            PASSED  RESPONSE PAYLOAD BODY 
            PASSED  RESPONSE PAYLOAD SCHEMA 
        FAILED  Get server info (pretty=false). 
            PASSED  PARAMETERS 
                PASSED  pretty 
            PASSED  REQUEST BODY 
            PASSED  RESPONSE STATUS 
            FAILED  RESPONSE PAYLOAD BODY (expected version.distribution='opensearchX', got 'opensearch', expected tagline='The OpenSearch Project: https://opensearch.org/.', got 'The OpenSearch Project: https://opensearch.org/', missing x=y)
            PASSED  RESPONSE PAYLOAD SCHEMA 

```

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/issues/330.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
