### PR TITLE
Makes source field in InlineGet optional

### DIFF
--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -1255,7 +1255,6 @@ components:
           type: object
       required:
         - found
-        - _source
     IndexAlias:
       type: string
     ErrorResponseBase:


### PR DESCRIPTION
This addresses the bug in [#1042](https://github.com/opensearch-project/opensearch-java/issues/1042)

Developer's Certificate of Origin 1.1
By making a contribution to this project, I certify that:
(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or
(b) The contribution is based upon previous work that, to the
    best of my knowledge, is covered under an appropriate open
    source license and I have the right under that license to
    submit that work with modifications, whether created in whole
    or in part by me, under the same open source license (unless
    I am permitted to submit under a different license), as
    Indicated in the file; or
(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.
(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including
    all personal information I submit with it, including my
    sign-off) is maintained indefinitely and may be redistributed
    consistent with this project or the open source license(s)
    involved.

Signed-off-by: Brendon Faleiro <bren.faleiro@gmail.com>
