### PR TITLE
Fix: cat the alias we are looking for.

### DIFF
--- a/tests/cat/aliases.yaml
+++ b/tests/cat/aliases.yaml
@@ -23,9 +23,12 @@ chapters:
       status: 200
       content_type: text/plain
   - synopsis: Cat with a json response.
-    path: /_cat/aliases
+    path: /_cat/aliases/{name}
     parameters:
       format: json
+      name: je*
+      expand_wildcards: all
+      local: true
     method: GET
     response:
       status: 200


### PR DESCRIPTION
### Description

If you have existing aliases in a local OpenSearch this test will start failing. Make it more reliably by specifying which alias we're looking for. We're already testing `/_cat/aliases` without an alias above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
