### PR TITLE
Fix: bulk response _source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `/_cat/cluster_manager`, `/_cat/allocation`, `/_cat/shards`, and `/_cat/thread_pool` ([#373](https://github.com/opensearch-project/opensearch-api-specification/pull/373))
 - Fixed optional field in `/_nodes` ([#365](https://github.com/opensearch-project/opensearch-api-specification/pull/365))
 - Fixed `/{index}/_open` can return a `task` ([#376](https://github.com/opensearch-project/opensearch-api-specification/pull/376))
- 
+- Fixed `_source` in `bulk` responses ([#375](https://github.com/opensearch-project/opensearch-api-specification/pull/375))
+
 ### Security
 
 [Unreleased]: https://github.com/opensearch-project/opensearch-api-specification/commits/main/

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -671,11 +671,9 @@ components:
           $ref: '#/components/schemas/Routing'
         _source:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
       required:
         - found
-        - _source
     Names:
       oneOf:
         - $ref: '#/components/schemas/Name'
@@ -1256,7 +1254,6 @@ components:
           type: object
       required:
         - found
-        - _source
     IndexAlias:
       type: string
     ErrorResponseBase:

--- a/tests/_core/bulk.yaml
+++ b/tests/_core/bulk.yaml
@@ -12,18 +12,23 @@ chapters:
     request_body:
       content_type: application/x-ndjson
       payload:
-        - {create: {_index: movies}}
-        - {director: Bennett Miller, title: Moneyball, year: 2011}
+        - { create: { _index: movies } }
+        - { director: Bennett Miller, title: Moneyball, year: 2011 }
   - synopsis: Bulk document CRUD.
     path: /_bulk
     method: POST
     request_body:
       content_type: application/x-ndjson
       payload:
-        - {create: {_index: books, _id: book_1392214}}
-        - {author: Harper Lee, title: To Kill a Mockingbird, year: 1960}
-        - {update: {_index: books, _id: book_1392214}}
-        - {doc: {pages: 376}}
-        - {update: {_index: books, _id: book_1392214}}
-        - {script: {source: 'ctx._source.pages = 376;'}}
-        - {delete: {_index: books, _id: book_1392214}}
+        - { create: { _index: books, _id: book_1392214 } }
+        - { author: Harper Lee, title: To Kill a Mockingbird, year: 1960 }
+        - { update: { _index: books, _id: book_1392214 } }
+        - { doc: { pages: 376 } }
+        - { update: { _index: books, _id: book_1392214 } }
+        - { doc: { pages: 376 }, _source: true }
+        - { update: { _index: books, _id: book_1392214 } }
+        - { script: { source: 'ctx._source.pages = 376;' } }
+        - { update: { _index: books, _id: does_not_exist } }
+        - { script: { source: 'ctx.op = "none";' }, scripted_upsert: true, upsert: { pages: 375 } }
+        - { delete: { _index: books, _id: book_1392214 } }
+


### PR DESCRIPTION
### Description

Two bugs fixed here.

1. The value of `_source` is a document, so it is `additionalProperties: true`, not a set of objects.
    ```
    - { doc: { pages: 376 }, _source: true }
    - { update: { _index: books, _id: book_1392214 } }
    ```
2. In a `scripted_upsert` a document may not be found, therefore not returning `_source`. There was an attempt to fix this in https://github.com/opensearch-project/opensearch-api-specification/pull/351, this PR replaces that one.
    ```
    - { update: { _index: books, _id: does_not_exist } }
    - { script: { source: 'ctx.op = "none";' }, scripted_upsert: true, upsert: { pages: 375 } }
    ```

Full response.

```json
{
      "update": {
        "_index": "books",
        "_id": "book_1392214",
        "_version": 2,
        "result": "noop",
        "_shards": {
          "total": 2,
          "successful": 1,
          "failed": 0
        },
        "_seq_no": 1,
        "_primary_term": 1,
        "get": {
          "_seq_no": 1,
          "_primary_term": 1,
          "found": true,
          "_source": {
            "author": "Harper Lee",
            "title": "To Kill a Mockingbird",
            "year": 1960,
            "pages": 376
          }
        },
        "status": 200
      }
    }
```

Without a `_source`.

```json
{
      "update": {
        "_index": "books",
        "_id": "does_not_exist",
        "_version": -1,
        "result": "noop",
        "_shards": {
          "total": 2,
          "successful": 1,
          "failed": 0
        },
        "get": {
          "found": false
        },
        "status": 200
      }
    }
```

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/issues/350.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
