### PR TITLE
Added missing fields to index stats.

### DIFF
--- a/.cspell
+++ b/.cspell
@@ -53,6 +53,7 @@ authinfo
 authtoken
 autocut
 backendroles
+backpressure
 beider
 boxplot
 caverphone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a linter for parameter sorting ([#369](https://github.com/opensearch-project/opensearch-api-specification/pull/369))
 - Added support for `application/cbor` responses ([#371](https://github.com/opensearch-project/opensearch-api-specification/pull/371))
 - Added support for `application/smile` responses ([#386](https://github.com/opensearch-project/opensearch-api-specification/pull/386))
- 
+- Added `doc_status`, `remote_store`, `segment_replication` and `unreferenced_file_cleanups_performed` to `SegmentStats` ([#395](https://github.com/opensearch-project/opensearch-api-specification/pull/395))
+- Added `concurrent_query_*` and `search_idle_reactivate_count_total` fields to `SearchStats` ([#395](https://github.com/opensearch-project/opensearch-api-specification/pull/395))
+- Added `remote_store` to `TranslogStats` ([#395](https://github.com/opensearch-project/opensearch-api-specification/pull/395))
+
 ### Changed
 
 - Replaced Smithy with a native OpenAPI spec ([#189](https://github.com/opensearch-project/opensearch-api-specification/issues/189))

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -16,6 +16,21 @@ components:
           type: boolean
       required:
         - acknowledged
+    DocStatus:
+      description: |-
+        Item level REST category class codes during indexing.
+      type: object
+      properties:
+        1xx:
+          type: number
+        2xx:
+          type: number
+        3xx:
+          type: number
+        4xx:
+          type: number
+        5xx:
+          type: number
     Duration:
       description: |-
         A duration. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and
@@ -978,6 +993,156 @@ components:
         - memory_size_in_bytes
         - miss_count
         - total_count
+    RemoteStoreStats:
+      type: object
+      description: Statistics about remote segment store operations.
+      properties:
+        upload:
+          $ref: '#/components/schemas/RemoteStoreUploadStats'
+        download:
+          $ref: '#/components/schemas/RemoteStoreDownloadStats'
+      required:
+        - upload
+        - download
+    RemoteStoreTranslogStats:
+      type: object
+      properties:
+        upload:
+          $ref: '#/components/schemas/RemoteStoreTranslogUploadStats'
+      required:
+        - upload
+    RemoteStoreTranslogUploadStats:
+      type: object
+      description: Statistics related to uploads to the remote translog store.
+      properties:
+        total_uploads:
+          $ref: '#/components/schemas/RemoteStoreTranslogUploadTotalUploadsStats'
+        total_upload_size:
+          $ref: '#/components/schemas/RemoteStoreTranslogUploadTotalUploadSizeStats'
+      required:
+        - total_uploads
+        - total_upload_size
+    RemoteStoreTranslogUploadTotalUploadsStats:
+      type: object
+      description: The number of syncs to the remote translog store.
+      properties:
+        failed:
+          description: The number of failed upload syncs to the remote translog store.
+          type: number
+        started:
+          description: The number of upload syncs to the remote translog store that have started.
+          type: number
+        succeeded:
+          description: The number of successful upload syncs to the remote translog store.
+          type: number
+      required:
+        - failed
+        - started
+        - succeeded
+    RemoteStoreTranslogUploadTotalUploadSizeStats:
+      type: object
+      description: The total amount of data uploaded to the remote translog store.
+      properties:
+        failed_bytes:
+          description: The number of bytes that failed to upload to the remote translog store.
+          $ref: '#/components/schemas/ByteSize'
+        started_bytes:
+          description: The number of bytes successfully uploaded to the remote translog store.
+          $ref: '#/components/schemas/ByteSize'
+        succeeded_bytes:
+          description: The number of bytes successfully uploaded to the remote translog store.
+          $ref: '#/components/schemas/ByteSize'
+      required:
+        - failed_bytes
+        - started_bytes
+        - succeeded_bytes
+    RemoteStoreUploadStats:
+      type: object
+      description: Statistics related to uploads to the remote segment store.
+      properties:
+        max_refresh_time_lag_in_millis:
+          description: The maximum duration, in milliseconds, that the remote refresh is behind the local refresh.
+          $ref: '#/components/schemas/DurationValueUnitMillis'
+        pressure:
+          $ref: '#/components/schemas/RemoteStoreUploadPressureStats'
+        refresh_size_lag:
+          $ref: '#/components/schemas/RemoteStoreUploadRefreshSizeLagStats'
+        total_time_spent_in_millis:
+          description: The total amount of time, in milliseconds, spent on uploads to the remote segment store.
+          $ref: '#/components/schemas/DurationValueUnitMillis'
+        total_upload_size:
+          $ref: '#/components/schemas/RemoteStoreUploadDownloadStats'
+      required:
+        - max_refresh_time_lag_in_millis
+        - pressure
+        - refresh_size_lag
+        - total_time_spent_in_millis
+        - total_upload_size
+    RemoteStoreUploadDownloadStats:
+      type: object
+      description: The amount of data, in bytes, uploaded or downloaded to/from the remote segment store.
+      properties:
+        failed_bytes:
+          description: The number of bytes that failed to upload/upload to/from the remote segment store.
+          $ref: '#/components/schemas/ByteSize'
+        started_bytes:
+          description: The number of bytes to upload/download to/from the remote segment store after the upload/download has started.
+          $ref: '#/components/schemas/ByteSize'
+        succeeded_bytes:
+          description: The number of bytes successfully uploaded/downloaded to/from the remote segment store.
+          $ref: '#/components/schemas/ByteSize'
+      required:
+        - failed_bytes
+        - started_bytes
+        - succeeded_bytes
+    RemoteStoreUploadPressureStats:
+      type: object
+      description: Statistics related to segment store upload backpressure.
+      properties:
+        total_rejections:
+          description: The total number of requests rejected due to segment store upload backpressure.
+          type: number
+      required:
+        - total_rejections
+    RemoteStoreUploadRefreshSizeLagStats:
+      type: object
+      description: The amount of lag during upload between the remote segment store and the local store.
+      properties:
+        max_bytes:
+          description: The maximum amount of lag, in bytes, during the upload refresh between the remote segment store and the local store.
+          $ref: '#/components/schemas/ByteSize'
+        total_bytes:
+          description: The total number of bytes that lagged during the upload refresh between the remote segment store and the local store.
+          $ref: '#/components/schemas/ByteSize'
+      required:
+        - max_bytes
+        - total_bytes
+    RemoteStoreDownloadStats:
+      type: object
+      description: Statistics related to downloads to the remote segment store.
+      properties:
+        total_download_size:
+          description: The total amount of data download from the remote segment store.
+          $ref: '#/components/schemas/RemoteStoreUploadDownloadStats'
+        total_time_spent_in_millis:
+          description: The total duration, in milliseconds, spent on downloads from the remote segment store.
+          $ref: '#/components/schemas/DurationValueUnitMillis'
+      required:
+        - total_download_size
+        - total_time_spent_in_millis
+    SegmentReplicationStats:
+      type: object
+      properties:
+        max_bytes_behind:
+          $ref: '#/components/schemas/ByteSize'
+        max_replication_lag:
+          $ref: '#/components/schemas/ByteSize'
+        total_bytes_behind:
+          $ref: '#/components/schemas/ByteSize'
+      required:
+        - max_bytes_behind
+        - max_replication_lag
+        - total_bytes_behind
     SegmentsStats:
       type: object
       properties:
@@ -1046,6 +1211,10 @@ components:
         version_map_memory_in_bytes:
           description: Total amount, in bytes, of memory used by all version maps across all shards assigned to selected nodes.
           type: number
+        remote_store:
+          $ref: '#/components/schemas/RemoteStoreStats'
+        segment_replication:
+          $ref: '#/components/schemas/SegmentReplicationStats'
       required:
         - count
         - doc_values_memory_in_bytes
@@ -1365,6 +1534,8 @@ components:
           $ref: '#/components/schemas/DurationValueUnitMillis'
         delete_total:
           type: number
+        doc_status:
+          $ref: '#/components/schemas/DocStatus'
         is_throttled:
           type: boolean
         noop_update_total:
@@ -1433,6 +1604,8 @@ components:
           $ref: '#/components/schemas/Duration'
         total_time_in_millis:
           $ref: '#/components/schemas/DurationValueUnitMillis'
+        unreferenced_file_cleanups_performed:
+          type: number
       required:
         - current
         - current_docs
@@ -1501,39 +1674,83 @@ components:
     SearchStats:
       type: object
       properties:
+        concurrent_query_total:
+          description: The total number of query operations that use concurrent segment search.
+          type: number
+        concurrent_query_time:
+          $ref: '#/components/schemas/Duration'
+        concurrent_query_time_in_millis:
+          description: The total amount of time taken by all query operations that use concurrent segment search, in milliseconds.
+          $ref: '#/components/schemas/DurationValueUnitMillis'
+        concurrent_query_current:
+          description: The number of currently running query operations that use concurrent segment search.
+          type: number
+        concurrent_avg_slice_count:
+          description: The average slice count of all search requests. This is computed as the total slice count divided by the total number of concurrent search requests.
+          type: number
         fetch_current:
+          description: The number of shard fetch operations that are currently running.
           type: number
         fetch_time:
+          description: The total amount of time for all shard fetch operations.
           $ref: '#/components/schemas/Duration'
         fetch_time_in_millis:
+          description: The total amount of time for all shard fetch operations, in milliseconds.
           $ref: '#/components/schemas/DurationValueUnitMillis'
         fetch_total:
+          description: The total number of shard fetch operations.
           type: number
         open_contexts:
+          description: The number of open search contexts.
+          type: number
+        point_in_time_total:
+          description: The total number of shard Point in Time (PIT) contexts that have been created (completed and active) since the node last restarted.
+          type: number
+        point_in_time_time:
+          $ref: '#/components/schemas/Duration'
+        point_in_time_time_in_millis:
+          description: The amount of time that shard PIT contexts have been held open since the node last restarted, in milliseconds.
+          $ref: '#/components/schemas/DurationValueUnitMillis'
+        point_in_time_current:
+          description: The number of shard PIT contexts currently open.
           type: number
         query_current:
+          description: The number of shard query operations that are currently running.
           type: number
         query_time:
+          description: The total amount of time for all shard query operations.
           $ref: '#/components/schemas/Duration'
         query_time_in_millis:
+          description: The total amount of time for all shard query operations, in milliseconds.
           $ref: '#/components/schemas/DurationValueUnitMillis'
         query_total:
+          description: The total number of shard query operations.
+          type: number
+        search_idle_reactivate_count_total:
           type: number
         scroll_current:
+          description: The number of shard scroll operations that are currently running.
           type: number
         scroll_time:
+          description: The total amount of time for all shard scroll operations.
           $ref: '#/components/schemas/Duration'
         scroll_time_in_millis:
+          description: The total amount of time for all shard scroll operations, in milliseconds.
           $ref: '#/components/schemas/DurationValueUnitMillis'
         scroll_total:
+          description: The total number of shard scroll operations.
           type: number
         suggest_current:
+          description: The number of shard suggest operations that are currently running.
           type: number
         suggest_time:
+          description: The total amount of time for all shard suggest operations.
           $ref: '#/components/schemas/Duration'
         suggest_time_in_millis:
+          description: The total amount of time for all shard suggest operations, in milliseconds.
           $ref: '#/components/schemas/DurationValueUnitMillis'
         suggest_total:
+          description: The total number of shard suggest operations.
           type: number
         groups:
           type: object
@@ -1559,6 +1776,8 @@ components:
           type: number
         operations:
           type: number
+        remote_store:
+          $ref: '#/components/schemas/RemoteStoreTranslogStats'
         size:
           type: string
         size_in_bytes:

--- a/tests/indices/stats.yaml
+++ b/tests/indices/stats.yaml
@@ -1,0 +1,61 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: Test stats for an index.
+prologues:
+  - path: /movies
+    method: PUT
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Get global stats.
+    path: /_stats
+    method: GET
+    parameters:
+      expand_wildcards: none
+    response:
+      status: 200
+  - synopsis: Get stats for an index.
+    path: /{index}/_stats
+    method: GET
+    parameters:
+      index: movies
+      expand_wildcards: none
+      fields: '*'
+      completion_fields: '*'
+      fielddata_fields: '*'
+      include_segment_file_sizes: true
+      include_unloaded_segments: true
+    response:
+      status: 200
+      payload:
+        _shards: {}
+        _all: {}
+        indices:
+          movies: {}
+  - synopsis: Get a metric stat for an index.
+    path: /{index}/_stats/{metric}
+    method: GET
+    parameters:
+      index: movies
+      metric: docs
+      expand_wildcards: all
+      forbid_closed_indices: false
+      groups: '*'
+      level: indices
+    response:
+      status: 200
+      payload:
+        _shards:
+          failed: 0
+        _all:
+          primaries:
+            docs:
+              count: 0
+              deleted: 0
+        indices:
+          movies:
+            total:
+              docs:
+                count: 0


### PR DESCRIPTION
### Description

- Added `doc_status`, `remote_store`, `segment_replication` and `unreferenced_file_cleanups_performed` to `SegmentStats` 
- Added `concurrent_query_*` and `search_idle_reactivate_count_total` fields to `SearchStats`
- Added `remote_store` to `TranslogStats`

Successfully passes `/_stats` and `/{index}/_stats`.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
