### PR TITLE
Added text/plain responses to cat APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for testing `application/x-ndjson` payloads ([#355](https://github.com/opensearch-project/opensearch-api-specification/pull/355))
 - Added SPECIFICATION_TESTING.md [#359](https://github.com/opensearch-project/opensearch-api-specification/pull/359)
 - Added StoryValidator to validate stories before running them ([#354](https://github.com/opensearch-project/opensearch-api-specification/issues/354))
+- Added support for `text/plain` responses in `_cat` APIs ([#360](https://github.com/opensearch-project/opensearch-api-specification/pull/360))
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@eslint/js": "^9.1.1",
         "@stylistic/eslint-plugin": "^2.3.0",
         "@types/jest": "^29.5.12",
+        "@types/qs": "^6.9.15",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "ajv-errors": "^3.0.0",
         "eslint": "^8.57.0",
@@ -42,6 +43,7 @@
         "jest": "^29.7.0",
         "json-diff-ts": "^4.0.1",
         "json-schema-to-typescript": "^14.0.4",
+        "qs": "^6.12.1",
         "ts-jest": "^29.1.2"
       }
     },
@@ -2402,6 +2404,12 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -7436,6 +7444,21 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
+    },
+    "node_modules/qs": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@eslint/js": "^9.1.1",
     "@stylistic/eslint-plugin": "^2.3.0",
     "@types/jest": "^29.5.12",
+    "@types/qs": "^6.9.15",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "ajv-errors": "^3.0.0",
     "eslint": "^8.57.0",
@@ -51,6 +52,7 @@
     "jest": "^29.7.0",
     "json-diff-ts": "^4.0.1",
     "json-schema-to-typescript": "^14.0.4",
+    "qs": "^6.12.1",
     "ts-jest": "^29.1.2"
   }
 }

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -789,6 +789,8 @@ components:
     cat.aliases@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -797,6 +799,8 @@ components:
     cat.all_pit_segments@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -805,6 +809,8 @@ components:
     cat.allocation@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -815,6 +821,8 @@ components:
     cat.count@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -823,6 +831,8 @@ components:
     cat.fielddata@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -831,6 +841,8 @@ components:
     cat.health@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -845,6 +857,8 @@ components:
     cat.indices@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -853,6 +867,8 @@ components:
     cat.master@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -861,6 +877,8 @@ components:
     cat.nodeattrs@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -869,6 +887,8 @@ components:
     cat.nodes@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -877,6 +897,8 @@ components:
     cat.pending_tasks@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -885,6 +907,8 @@ components:
     cat.pit_segments@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -893,6 +917,8 @@ components:
     cat.plugins@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -901,6 +927,8 @@ components:
     cat.recovery@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -909,6 +937,8 @@ components:
     cat.repositories@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -917,6 +947,8 @@ components:
     cat.segment_replication@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -925,6 +957,8 @@ components:
     cat.segments@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -933,6 +967,8 @@ components:
     cat.shards@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -941,6 +977,8 @@ components:
     cat.snapshots@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -949,6 +987,8 @@ components:
     cat.tasks@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -957,6 +997,8 @@ components:
     cat.templates@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -965,6 +1007,8 @@ components:
     cat.thread_pool@200:
       description: ''
       content:
+        text/plain:
+          type: string
         application/json:
           schema:
             type: array
@@ -1009,9 +1053,9 @@ components:
       in: query
       description: Return help information.
       schema:
+        description: Return help information.
         type: boolean
         default: false
-        description: Return help information.
     cat.aliases::query.local:
       name: local
       in: query

--- a/tests/cat/aliases.yaml
+++ b/tests/cat/aliases.yaml
@@ -1,0 +1,19 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: Test cat/aliases endpoints.
+chapters:
+  - synopsis: Cat with a text response.
+    path: /_cat/aliases
+    method: GET
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Cat with a json response.
+    path: /_cat/aliases
+    parameters:
+      format: json
+    method: GET
+    response:
+      status: 200
+      content_type: application/json
+      payload: []

--- a/tests/cat/health.yaml
+++ b/tests/cat/health.yaml
@@ -1,0 +1,58 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: Test cat/health endpoints.
+chapters:
+  - synopsis: Cat with a default text response.
+    method: GET
+    path: /_cat/health
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Cat with verbose output (v=true).
+    method: GET
+    path: /_cat/health
+    parameters:
+      v: true
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Cat with headers (h=header1,header2).
+    method: GET
+    path: /_cat/health
+    parameters:
+      h:
+        - status
+        - timestamp
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Cat displaying all available headers (help=true).
+    method: GET
+    path: /_cat/health
+    parameters:
+      help: true
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Cat with sorted results.
+    method: GET
+    path: /_cat/health
+    parameters:
+      s:
+        - status
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Cat with a json response.
+    method: GET
+    path: /_cat/health
+    parameters:
+      format: json
+    response:
+      status: 200
+      content_type: application/json
+      payload:
+        - node.total: '1'
+          status: yellow
+          node.data: '1'
+          discovered_cluster_manager: 'true'

--- a/tools/src/tester/ChapterReader.ts
+++ b/tools/src/tester/ChapterReader.ts
@@ -12,6 +12,7 @@ import { type OpenSearchHttpClient } from '../OpenSearchHttpClient'
 import { type StoryOutputs } from './StoryOutputs'
 import { Logger } from 'Logger'
 import { to_json, to_ndjson } from '../helpers'
+import qs from 'qs'
 
 export default class ChapterReader {
   private readonly _client: OpenSearchHttpClient
@@ -37,7 +38,10 @@ export default class ChapterReader {
       method: chapter.method,
       headers: { 'Content-Type' : content_type },
       params,
-      data: request_data
+      data: request_data,
+      paramsSerializer: (params) => { // eslint-disable-line @typescript-eslint/naming-convention
+        return qs.stringify(params, { arrayFormat: 'comma' })
+      }
     }).then(r => {
       this.logger.info(`<= ${r.status} (${r.headers['content-type']}) | ${to_json(r.data)}`)
       response.status = r.status

--- a/tools/tests/tester/ChapterReader.test.ts
+++ b/tools/tests/tester/ChapterReader.test.ts
@@ -48,7 +48,14 @@ describe('ChapterReader', () => {
 
     expect(result).toEqual({ status: 200, content_type: 'application/json', payload: undefined })
     expect(mocked_axios.request.mock.calls).toEqual([
-      [{ url: 'path', method: 'GET', headers: { 'Content-Type': 'application/json' }, params: {}, data: undefined }]
+      [{
+        url: 'path',
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        params: {},
+        paramsSerializer: expect.any(Function),
+        data: undefined
+      }]
     ])
   })
 
@@ -64,8 +71,41 @@ describe('ChapterReader', () => {
 
     expect(result).toEqual({ status: 200, content_type: 'application/json', payload: undefined })
     expect(mocked_axios.request.mock.calls).toEqual([
-      [{ url: 'books/path', method: 'GET', headers: { 'Content-Type': 'application/json' }, params: {}, data: undefined }]
+      [{
+        url: 'books/path',
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        params: {},
+        paramsSerializer: expect.any(Function),
+        data: undefined
+      }]
     ])
+  })
+
+  it('resolves array parameters', async () => {
+    const result = await reader.read({
+      id: 'id',
+      path: '/path',
+      method: 'GET',
+      parameters: { indexes: ['book1', 'book2'] },
+      request_body: undefined,
+      output: undefined
+    }, new StoryOutputs())
+
+    expect(result).toEqual({ status: 200, content_type: 'application/json', payload: undefined })
+    expect(mocked_axios.request.mock.calls).toEqual([
+      [{
+        url: '/path',
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        params: { indexes: ['book1', 'book2'] },
+        paramsSerializer: expect.any(Function),
+        data: undefined
+      }]
+    ])
+
+    const call = mocked_axios.request.mock.calls[0][0] as any
+    expect(call.paramsSerializer(call.params)).toEqual(`indexes=${encodeURIComponent('book1,book2')}`)
   })
 
   it('sends a POST request', async () => {
@@ -80,7 +120,14 @@ describe('ChapterReader', () => {
 
     expect(result).toEqual({ status: 200, content_type: 'application/json', payload: undefined })
     expect(mocked_axios.request.mock.calls).toEqual([
-      [{ url: 'path', method: 'POST', headers: { 'Content-Type': 'application/json' }, params: { 'x': 1 }, data: { 'body': 'present' } }]
+      [{
+        url: 'path',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        params: { 'x': 1 },
+        paramsSerializer: expect.any(Function),
+        data: { 'body': 'present' }
+      }]
     ])
   })
 
@@ -99,7 +146,14 @@ describe('ChapterReader', () => {
 
     expect(result).toEqual({ status: 200, content_type: 'application/json', payload: undefined })
     expect(mocked_axios.request.mock.calls).toEqual([
-      [{ url: 'path', method: 'POST', headers: { 'Content-Type': 'application/x-ndjson' }, params: { 'x': 1 }, data: "{\"body\":\"present\"}\n" }]
+      [{
+        url: 'path',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-ndjson' },
+        params: { 'x': 1 },
+        paramsSerializer: expect.any(Function),
+        data: "{\"body\":\"present\"}\n"
+      }]
     ])
   })
 })


### PR DESCRIPTION
### Description

- Adds text/plain response types to `cat` APIs.
- Fixes passing array parameters such as `h=status,timestamp` by serializing them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
