### PR TITLE
add test for search with seq_no_primary_term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added SPECIFICATION_TESTING.md [#359](https://github.com/opensearch-project/opensearch-api-specification/pull/359)
 - Added StoryValidator to validate stories before running them ([#354](https://github.com/opensearch-project/opensearch-api-specification/issues/354))
 - Added support for `text/plain` responses in `_cat` APIs ([#360](https://github.com/opensearch-project/opensearch-api-specification/pull/360))
+- Added test for search with seq_no_primary_term ([#367](https://github.com/opensearch-project/opensearch-api-specification/pull/367))
 
 ### Changed
 

--- a/tests/_core/search.yaml
+++ b/tests/_core/search.yaml
@@ -96,3 +96,25 @@ chapters:
     method: POST
     response:
       status: 200
+  - synopsis: Search with seq_no_primary_term.
+    path: /{index}/_search
+    parameters:
+      index: movies
+      seq_no_primary_term: true
+    method: POST
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 1
+            relation: eq
+          hits:
+            - _index: movies
+              _source:
+                director: Bennett Miller
+                title: Moneyball
+                year: 2011
+              _seq_no: 0
+              _primary_term: 1


### PR DESCRIPTION
### Description
Add test spec for search with the `seq_no_primary_term` param as suggested by @dblock here: https://github.com/opensearch-project/opensearch-go/pull/574#issuecomment-2195683900

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
