### PR TITLE
Fix: GET _mapping with index in query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `Metadata` schema ([#399](https://github.com/opensearch-project/opensearch-api-specification/pull/399))
 - Fixed `/_data_stream` health status and required fields ([#401](https://github.com/opensearch-project/opensearch-api-specification/pull/401))
 - Fixed query DSL `match` that supports a field name and value ([#405](https://github.com/opensearch-project/opensearch-api-specification/pull/405)) 
+- Fixed `/_mapping` with `index` in query ([#385](https://github.com/opensearch-project/opensearch-api-specification/pull/385))
 
 ### Security
 

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -418,6 +418,7 @@ paths:
         - $ref: '#/components/parameters/indices.get_mapping::query.cluster_manager_timeout'
         - $ref: '#/components/parameters/indices.get_mapping::query.expand_wildcards'
         - $ref: '#/components/parameters/indices.get_mapping::query.ignore_unavailable'
+        - $ref: '#/components/parameters/indices.get_mapping::query.index'
         - $ref: '#/components/parameters/indices.get_mapping::query.local'
         - $ref: '#/components/parameters/indices.get_mapping::query.master_timeout'
       responses:
@@ -1302,6 +1303,7 @@ paths:
         - $ref: '#/components/parameters/indices.get_mapping::query.cluster_manager_timeout'
         - $ref: '#/components/parameters/indices.get_mapping::query.expand_wildcards'
         - $ref: '#/components/parameters/indices.get_mapping::query.ignore_unavailable'
+        - $ref: '#/components/parameters/indices.get_mapping::query.index'
         - $ref: '#/components/parameters/indices.get_mapping::query.local'
         - $ref: '#/components/parameters/indices.get_mapping::query.master_timeout'
       responses:
@@ -3828,6 +3830,17 @@ components:
       schema:
         type: boolean
       style: form
+    indices.get_mapping::query.index:
+      in: query
+      name: index
+      description: |-
+        Comma-separated list of data streams, indices, and aliases used to limit the request.
+        Supports wildcards (`*`).
+        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+      required: true
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
+      style: simple
     indices.get_mapping::query.local:
       in: query
       name: local

--- a/tests/_core/mapping.yaml
+++ b/tests/_core/mapping.yaml
@@ -1,0 +1,54 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: Test mappings endpoints.
+prologues:
+  - path: /{index}
+    method: PUT
+    parameters:
+      index: movies
+    request_body:
+      payload:
+        mappings:
+          properties:
+            director:
+              type: text
+            year:
+              type: integer
+            location:
+              type: ip
+              ignore_malformed: true
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Get mappings for an index (index in query).
+    path: /_mapping
+    method: GET
+    parameters:
+      index: movies
+    response:
+      status: 200
+      payload:
+        movies:
+          mappings:
+            properties:
+              director:
+                type: text
+              year:
+                type: integer
+  - synopsis: Get mappings for an index (index in path).
+    path: /{index}/_mapping
+    method: GET
+    parameters:
+      index: movies
+    response:
+      status: 200
+      payload:
+        movies:
+          mappings:
+            properties:
+              director:
+                type: text
+              year:
+                type: integer


### PR DESCRIPTION
### Description

OpenSearch supports `GET _mapping?index=...`. If you specify it both on the path and query the query is ignored.

```
$ curl -u admin:$OPENSEARCH_PASSWORD -k https://localhost:9200/_mapping?index=games | jq

{
  "games": {
    "mappings": {}
  }
}
```

```
$ curl --silent -u admin:$OPENSEARCH_PASSWORD -k https://localhost:9200/games/_mapping?index=foobars | jq
{
  "games": {
    "mappings": {}
  }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
