### PR TITLE
Fixed query DSL `match` that supports a field name and value

### DIFF
--- a/.cspell
+++ b/.cspell
@@ -166,6 +166,7 @@ termvectors
 tfidf
 tokenfilters
 translog
+tubone
 unigrams
 unmatch
 untriaged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `/{index}/_dangling` that can return `nodes` and `cluster_name` ([#391](https://github.com/opensearch-project/opensearch-api-specification/pull/391))
 - Fixed `Metadata` schema ([#399](https://github.com/opensearch-project/opensearch-api-specification/pull/399))
 - Fixed `/_data_stream` health status and required fields ([#401](https://github.com/opensearch-project/opensearch-api-specification/pull/401))
+- Fixed query DSL `match` that supports a field name and value ([#405](https://github.com/opensearch-project/opensearch-api-specification/pull/405)) 
 
 ### Security
 

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -69,16 +69,13 @@ components:
           description: |-
             Returns documents that match a provided text, number, date or boolean value.
             The provided text is analyzed before matching.
-          anyOf:
-            - type: object
-              additionalProperties:
-                $ref: '#/components/schemas/MatchQuery'
-              minProperties: 1
-              maxProperties: 1
-            - type: object
-              additionalProperties: true
-              minProperties: 1
-              maxProperties: 1
+          type: object
+          additionalProperties:
+            anyOf:
+              - $ref: '#/components/schemas/MatchQuery'
+              - true
+          minProperties: 1
+          maxProperties: 1
         match_all:
           $ref: '#/components/schemas/MatchAllQuery'
         match_bool_prefix:

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -69,11 +69,16 @@ components:
           description: |-
             Returns documents that match a provided text, number, date or boolean value.
             The provided text is analyzed before matching.
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/MatchQuery'
-          minProperties: 1
-          maxProperties: 1
+          anyOf:
+            - type: object
+              additionalProperties:
+                $ref: '#/components/schemas/MatchQuery'
+              minProperties: 1
+              maxProperties: 1
+            - type: object
+              additionalProperties: true
+              minProperties: 1
+              maxProperties: 1
         match_all:
           $ref: '#/components/schemas/MatchAllQuery'
         match_bool_prefix:

--- a/tests/_core/reindex.yaml
+++ b/tests/_core/reindex.yaml
@@ -1,0 +1,212 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: Test reindex.
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+  - path: /films
+    method: DELETE
+    status: [200, 404]
+  - path: /videos
+    method: DELETE
+    status: [200, 404]
+  - path: /_ingest/pipeline/transform-and-count
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create a document.
+    path: /{index}/_doc
+    method: POST
+    parameters:
+      index: movies
+    request_body:
+      payload:
+        title: Beauty and the Beast
+        year: 91
+    response:
+      status: 201
+  - synopsis: Refresh the index.
+    path: /{index}/_refresh
+    method: POST
+    parameters:
+      index: movies
+  - synopsis: Reindex from movies to films.
+    path: /_reindex
+    method: POST
+    request_body:
+      payload:
+        source:
+          index: movies
+        dest:
+          index: films
+    response:
+      status: 200
+      payload:
+        total: 1
+  - synopsis: Reindex a subset of documents (match).
+    path: /_reindex
+    method: POST
+    request_body:
+      payload:
+        source:
+          index: movies
+          query:
+            match:
+              title: Beauty and the Beast
+        dest:
+          index: films
+    response:
+      status: 200
+      payload:
+        total: 1
+  - synopsis: Reindex a subset of documents (no match).
+    path: /_reindex
+    method: POST
+    request_body:
+      payload:
+        source:
+          index: movies
+          query:
+            match:
+              title: Does not Exist
+        dest:
+          index: films
+    response:
+      status: 200
+      payload:
+        total: 0
+  - synopsis: Combine two indexes.
+    path: /_reindex
+    method: POST
+    request_body:
+      payload:
+        source:
+          index:
+            - movies
+            - films
+        dest:
+          index: videos
+    response:
+      status: 200
+      payload:
+        total: 1
+  - synopsis: Reindex only unique documents.
+    path: /_reindex
+    method: POST
+    request_body:
+      payload:
+        conflicts: proceed
+        source:
+          index: movies
+        dest:
+          index: videos
+          op_type: create
+    response:
+      status: 200
+      payload:
+        total: 1
+  - synopsis: Transform documents during reindex.
+    path: /_reindex
+    method: POST
+    request_body:
+      payload:
+        source:
+          index: movies
+        dest:
+          index: videos
+        script:
+          lang: painless
+          source: ctx._source.year += 1900
+    response:
+      status: 200
+      payload:
+        total: 1
+  - synopsis: Create an ingest pipeline.
+    path: /_ingest/pipeline/{id}
+    method: PUT
+    parameters:
+      id: transform-and-count
+    request_body:
+      payload:
+        description: |
+          Splits the `title`` field into a `words` list.
+          Computes the length of the title field and stores it in a new `length` field.
+          Removes the `year` field.
+        processors:
+          - split:
+              field: title
+              separator: '\s+'
+              target_field: words
+          - script:
+              lang: painless
+              source: 'ctx.length = ctx.words.length'
+          - remove:
+              field: year
+  - synopsis: Transform documents using a pipeline.
+    path: /_reindex
+    method: POST
+    request_body:
+      payload:
+        source:
+          index: movies
+        dest:
+          index: videos
+          pipeline: transform-and-count
+    response:
+      status: 200
+  - synopsis: Refresh the index.
+    path: /{index}/_refresh
+    method: POST
+    parameters:
+      index: videos
+  - synopsis: Get all videos.
+    path: /{index}/_search
+    method: POST
+    parameters:
+      index: videos
+    request_body:
+      payload:
+        query:
+          match_all: {}
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _index: videos
+              _source:
+                words:
+                  - Beauty
+                  - and
+                  - the
+                  - Beast
+                length: 4
+                title: Beauty and the Beast
+  - synopsis: Update documents in the current index.
+    path: /{index}/_update_by_query
+    method: POST
+    parameters:
+      index: videos
+    response:
+      status: 200
+      payload:
+        updated: 1
+  - synopsis: Reindex from movies to films with all options.
+    path: /_reindex
+    method: POST
+    parameters:
+      max_docs: 1
+      slices: 1
+    request_body:
+      payload:
+        source:
+          index: movies
+          size: 1
+        dest:
+          index: films
+          version_type: internal
+    response:
+      status: 200
+      payload:
+        total: 1

--- a/tests/_core/reindex.yaml
+++ b/tests/_core/reindex.yaml
@@ -14,23 +14,36 @@ epilogues:
   - path: /_ingest/pipeline/transform-and-count
     method: DELETE
     status: [200, 404]
-chapters:
-  - synopsis: Create a document.
-    path: /{index}/_doc
+prologues:
+  - path: /_ingest/pipeline/transform-and-count
+    method: PUT
+    request_body:
+      payload:
+        description: |
+          Splits the `title`` field into a `words` list.
+          Computes the length of the title field and stores it in a new `length` field.
+          Removes the `year` field.
+        processors:
+          - split:
+              field: title
+              separator: '\s+'
+              target_field: words
+          - script:
+              lang: painless
+              source: 'ctx.length = ctx.words.length'
+          - remove:
+              field: year
+  - path: /{index}/_doc
     method: POST
     parameters:
       index: movies
+      refresh: true
     request_body:
       payload:
         title: Beauty and the Beast
         year: 91
-    response:
-      status: 201
-  - synopsis: Refresh the index.
-    path: /{index}/_refresh
-    method: POST
-    parameters:
-      index: movies
+    status: [201]
+chapters:
   - synopsis: Reindex from movies to films.
     path: /_reindex
     method: POST
@@ -122,27 +135,6 @@ chapters:
       status: 200
       payload:
         total: 1
-  - synopsis: Create an ingest pipeline.
-    path: /_ingest/pipeline/{id}
-    method: PUT
-    parameters:
-      id: transform-and-count
-    request_body:
-      payload:
-        description: |
-          Splits the `title`` field into a `words` list.
-          Computes the length of the title field and stores it in a new `length` field.
-          Removes the `year` field.
-        processors:
-          - split:
-              field: title
-              separator: '\s+'
-              target_field: words
-          - script:
-              lang: painless
-              source: 'ctx.length = ctx.words.length'
-          - remove:
-              field: year
   - synopsis: Transform documents using a pipeline.
     path: /_reindex
     method: POST

--- a/tests/_core/search.yaml
+++ b/tests/_core/search.yaml
@@ -61,6 +61,29 @@ chapters:
                 director: Bennett Miller
                 title: Moneyball
                 year: 2011
+  - synopsis: Search with a match query object.
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request_body:
+      payload:
+        size: 1
+        query:
+          match:
+            director:
+              query: Bennett Miller
+  - synopsis: Search with a match query field.
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request_body:
+      payload:
+        size: 1
+        query:
+          match:
+            director: Bennett Miller
   - synopsis: Search with multi_match query.
     path: /{index}/_search
     parameters:

--- a/tools/src/_utils/index.ts
+++ b/tools/src/_utils/index.ts
@@ -11,7 +11,7 @@ import { type OpenAPIV3 } from 'openapi-types'
 import { type ValidationError } from 'types'
 
 export function is_ref<O extends object> (o: MaybeRef<O>): o is OpenAPIV3.ReferenceObject {
-  return '$ref' in o
+  return typeof (o) === 'object' && '$ref' in o
 }
 
 export function is_array_schema (schema: OpenAPIV3.SchemaObject): schema is OpenAPIV3.ArraySchemaObject {


### PR DESCRIPTION
### Description

Fixed query DSL match that supports a field name and value.
Added reindex tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
