### PR TITLE
Fix: Metadata schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `/{index}/_open` can return a `task` ([#376](https://github.com/opensearch-project/opensearch-api-specification/pull/376))
 - Fixed `_source` in `bulk` responses ([#375](https://github.com/opensearch-project/opensearch-api-specification/pull/375))
 - Fixed `/{index}/_dangling` that can return `nodes` and `cluster_name` ([#391](https://github.com/opensearch-project/opensearch-api-specification/pull/391))
+- Fixed `Metadata` schema ([#399](https://github.com/opensearch-project/opensearch-api-specification/pull/399))
 
 ### Security
 

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -24,8 +24,7 @@ components:
       type: string
     Metadata:
       type: object
-      additionalProperties:
-        type: object
+      additionalProperties: true
     GeoBounds:
       description: |-
         A geo bounding box. It can be represented in various ways:

--- a/tests/indices/component_template.yaml
+++ b/tests/indices/component_template.yaml
@@ -1,0 +1,111 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: Test component templates.
+epilogues:
+  - path: /logs-2020-01-01
+    method: DELETE
+    status: [200, 404]
+  - path: /_index_template/daily_logs
+    method: DELETE
+    status: [200, 404]
+  - path: /_component_template/component_template1
+    method: DELETE
+    status: [200, 404]
+  - path: /_component_template/component_template2
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create a component template 1.
+    path: /_component_template/{name}
+    method: POST
+    parameters:
+      name: component_template_1
+    request_body:
+      payload:
+        template:
+          mappings:
+            properties:
+              '@timestamp':
+                type: date
+    response:
+      status: 200
+  - synopsis: Get component template 1.
+    path: /_component_template/{name}
+    method: GET
+    parameters:
+      name: component_template_1
+    response:
+      status: 200
+  - synopsis: Create a component template 2.
+    path: /_component_template/{name}
+    method: POST
+    parameters:
+      name: component_template_2
+    request_body:
+      payload:
+        template:
+          mappings:
+            properties:
+              ip_address:
+                type: ip
+    response:
+      status: 200
+  - synopsis: Create an index template composed of 2 component templates.
+    path: /_index_template/{name}
+    method: POST
+    parameters:
+      name: daily_logs
+    request_body:
+      payload:
+        index_patterns:
+          - "logs*"
+        template:
+          aliases:
+            my_logs: {}
+          settings:
+            number_of_shards: 2
+            number_of_replicas: 2
+          mappings:
+            properties:
+              timestamp:
+                type: date
+                format: yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis
+              value:
+                type: double
+        priority: 200
+        composed_of:
+          - component_template_1
+          - component_template_2
+        version: 3
+        _meta:
+          description: Template using component templates.
+    response:
+      status: 200
+  - synopsis: Create an index using the composite template.
+    path: /{index}
+    method: PUT
+    parameters:
+      index: logs-2020-01-01
+    response:
+      status: 200
+  - synopsis: Get an index using the composite template.
+    path: /{index}
+    method: GET
+    parameters:
+      index: logs-2020-01-01
+    response:
+      status: 200
+  - synopsis: Delete index template.
+    path: /_index_template/{name}
+    method: DELETE
+    parameters:
+      name: daily_logs
+    response:
+      status: 200
+  - synopsis: Delete component template 1.
+    path: /_component_template/{name}
+    method: DELETE
+    parameters:
+      name: component_template_1
+    response:
+      status: 200

--- a/tests/indices/index_template.yaml
+++ b/tests/indices/index_template.yaml
@@ -1,0 +1,78 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: Test index templates.
+epilogues:
+  - path: /_index_template/daily_logs
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create an index template.
+    path: /_index_template/{name}
+    method: POST
+    parameters:
+      name: daily_logs
+    request_body:
+      payload:
+        index_patterns:
+          - "logs*"
+        priority: 0
+        template:
+          settings:
+            number_of_shards: 2
+            number_of_replicas: 2
+    response:
+      status: 200
+  - synopsis: Update an index template.
+    path: /_index_template/{name}
+    method: PUT
+    parameters:
+      name: daily_logs
+    request_body:
+      payload:
+        index_patterns:
+          - "logs*"
+        priority: 0
+        template:
+          aliases:
+            my_logs: {}
+          settings:
+            number_of_shards: 4
+            number_of_replicas: 4
+          mappings:
+            properties:
+              timestamp:
+                type: date
+                format: yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis
+              value:
+                type: double
+    response:
+      status: 200
+  - synopsis: Retrieve all index templates.
+    path: /_index_template
+    method: GET
+    response:
+      status: 200
+  - synopsis: Retrieve an index template.
+    path: /_index_template/{name}
+    method: GET
+    parameters:
+      name: daily_logs
+    response:
+      status: 200
+      payload:
+        index_templates:
+          - name: daily_logs
+  - synopsis: Check that an index template exists.
+    path: /_index_template/{name}
+    method: HEAD
+    parameters:
+      name: daily_logs
+    response:
+      status: 200
+  - synopsis: Delete an index template.
+    path: /_index_template/{name}
+    method: DELETE
+    parameters:
+      name: daily_logs
+    response:
+      status: 200


### PR DESCRIPTION
### Description

Fixes `_meta` in various places. Currently the following doesn't work because it wants `description` to also be an object.

```
_meta:
  description: xyz
```

Adds tests for index and component templates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
