### PR TITLE
Run linter on all relevant file changes.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - '**/*.yaml'
+      - '**/*.ts'
+  pull_request:
+    branches: ['**']
+    paths:
+      - '**/*.yaml'
+      - '**/*.ts'
+  
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/test-tools-unit.yml
+++ b/.github/workflows/test-tools-unit.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Lint
-        run: npm run lint
-
       - name: Tests
         run: |
           npm run test:unit -- --coverage

--- a/tests/_core/bulk.yaml
+++ b/tests/_core/bulk.yaml
@@ -12,23 +12,23 @@ chapters:
     request_body:
       content_type: application/x-ndjson
       payload:
-        - { create: { _index: movies } }
-        - { director: Bennett Miller, title: Moneyball, year: 2011 }
+        - {create: {_index: movies}}
+        - {director: Bennett Miller, title: Moneyball, year: 2011}
   - synopsis: Bulk document CRUD.
     path: /_bulk
     method: POST
     request_body:
       content_type: application/x-ndjson
       payload:
-        - { create: { _index: books, _id: book_1392214 } }
-        - { author: Harper Lee, title: To Kill a Mockingbird, year: 1960 }
-        - { update: { _index: books, _id: book_1392214 } }
-        - { doc: { pages: 376 } }
-        - { update: { _index: books, _id: book_1392214 } }
-        - { doc: { pages: 376 }, _source: true }
-        - { update: { _index: books, _id: book_1392214 } }
-        - { script: { source: 'ctx._source.pages = 376;' } }
-        - { update: { _index: books, _id: does_not_exist } }
-        - { script: { source: 'ctx.op = "none";' }, scripted_upsert: true, upsert: { pages: 375 } }
-        - { delete: { _index: books, _id: book_1392214 } }
+        - {create: {_index: books, _id: book_1392214}}
+        - {author: Harper Lee, title: To Kill a Mockingbird, year: 1960}
+        - {update: {_index: books, _id: book_1392214}}
+        - {doc: {pages: 376}}
+        - {update: {_index: books, _id: book_1392214}}
+        - {doc: {pages: 376}, _source: true}
+        - {update: {_index: books, _id: book_1392214}}
+        - {script: {source: 'ctx._source.pages = 376;'}}
+        - {update: {_index: books, _id: does_not_exist}}
+        - {script: {source: 'ctx.op = "none";'}, scripted_upsert: true, upsert: {pages: 375}}
+        - {delete: {_index: books, _id: book_1392214}}
 


### PR DESCRIPTION
### Description

We were a little conservative on running the linter to errors in bulk.yaml slipped through.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
