### PR TITLE
Renamed files and operations for consistency.

### DIFF
--- a/spec/namespaces/dangling.yaml
+++ b/spec/namespaces/dangling.yaml
@@ -1,13 +1,13 @@
 openapi: 3.1.0
 info:
-  title: OpenSearch Dangling_indices API
-  description: OpenSearch Dangling_indices API
+  title: OpenSearch Dangling Indices API
+  description: OpenSearch Dangling Indices API
   version: 1.0.0
 paths:
   /_dangling:
     get:
-      operationId: dangling_indices.list_dangling_indices.0
-      x-operation-group: dangling_indices.list_dangling_indices
+      operationId: dangling.list_dangling.0
+      x-operation-group: dangling.list_dangling_indices
       x-version-added: '1.0'
       description: Returns all dangling indices.
       externalDocs:
@@ -15,56 +15,56 @@ paths:
       parameters: []
       responses:
         '200':
-          $ref: '#/components/responses/dangling_indices.list_dangling_indices@200'
+          $ref: '#/components/responses/dangling.list_dangling_indices@200'
   /_dangling/{index_uuid}:
     post:
-      operationId: dangling_indices.import_dangling_index.0
-      x-operation-group: dangling_indices.import_dangling_index
+      operationId: dangling.import_dangling_index.0
+      x-operation-group: dangling.import_dangling_index
       x-version-added: '1.0'
       description: Imports the specified dangling index.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/
       parameters:
-        - $ref: '#/components/parameters/dangling_indices.import_dangling_index::path.index_uuid'
-        - $ref: '#/components/parameters/dangling_indices.import_dangling_index::query.accept_data_loss'
-        - $ref: '#/components/parameters/dangling_indices.import_dangling_index::query.cluster_manager_timeout'
-        - $ref: '#/components/parameters/dangling_indices.import_dangling_index::query.master_timeout'
-        - $ref: '#/components/parameters/dangling_indices.import_dangling_index::query.timeout'
+        - $ref: '#/components/parameters/dangling.import_dangling_index::path.index_uuid'
+        - $ref: '#/components/parameters/dangling.import_dangling_index::query.accept_data_loss'
+        - $ref: '#/components/parameters/dangling.import_dangling_index::query.cluster_manager_timeout'
+        - $ref: '#/components/parameters/dangling.import_dangling_index::query.master_timeout'
+        - $ref: '#/components/parameters/dangling.import_dangling_index::query.timeout'
       responses:
         '200':
-          $ref: '#/components/responses/dangling_indices.import_dangling_index@200'
+          $ref: '#/components/responses/dangling.import_dangling_index@200'
     delete:
-      operationId: dangling_indices.delete_dangling_index.0
-      x-operation-group: dangling_indices.delete_dangling_index
+      operationId: dangling.delete_dangling_index.0
+      x-operation-group: dangling.delete_dangling_index
       x-version-added: '1.0'
       description: Deletes the specified dangling index.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/
       parameters:
-        - $ref: '#/components/parameters/dangling_indices.delete_dangling_index::path.index_uuid'
-        - $ref: '#/components/parameters/dangling_indices.delete_dangling_index::query.accept_data_loss'
-        - $ref: '#/components/parameters/dangling_indices.delete_dangling_index::query.cluster_manager_timeout'
-        - $ref: '#/components/parameters/dangling_indices.delete_dangling_index::query.master_timeout'
-        - $ref: '#/components/parameters/dangling_indices.delete_dangling_index::query.timeout'
+        - $ref: '#/components/parameters/dangling.delete_dangling_index::path.index_uuid'
+        - $ref: '#/components/parameters/dangling.delete_dangling_index::query.accept_data_loss'
+        - $ref: '#/components/parameters/dangling.delete_dangling_index::query.cluster_manager_timeout'
+        - $ref: '#/components/parameters/dangling.delete_dangling_index::query.master_timeout'
+        - $ref: '#/components/parameters/dangling.delete_dangling_index::query.timeout'
       responses:
         '200':
-          $ref: '#/components/responses/dangling_indices.delete_dangling_index@200'
+          $ref: '#/components/responses/dangling.delete_dangling_index@200'
 components:
   requestBodies: {}
   responses:
-    dangling_indices.delete_dangling_index@200:
+    dangling.delete_dangling_index@200:
       description: ''
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    dangling_indices.import_dangling_index@200:
+    dangling.import_dangling_index@200:
       description: ''
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    dangling_indices.list_dangling_indices@200:
+    dangling.list_dangling_indices@200:
       description: ''
       content:
         application/json:
@@ -78,11 +78,11 @@ components:
               dangling_indices:
                 type: array
                 items:
-                  $ref: '../schemas/dangling_indices.list_dangling_indices.yaml#/components/schemas/DanglingIndex'
+                  $ref: '../schemas/dangling.list_dangling.yaml#/components/schemas/DanglingIndex'
             required:
               - dangling_indices
   parameters:
-    dangling_indices.delete_dangling_index::path.index_uuid:
+    dangling.delete_dangling_index::path.index_uuid:
       in: path
       name: index_uuid
       description: The UUID of the dangling index
@@ -90,7 +90,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Uuid'
       style: simple
-    dangling_indices.delete_dangling_index::query.accept_data_loss:
+    dangling.delete_dangling_index::query.accept_data_loss:
       in: query
       name: accept_data_loss
       description: Must be set to true in order to delete the dangling index
@@ -98,14 +98,14 @@ components:
       schema:
         type: boolean
       style: form
-    dangling_indices.delete_dangling_index::query.cluster_manager_timeout:
+    dangling.delete_dangling_index::query.cluster_manager_timeout:
       name: cluster_manager_timeout
       in: query
       description: Operation timeout for connection to cluster-manager node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       x-version-added: '2.0'
-    dangling_indices.delete_dangling_index::query.master_timeout:
+    dangling.delete_dangling_index::query.master_timeout:
       in: query
       name: master_timeout
       description: Specify timeout for connection to master
@@ -115,14 +115,14 @@ components:
       style: form
       x-version-deprecated: 2.0.0
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
-    dangling_indices.delete_dangling_index::query.timeout:
+    dangling.delete_dangling_index::query.timeout:
       in: query
       name: timeout
       description: Explicit operation timeout
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-    dangling_indices.import_dangling_index::path.index_uuid:
+    dangling.import_dangling_index::path.index_uuid:
       in: path
       name: index_uuid
       description: The UUID of the dangling index
@@ -130,7 +130,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Uuid'
       style: simple
-    dangling_indices.import_dangling_index::query.accept_data_loss:
+    dangling.import_dangling_index::query.accept_data_loss:
       in: query
       name: accept_data_loss
       description: Must be set to true in order to import the dangling index
@@ -138,14 +138,14 @@ components:
       schema:
         type: boolean
       style: form
-    dangling_indices.import_dangling_index::query.cluster_manager_timeout:
+    dangling.import_dangling_index::query.cluster_manager_timeout:
       name: cluster_manager_timeout
       in: query
       description: Operation timeout for connection to cluster-manager node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       x-version-added: '2.0'
-    dangling_indices.import_dangling_index::query.master_timeout:
+    dangling.import_dangling_index::query.master_timeout:
       in: query
       name: master_timeout
       description: Specify timeout for connection to master
@@ -155,7 +155,7 @@ components:
       style: form
       x-version-deprecated: 2.0.0
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
-    dangling_indices.import_dangling_index::query.timeout:
+    dangling.import_dangling_index::query.timeout:
       in: query
       name: timeout
       description: Explicit operation timeout

--- a/spec/namespaces/remotestore.yaml
+++ b/spec/namespaces/remotestore.yaml
@@ -6,23 +6,23 @@ info:
 paths:
   /_remotestore/_restore:
     post:
-      operationId: remote_store.restore.0
-      x-operation-group: remote_store.restore
+      operationId: remotestore.restore.0
+      x-operation-group: remotestore.restore
       x-version-added: '1.0'
       description: Restores from remote store.
       externalDocs:
         url: https://opensearch.org/docs/latest/opensearch/remote/#restoring-from-a-backup
       parameters:
-        - $ref: '#/components/parameters/remote_store.restore::query.cluster_manager_timeout'
-        - $ref: '#/components/parameters/remote_store.restore::query.wait_for_completion'
+        - $ref: '#/components/parameters/remotestore.restore::query.cluster_manager_timeout'
+        - $ref: '#/components/parameters/remotestore.restore::query.wait_for_completion'
       requestBody:
-        $ref: '#/components/requestBodies/remote_store.restore'
+        $ref: '#/components/requestBodies/remotestore.restore'
       responses:
         '200':
-          $ref: '#/components/responses/remote_store.restore@200'
+          $ref: '#/components/responses/remotestore.restore@200'
 components:
   requestBodies:
-    remote_store.restore:
+    remotestore.restore:
       content:
         application/json:
           schema:
@@ -44,7 +44,7 @@ components:
                   - books
       required: true
   responses:
-    remote_store.restore@200:
+    remotestore.restore@200:
       description: ''
       content:
         application/json:
@@ -53,14 +53,14 @@ components:
             properties:
               accepted:
                 type: boolean
-              remote_store:
-                $ref: '../schemas/remote_store._common.yaml#/components/schemas/RemoteStoreRestoreInfo'
+              remotestore:
+                $ref: '../schemas/remotestore._common.yaml#/components/schemas/RemoteStoreRestoreInfo'
           examples:
             RemoteStoreRestore_example1:
               summary: Examples for Post Remote Storage Restore Operation.
               description: ''
               value:
-                remote_store:
+                remotestore:
                   indices:
                     - books
                   shards:
@@ -68,14 +68,14 @@ components:
                     failed: 0
                     successful: 1
   parameters:
-    remote_store.restore::query.cluster_manager_timeout:
+    remotestore.restore::query.cluster_manager_timeout:
       name: cluster_manager_timeout
       in: query
       description: Operation timeout for connection to cluster-manager node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       x-version-added: '2.0'
-    remote_store.restore::query.wait_for_completion:
+    remotestore.restore::query.wait_for_completion:
       name: wait_for_completion
       in: query
       description: Should this request wait until the operation has completed before returning.

--- a/spec/namespaces/transform.yaml
+++ b/spec/namespaces/transform.yaml
@@ -6,159 +6,159 @@ info:
 paths:
   /_plugins/_transform:
     get:
-      operationId: transforms.search.0
-      x-operation-group: transforms.search
+      operationId: transform.search.0
+      x-operation-group: transform.search
       x-version-added: '1.0'
       description: Returns the details of all transform jobs.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/index-transforms/transforms-apis/#get-a-transform-jobs-details
       parameters:
-        - $ref: '#/components/parameters/transforms.search::query.from'
-        - $ref: '#/components/parameters/transforms.search::query.search'
-        - $ref: '#/components/parameters/transforms.search::query.size'
-        - $ref: '#/components/parameters/transforms.search::query.sortDirection'
-        - $ref: '#/components/parameters/transforms.search::query.sortField'
+        - $ref: '#/components/parameters/transform.search::query.from'
+        - $ref: '#/components/parameters/transform.search::query.search'
+        - $ref: '#/components/parameters/transform.search::query.size'
+        - $ref: '#/components/parameters/transform.search::query.sortDirection'
+        - $ref: '#/components/parameters/transform.search::query.sortField'
       responses:
         '200':
-          $ref: '#/components/responses/transforms.search@200'
+          $ref: '#/components/responses/transform.search@200'
   /_plugins/_transform/{id}:
     get:
-      operationId: transforms.get.0
-      x-operation-group: transforms.get
+      operationId: transform.get.0
+      x-operation-group: transform.get
       x-version-added: '1.0'
       description: Returns the status and metadata of a transform job.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/index-transforms/transforms-apis/#get-a-transform-jobs-details
       parameters:
-        - $ref: '#/components/parameters/transforms.get::path.id'
+        - $ref: '#/components/parameters/transform.get::path.id'
       responses:
         '200':
-          $ref: '#/components/responses/transforms.get@200'
+          $ref: '#/components/responses/transform.get@200'
     put:
-      operationId: transforms.put.0
-      x-operation-group: transforms.put
+      operationId: transform.put.0
+      x-operation-group: transform.put
       x-version-added: '1.0'
       description: Create an index transform, or update a transform if if_seq_no and if_primary_term are provided.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/index-transforms/transforms-apis/#create-a-transform-job      
       parameters:
-        - $ref: '#/components/parameters/transforms.put::path.id'
-        - $ref: '#/components/parameters/transforms.put::query.if_primary_term'
-        - $ref: '#/components/parameters/transforms.put::query.if_seq_no'
+        - $ref: '#/components/parameters/transform.put::path.id'
+        - $ref: '#/components/parameters/transform.put::query.if_primary_term'
+        - $ref: '#/components/parameters/transform.put::query.if_seq_no'
       requestBody:
-        $ref: '#/components/requestBodies/transforms.put'
+        $ref: '#/components/requestBodies/transform.put'
       responses:
         '200':
-          $ref: '#/components/responses/transforms.put@200'
+          $ref: '#/components/responses/transform.put@200'
     delete:
-      operationId: transforms.delete.0
-      x-operation-group: transforms.delete
+      operationId: transform.delete.0
+      x-operation-group: transform.delete
       x-version-added: '1.0'
       description: Delete an index transform.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/index-transforms/transforms-apis/#delete-a-transform-job
       parameters:
-        - $ref: '#/components/parameters/transforms.delete::path.id'
+        - $ref: '#/components/parameters/transform.delete::path.id'
       responses:
         '200':
-          $ref: '#/components/responses/transforms.delete@200'
+          $ref: '#/components/responses/transform.delete@200'
   /_plugins/_transform/{id}/_start:
     post:
-      operationId: transforms.start.0
-      x-operation-group: transforms.start
+      operationId: transform.start.0
+      x-operation-group: transform.start
       x-version-added: '1.0'
       description: Start transform.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/index-transforms/transforms-apis/#start-a-transform-job
       parameters:
-        - $ref: '#/components/parameters/transforms.start::path.id'
+        - $ref: '#/components/parameters/transform.start::path.id'
       responses:
         '200':
-          $ref: '#/components/responses/transforms.start@200'
+          $ref: '#/components/responses/transform.start@200'
   /_plugins/_transform/{id}/_stop:
     post:
-      operationId: transforms.stop.0
-      x-operation-group: transforms.stop
+      operationId: transform.stop.0
+      x-operation-group: transform.stop
       x-version-added: '1.0'
       description: stop transform.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/index-transforms/transforms-apis/#stop-a-transform-job
       parameters:
-        - $ref: '#/components/parameters/transforms.stop::path.id'
+        - $ref: '#/components/parameters/transform.stop::path.id'
       responses:
         '200':
-          $ref: '#/components/responses/transforms.stop@200'
+          $ref: '#/components/responses/transform.stop@200'
   /_plugins/_transform/{id}/_explain:
     get:
-      operationId: transforms.explain.0
-      x-operation-group: transforms.explain
+      operationId: transform.explain.0
+      x-operation-group: transform.explain
       x-version-added: '1.0'
       description: Returns the status and metadata of a transform job.      
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/index-transforms/transforms-apis/#get-the-status-of-a-transform-job
       parameters:
-        - $ref: '#/components/parameters/transforms.explain::path.id'
+        - $ref: '#/components/parameters/transform.explain::path.id'
       responses:
         '200':
-          $ref: '#/components/responses/transforms.explain@200'
+          $ref: '#/components/responses/transform.explain@200'
   /_plugins/_transform/_preview:
     get:
-      operationId: transforms.preview.0
-      x-operation-group: transforms.preview
+      operationId: transform.preview.0
+      x-operation-group: transform.preview
       x-version-added: '1.0'
       description: Returns a preview of what a transformed index would look like.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/index-transforms/transforms-apis/#preview-a-transform-jobs-results
       responses:
         '200':
-          $ref: '#/components/responses/transforms.preview@200'
+          $ref: '#/components/responses/transform.preview@200'
 components:
   requestBodies:
-    transforms.put:
+    transform.put:
       content:
         application/json:
           schema:
-            $ref: '../schemas/transforms._common.yaml#/components/schemas/Transform'
+            $ref: '../schemas/transform._common.yaml#/components/schemas/Transform'
   responses:
-    transforms.search@200:
+    transform.search@200:
       content:
         application/json:
           schema:
-            $ref: '../schemas/transforms._common.yaml#/components/schemas/TransformsResponse'
-    transforms.get@200:
+            $ref: '../schemas/transform._common.yaml#/components/schemas/TransformsResponse'
+    transform.get@200:
       content:
         application/json:
           schema:
-            $ref: '../schemas/transforms._common.yaml#/components/schemas/TransformEntity'
-    transforms.put@200:
+            $ref: '../schemas/transform._common.yaml#/components/schemas/TransformEntity'
+    transform.put@200:
       content:
         application/json:
           schema:
-            $ref: '../schemas/transforms._common.yaml#/components/schemas/TransformEntity'
-    transforms.delete@200:
+            $ref: '../schemas/transform._common.yaml#/components/schemas/TransformEntity'
+    transform.delete@200:
       description: ''
-    transforms.start@200:
+    transform.start@200:
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    transforms.stop@200:
+    transform.stop@200:
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    transforms.explain@200:
+    transform.explain@200:
       content:
         application/json:
           schema:
-            $ref: '../schemas/transforms._common.yaml#/components/schemas/ExplainResponse'
-    transforms.preview@200:
+            $ref: '../schemas/transform._common.yaml#/components/schemas/ExplainResponse'
+    transform.preview@200:
       content:
         application/json:
           schema:
-            $ref: '../schemas/transforms._common.yaml#/components/schemas/Preview'
+            $ref: '../schemas/transform._common.yaml#/components/schemas/Preview'
   parameters:
-    transforms.get::path.id:
+    transform.get::path.id:
       name: id
       in: path
       description: Transform to access
@@ -166,7 +166,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Id'
       style: simple
-    transforms.put::path.id:
+    transform.put::path.id:
       name: id
       in: path
       description: Transform to create/update
@@ -174,7 +174,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Id'
       style: simple
-    transforms.delete::path.id:
+    transform.delete::path.id:
       name: id
       in: path
       description: Transform to delete
@@ -182,7 +182,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Id'
       style: simple
-    transforms.start::path.id:
+    transform.start::path.id:
       name: id
       in: path
       description: Transform to start
@@ -190,7 +190,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Id'
       style: simple
-    transforms.stop::path.id:
+    transform.stop::path.id:
       name: id
       in: path
       description: Transform to stop
@@ -198,7 +198,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Id'
       style: simple
-    transforms.explain::path.id:
+    transform.explain::path.id:
       name: id
       in: path
       description: Transform to explain
@@ -206,7 +206,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Id'
       style: simple
-    transforms.put::query.if_seq_no:
+    transform.put::query.if_seq_no:
       name: if_seq_no
       in: query
       description: Only perform the operation if the document has this sequence number.
@@ -214,7 +214,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/SequenceNumber'
       style: form
-    transforms.put::query.if_primary_term:
+    transform.put::query.if_primary_term:
       name: if_primary_term
       in: query
       description: Only perform the operation if the document has this primary term.
@@ -222,7 +222,7 @@ components:
       schema:
         type: number
       style: form
-    transforms.search::query.size:
+    transform.search::query.size:
       name: size
       in: query
       description: Specifies the number of transforms to return. Default is `10`.
@@ -230,7 +230,7 @@ components:
       schema:
         type: number
       style: form
-    transforms.search::query.from:
+    transform.search::query.from:
       name: from
       in: query
       description: The starting transform to return. Default is `0`.
@@ -238,7 +238,7 @@ components:
       schema:
         type: number
       style: form
-    transforms.search::query.search:
+    transform.search::query.search:
       name: search
       in: query
       description: The search term to use to filter results.
@@ -246,7 +246,7 @@ components:
       schema:
         type: string
       style: form
-    transforms.search::query.sortField:
+    transform.search::query.sortField:
       name: sortField
       in: query
       description: The field to sort results with.
@@ -254,7 +254,7 @@ components:
       schema:
         type: string
       style: form
-    transforms.search::query.sortDirection:
+    transform.search::query.sortDirection:
       name: sortDirection
       in: query
       description: Specifies the direction to sort results in. Can be `ASC` or `DESC`. Default is `ASC`.

--- a/spec/schemas/dangling_indices.list_dangling_indices.yaml
+++ b/spec/schemas/dangling_indices.list_dangling_indices.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
-  title: Schemas of dangling_indices.list_dangling_indices category
-  description: Schemas of dangling_indices.list_dangling_indices category
+  title: Schemas of dangling.list_dangling_indices category
+  description: Schemas of dangling.list_dangling_indices category
   version: 1.0.0
 paths: {}
 components:


### PR DESCRIPTION
### Description

I am not sure it makes sense to rename operation IDs, but this is what it would look like for `dangling`, `remotestore` and `transform`. Currently the files and the APIs don't match the operation IDs, not sure whether that was intentional?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
