### PR TITLE
Test against OpenSearch 1.3.17.

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         entry:
+          - {version: 1.3.17, admin_password: admin}
           - {version: 2.0.0, admin_password: admin}
           - {version: 2.15.0}
           - {version: 2.16.0, hub: opensearchstaging}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `cluster_manager_timeout` to `HEAD /{index}` ([#421](https://github.com/opensearch-project/opensearch-api-specification/pull/421))
 - Added missing fields to `/_nodes/stats` ([#415](https://github.com/opensearch-project/opensearch-api-specification/pull/415))
 - Added missing metrics options to `/_nodes/stats` ([#422](https://github.com/opensearch-project/opensearch-api-specification/pull/422))
+- Added tests against OpenSearch 1.3 ([#424](https://github.com/opensearch-project/opensearch-api-specification/pull/424))
 
 ### Changed
 

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -6,6 +6,9 @@ info:
 paths: {}
 components:
   schemas:
+    Type:
+      type: string
+      x-version-removed: '2.0'
     Id:
       type: string
     AcknowledgedResponseBase:
@@ -1315,6 +1318,8 @@ components:
     WriteResponseBase:
       type: object
       properties:
+        _type:
+          $ref: '#/components/schemas/Type'
         _id:
           $ref: '#/components/schemas/Id'
         _index:

--- a/spec/schemas/_core.bulk.yaml
+++ b/spec/schemas/_core.bulk.yaml
@@ -110,6 +110,10 @@ components:
     ResponseItem:
       type: object
       properties:
+        _type:
+          description: The document type.
+          type: string
+          x-version-removed: '2.0'
         _id:
           description: The document ID associated with the operation.
           anyOf:

--- a/spec/schemas/_core.get.yaml
+++ b/spec/schemas/_core.get.yaml
@@ -9,6 +9,8 @@ components:
     GetResult:
       type: object
       properties:
+        _type:
+          $ref: '_common.yaml#/components/schemas/Type'
         _index:
           $ref: '_common.yaml#/components/schemas/IndexName'
         fields:

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -43,6 +43,8 @@ components:
     Hit:
       type: object
       properties:
+        _type:
+          $ref: '_common.yaml#/components/schemas/Type'
         _index:
           $ref: '_common.yaml#/components/schemas/IndexName'
         _id:

--- a/spec/schemas/cat.health.yaml
+++ b/spec/schemas/cat.health.yaml
@@ -52,3 +52,7 @@ components:
         discovered_cluster_manager:
           description: cluster manager is discovered or not
           type: string
+        discovered_master:
+          x-version-removed: '2.0'
+          description: cluster manager is discovered or not
+          type: string

--- a/tests/cat/health.yaml
+++ b/tests/cat/health.yaml
@@ -55,6 +55,33 @@ chapters:
         - node.total: '1'
           status: yellow
           node.data: '1'
+  - synopsis: Cat with master response (format=json).
+    method: GET
+    path: /_cat/health
+    version: < 2.0
+    parameters:
+      format: json
+    response:
+      status: 200
+      content_type: application/json
+      payload:
+        - node.total: '1'
+          status: yellow
+          node.data: '1'
+          discovered_master: 'true'
+  - synopsis: Cat with cluster_manager response (format=json).
+    method: GET
+    path: /_cat/health
+    version: '>= 2.0'
+    parameters:
+      format: json
+    response:
+      status: 200
+      content_type: application/json
+      payload:
+        - node.total: '1'
+          status: yellow
+          node.data: '1'
           discovered_cluster_manager: 'true'
   - synopsis: Cat in different formats (format=yaml).
     method: GET
@@ -68,7 +95,6 @@ chapters:
         - node.total: '1'
           status: yellow
           node.data: '1'
-          discovered_cluster_manager: 'true'
   - synopsis: Cat in different formats (format=cbor).
     method: GET
     path: /_cat/health
@@ -81,7 +107,6 @@ chapters:
         - node.total: '1'
           status: yellow
           node.data: '1'
-          discovered_cluster_manager: 'true'
   - synopsis: Cat in different formats (format=smile).
     method: GET
     path: /_cat/health
@@ -94,4 +119,3 @@ chapters:
         - node.total: '1'
           status: yellow
           node.data: '1'
-          discovered_cluster_manager: 'true'

--- a/tests/cat/master.yaml
+++ b/tests/cat/master.yaml
@@ -1,10 +1,10 @@
 $schema: ../../json_schemas/test_story.schema.yaml
 
-description: Test cat/cluster_manager endpoints.
+description: Test cat/master endpoints.
 chapters:
   - synopsis: Cat with a json response.
-    version: '>= 2.0'
-    path: /_cat/cluster_manager
+    version: < 2.0
+    path: /_cat/master
     method: GET
     parameters:
       format: json

--- a/tests/cat/nodes.yaml
+++ b/tests/cat/nodes.yaml
@@ -5,6 +5,17 @@ chapters:
   - synopsis: Cat with a json response.
     path: /_cat/nodes
     method: GET
+    version: < 2.0
+    parameters:
+      format: json
+    response:
+      status: 200
+      payload:
+        - master: '*'
+  - synopsis: Cat with a json response.
+    path: /_cat/nodes
+    version: '>= 2.0'
+    method: GET
     parameters:
       format: json
     response:

--- a/tests/cluster/component_template.yaml
+++ b/tests/cluster/component_template.yaml
@@ -53,13 +53,29 @@ chapters:
     method: HEAD
     parameters:
       name: template1
-      cluster_manager_timeout: 10s
       local: false
+    response:
+      status: 200
+  - synopsis: Check if the component template exists (cluster_manager_timeout).
+    path: /_component_template/{name}
+    method: HEAD
+    version: '>= 2.0'
+    parameters:
+      name: template1
+      cluster_manager_timeout: 10s
     response:
       status: 200
   - synopsis: Get all component templates.
     path: /_component_template
     method: GET
+    parameters:
+      local: false
+    response:
+      status: 200
+  - synopsis: Get all component templates (cluster_manager_timeout).
+    path: /_component_template
+    method: GET
+    version: '>= 2.0'
     parameters:
       cluster_manager_timeout: 10s
       local: false

--- a/tests/indices/clone.yaml
+++ b/tests/indices/clone.yaml
@@ -14,6 +14,9 @@ epilogues:
   - path: /games2
     method: DELETE
     status: [200, 404]
+  - path: /games3
+    method: DELETE
+    status: [200, 404]
 chapters:
   - synopsis: Block writes to the source index.
     path: /{index}/_settings
@@ -31,7 +34,6 @@ chapters:
       index: movies
       target: games1
       wait_for_active_shards: 1
-      cluster_manager_timeout: 10s
       timeout: 10s
     response:
       status: 200
@@ -47,5 +49,15 @@ chapters:
       index: movies
       target: games2
       wait_for_completion: true
+    response:
+      status: 200
+  - synopsis: Clone an index (cluster_manager_timeout).
+    version: '>= 2.0'
+    path: /{index}/_clone/{target}
+    method: POST
+    parameters:
+      index: movies
+      target: games3
+      cluster_manager_timeout: 10s
     response:
       status: 200

--- a/tests/indices/close.yaml
+++ b/tests/indices/close.yaml
@@ -5,8 +5,14 @@ prologues:
   - path: /movies
     method: PUT
     status: [200]
+  - path: /games
+    method: PUT
+    status: [200]
 epilogues:
   - path: /movies
+    method: DELETE
+    status: [200, 404]
+  - path: /games
     method: DELETE
     status: [200, 404]
 chapters:
@@ -19,13 +25,26 @@ chapters:
       expand_wildcards: all
       ignore_unavailable: true
       wait_for_active_shards: 0
-      cluster_manager_timeout: 30s
       timeout: 30s
     response:
       status: 200
       payload:
         indices:
           movies:
+            closed: true
+  - synopsis: Close an index (cluster_manager_timeout).
+    path: /{index}/_close
+    method: POST
+    version: '>= 2.0'
+    parameters:
+      index: games
+      cluster_manager_timeout: 30s
+      timeout: 30s
+    response:
+      status: 200
+      payload:
+        indices:
+          games:
             closed: true
   - synopsis: Close an already closed index.
     path: /{index}/_close

--- a/tests/indices/index.yaml
+++ b/tests/indices/index.yaml
@@ -51,6 +51,15 @@ chapters:
     method: HEAD
     parameters:
       index: movies
+    response:
+      status: 404
+
+  - synopsis: Check if the index `movies` exists (cluster_manager_timeout). It should not.
+    path: /{index}
+    method: HEAD
+    version: '>= 2.0'
+    parameters:
+      index: movies
       cluster_manager_timeout: 10s
     response:
       status: 404
@@ -77,6 +86,15 @@ chapters:
   - synopsis: Delete the `books` and `games` indices.
     path: /{index}
     method: DELETE
+    version: < 2.0
+    parameters:
+      index: books,games
+
+  - synopsis: Delete the `books` index (cluster_manager_timeout).
+    path: /{index}
+    method: DELETE
+    version: '>= 2.0'
     parameters:
       index: books,games
       cluster_manager_timeout: 10s
+      

--- a/tests/indices/index_template.yaml
+++ b/tests/indices/index_template.yaml
@@ -67,6 +67,14 @@ chapters:
     method: HEAD
     parameters:
       name: daily_logs
+    response:
+      status: 200
+  - synopsis: Check that an index template exists (cluster_manager_timeout).
+    path: /_index_template/{name}
+    method: HEAD
+    version: '>= 2.0'
+    parameters:
+      name: daily_logs
       cluster_manager_timeout: 10s
     response:
       status: 200

--- a/tests/indices/mapping.yml
+++ b/tests/indices/mapping.yml
@@ -66,9 +66,24 @@ chapters:
       allow_no_indices: true
       expand_wildcards: none
       ignore_unavailable: true
-      cluster_manager_timeout: 1s
       timeout: 10s
       write_index_only: true
+    request_body:
+      payload:
+        properties:
+          producer:
+            type: text
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Update mapping for an index (cluster_manager_timeout).
+    path: /{index}/_mapping
+    method: PUT
+    version: '>= 2.0'
+    parameters:
+      index: movies
+      cluster_manager_timeout: 1s
     request_body:
       payload:
         properties:

--- a/tests/indices/open.yaml
+++ b/tests/indices/open.yaml
@@ -8,14 +8,20 @@ prologues:
   - path: /games
     method: PUT
     status: [200]
+  - path: /films
+    method: PUT
+    status: [200]
   - path: /movies/_close
     method: POST
     status: [200]
   - path: /games/_close
     method: POST
     status: [200]
+  - path: /films/_close
+    method: POST
+    status: [200]
 epilogues:
-  - path: /movies,games
+  - path: /movies,games,films
     method: DELETE
     status: [200, 404]
 chapters:
@@ -28,7 +34,6 @@ chapters:
       expand_wildcards: all
       ignore_unavailable: true
       wait_for_active_shards: 0
-      cluster_manager_timeout: 30s
       timeout: 30s
     response:
       status: 200
@@ -49,6 +54,18 @@ chapters:
     method: POST
     parameters:
       index: movies
+    response:
+      status: 200
+      payload:
+        shards_acknowledged: true
+        acknowledged: true
+  - synopsis: Open a closed index (cluster_manager_timeout).
+    path: /{index}/_open
+    method: POST
+    version: '>= 2.0'
+    parameters:
+      index: films
+      cluster_manager_timeout: 30s
     response:
       status: 200
       payload:

--- a/tests/indices/settings.yaml
+++ b/tests/indices/settings.yaml
@@ -20,6 +20,19 @@ chapters:
       include_defaults: true
       ignore_unavailable: true
       local: true
+    response:
+      status: 200
+  - synopsis: Get global settings (cluster_manager_timeout).
+    path: /_settings
+    method: GET
+    version: '>= 2.0'
+    parameters:
+      allow_no_indices: true
+      expand_wildcards: none
+      flat_settings: true
+      include_defaults: true
+      ignore_unavailable: true
+      local: true
       cluster_manager_timeout: 1s
     response:
       status: 200

--- a/tests/indices/shrink.yaml
+++ b/tests/indices/shrink.yaml
@@ -21,6 +21,9 @@ epilogues:
   - path: /movies3
     method: DELETE
     status: [200, 404]
+  - path: /movies4
+    method: DELETE
+    status: [200, 404]
 chapters:
   - synopsis: Block writes to the source index.
     path: /{index}/_settings
@@ -38,7 +41,6 @@ chapters:
       index: movies
       target: movies1
       wait_for_active_shards: 1
-      cluster_manager_timeout: 10s
       timeout: 10s
     response:
       status: 200
@@ -63,7 +65,6 @@ chapters:
       index: movies
       target: movies3
       wait_for_active_shards: 1
-      cluster_manager_timeout: 10s
       timeout: 10s
     response:
       status: 200
@@ -71,3 +72,19 @@ chapters:
         shards_acknowledged: true
         acknowledged: true
         index: movies3
+  - synopsis: Shrink an index (cluster_manager_timeout).
+    path: /{index}/_shrink/{target}
+    method: POST
+    version: '>= 2.0'
+    parameters:
+      index: movies
+      target: movies4
+      wait_for_active_shards: 1
+      cluster_manager_timeout: 10s
+      timeout: 10s
+    response:
+      status: 200
+      payload:
+        shards_acknowledged: true
+        acknowledged: true
+        index: movies4

--- a/tests/indices/split.yaml
+++ b/tests/indices/split.yaml
@@ -21,6 +21,9 @@ epilogues:
   - path: /movies3
     method: DELETE
     status: [200, 404]
+  - path: /movies4
+    method: DELETE
+    status: [200, 404]
 chapters:
   - synopsis: Block writes to the source index.
     path: /{index}/_settings
@@ -38,7 +41,6 @@ chapters:
       index: movies
       target: movies1
       wait_for_active_shards: 1
-      cluster_manager_timeout: 10s
       timeout: 10s
     request_body:
       payload:
@@ -73,7 +75,6 @@ chapters:
       index: movies
       target: movies3
       wait_for_active_shards: 1
-      cluster_manager_timeout: 10s
       timeout: 10s
     request_body:
       payload:
@@ -86,3 +87,24 @@ chapters:
         shards_acknowledged: true
         acknowledged: true
         index: movies3
+  - synopsis: Split an index (cluster_manager_timeout).
+    path: /{index}/_split/{target}
+    method: POST
+    version: '>= 2.0'
+    parameters:
+      index: movies
+      target: movies4
+      wait_for_active_shards: 1
+      cluster_manager_timeout: 10s
+      timeout: 10s
+    request_body:
+      payload:
+        settings:
+          index:
+            number_of_shards: 6
+    response:
+      status: 200
+      payload:
+        shards_acknowledged: true
+        acknowledged: true
+        index: movies4


### PR DESCRIPTION
### Description

This passes tests against OpenSearch 1.x.

Since 1.x is still supported I think we should also support it in the spec. Clients can choose to ignore anything that's `x-version-removed=2.0`. This gives us a way to evolve backwards incompatible changes in 3.0.

The other option is a 1.x branch and we can have backports. It's possibly easier, and so if you think it's better, then I can PR spec and tests with `>= 2.0` separately so that the diff is smaller, and make a 1.x branch.

WDYT @nhtruong @Xtansia ?

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-api-specification/issues/84.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
