### PR TITLE
Make `indices.get_mapping::query.index` not required

### DIFF
--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -3837,7 +3837,6 @@ components:
         Comma-separated list of data streams, indices, and aliases used to limit the request.
         Supports wildcards (`*`).
         To target all data streams and indices, omit this parameter or use `*` or `_all`.
-      required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
       style: simple


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
