### PR TITLE
Fix _source accepting an array of fields in _search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed query DSL `match` that supports a field name and value ([#405](https://github.com/opensearch-project/opensearch-api-specification/pull/405)) 
 - Fixed `/_mapping` with `index` in query ([#385](https://github.com/opensearch-project/opensearch-api-specification/pull/385))
 - Fixed duplicate `/_nodes/{node_id}` path ([#416](https://github.com/opensearch-project/opensearch-api-specification/pull/416))
+- Fixed `_source` accepting an array of fields in `/_search` ([#430](https://github.com/opensearch-project/opensearch-api-specification/pull/430))
 
 ### Security
 

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -789,6 +789,9 @@ components:
       description: Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
       oneOf:
         - type: boolean
+        - type: array
+          items:
+            $ref: '_common.yaml#/components/schemas/Field' 
         - $ref: '#/components/schemas/SourceFilter'
     SourceFilter:
       type: object

--- a/tests/_core/search/_source.yaml
+++ b/tests/_core/search/_source.yaml
@@ -1,0 +1,147 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test search endpoint (_source).
+prologues:
+  - path: /movies/_doc
+    method: POST
+    parameters:
+      refresh: true
+    request_body:
+      payload:
+        director: Bennett Miller
+        title: Moneyball
+        year: 2011
+    status: [201]
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Search (_source=true).
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request_body:
+      payload:
+        _source: true
+        query:
+          match_all: {}
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 1
+            relation: eq
+          max_score: 1
+          hits:
+            - _index: movies
+              _score: 1
+              _source:
+                director: Bennett Miller
+                title: Moneyball
+                year: 2011
+  - synopsis: Search (_source=false).
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request_body:
+      payload:
+        _source: false
+        query:
+          match_all: {}
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 1
+            relation: eq
+          max_score: 1
+          hits:
+            - _index: movies
+              _score: 1
+  - synopsis: Search (_source=[fields]).
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request_body:
+      payload:
+        _source:
+          - director
+          - year
+        query:
+          match_all: {}
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 1
+            relation: eq
+          max_score: 1
+          hits:
+            - _index: movies
+              _score: 1
+              _source:
+                director: Bennett Miller
+                year: 2011
+  - synopsis: Search (_source=filter).
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request_body:
+      payload:
+        _source:
+          includes: director
+          excludes: year
+        query:
+          match_all: {}
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 1
+            relation: eq
+          max_score: 1
+          hits:
+            - _index: movies
+              _score: 1
+              _source:
+                director: Bennett Miller
+  - synopsis: Search (_source=filter with wildcards).
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request_body:
+      payload:
+        _source:
+          includes: '*'
+          excludes: year
+        query:
+          match_all: {}
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 1
+            relation: eq
+          max_score: 1
+          hits:
+            - _index: movies
+              _score: 1
+              _source:
+                director: Bennett Miller
+                title: Moneyball


### PR DESCRIPTION
### Description

Coming from https://github.com/opensearch-project/opensearch-java/issues/1087, `_source` accepts an array of fields in _search. Looks like we also don't properly document this in https://opensearch.org/docs/latest/api-reference/search.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
