### PR TITLE
Fix: make results logger errors manageable.

### DIFF
--- a/tools/src/tester/ResultLogger.ts
+++ b/tools/src/tester/ResultLogger.ts
@@ -90,7 +90,9 @@ export class ConsoleResultLogger implements ResultLogger {
 
   #log_evaluation (evaluation: Evaluation, title: string, prefix: number = 0): void {
     const result = ansi.padding(this.#result(evaluation.result), 0, prefix)
-    const message = evaluation.message != null ? `${ansi.gray('(' + evaluation.message + ')')}` : ''
+    var message = evaluation.message
+    if (message !== undefined && message?.length > 128 && !this._verbose) message = message.split(',')[0] + ', ...'
+    if (message !== undefined) message = ansi.gray(`${message}`)
     console.log(`${result} ${title} ${message}`)
   }
 


### PR DESCRIPTION
### Description

When the number of errors is high the results logger spews pages of them. This cuts down the list.

Before:

```
FAILED  RESPONSE PAYLOAD SCHEMA (data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/ignore_above property is not defined in the spec, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/type must be equal to one of the allowed values, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/ignore_above property is not defined in the spec, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/type must be equal to one of the allowed values, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/ignore_above property is not defined in the spec, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/type must be equal to one of the allowed values, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/ignore_above property is not defined in the spec, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/type must be equal to one of the allowed values, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/ignore_above property is not defined in the spec, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/ignore_above property is not defined in the spec, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/type must be equal to one of the allowed values, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/ignore_above property is not defined in the spec, data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/t

... many many lines
```

After:

```
FAILED  RESPONSE PAYLOAD SCHEMA data/security-auditlog-2024.07.03/mappings/properties/audit_category/fields/keyword/ignore_above property is not defined in the spec, ...
```

Not sure how it interacts with @nhtruong's #378, can wait for that to be merged or not. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
