### PR TITLE
Update release description with CHANGELOG and upload an artifact with every build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,42 @@ jobs:
         shell: bash
         run: echo "name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
 
+      - name: Upload Artifacts
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: |
+            build/*
+
       - name: Release Specification to GitHub
+        id: release
         uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: ${{ steps.branch.outputs.name }}-latest
           prerelease: true
           title: OpenSearch OpenAPI Spec (${{ steps.branch.outputs.name }})
           files: |
             LICENSE.txt
             build/*
+
+      - name: Extract Changelog
+        id: changelog
+        uses: sean0x42/markdown-extract@v2
+        with:
+          file: CHANGELOG.md
+          pattern: 'Unreleased'
+
+      - name: Update Release Description
+        id: update
+        uses: tubone24/update_release@v1.3.1
+        env:
+          TAG_NAME: ${{ steps.branch.outputs.name }}-latest
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body: |
+            ${{ steps.changelog.outputs.markdown }}
+
+            ### Links
+            - [Build Artifact](${{ steps.upload.outputs.artifact-url }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 
-- Removed the ability to skip an individual spec test ([#358](https://github.com/opensearch-project/opensearch-api-specification/pull/358)
+- Removed the ability to skip an individual spec test ([#358](https://github.com/opensearch-project/opensearch-api-specification/pull/358))
  
 ### Fixed
 


### PR DESCRIPTION
### Description

Update release description with CHANGELOG, and upload an artifact with every build.

Before:

<img width="950" alt="Screenshot 2024-07-10 at 3 09 00 PM" src="https://github.com/opensearch-project/opensearch-api-specification/assets/542335/5e0eca40-e4e3-4a0e-bdd1-3a29d575bb5b">

After:

https://github.com/dblock/opensearch-api-specification/releases/tag/release-permalink-latest

<img width="307" alt="Screenshot 2024-07-10 at 3 07 41 PM" src="https://github.com/opensearch-project/opensearch-api-specification/assets/542335/606ded92-2c3e-441f-9d06-20d4e5d97578">

Also uploads the build artifacts to the workflow run so it can be downloaded with a permalink if needed.

### Issues Resolved

Closes #380.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
