### PR TITLE
Added tests for index mapping.

### DIFF
--- a/tests/indices/mapping.yml
+++ b/tests/indices/mapping.yml
@@ -1,0 +1,80 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: Test mappings endpoints.
+prologues:
+  - path: /{index}
+    method: PUT
+    parameters:
+      index: games
+  - path: /{index}
+    method: PUT
+    parameters:
+      index: movies
+    request_body:
+      payload:
+        mappings:
+          properties:
+            director:
+              type: text
+            year:
+              type: integer
+            location:
+              type: ip
+              ignore_malformed: true
+epilogues:
+  - path: /movies,games
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Get mappings for an index.
+    path: /{index}/_mapping
+    method: GET
+    parameters:
+      index: movies
+    response:
+      status: 200
+      payload:
+        movies:
+          mappings:
+            properties:
+              director:
+                type: text
+              year:
+                type: integer
+  - synopsis: Get mappings for multiple indices.
+    path: /{index}/_mapping
+    method: GET
+    parameters:
+      index: movies,games
+    response:
+      status: 200
+      payload:
+        movies:
+          mappings:
+            properties:
+              director:
+                type: text
+              year:
+                type: integer
+        games:
+          mappings: {}
+  - synopsis: Update mapping for an index.
+    path: /{index}/_mapping
+    method: PUT
+    parameters:
+      index: movies
+      allow_no_indices: true
+      expand_wildcards: none
+      ignore_unavailable: true
+      cluster_manager_timeout: 1s
+      timeout: 10s
+      write_index_only: true
+    request_body:
+      payload:
+        properties:
+          producer:
+            type: text
+    response:
+      status: 200
+      payload:
+        acknowledged: true


### PR DESCRIPTION
### Description

This is a subset of #385, just the tests for working `/{index}/_mapping`. 

Found and fixed a bug in the documentation when trying to use `ignore_malformed` in the query string: https://github.com/opensearch-project/documentation-website/pull/7652.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
