### PR TITLE
Add API spec for Search Response Processors

### DIFF
--- a/.cspell
+++ b/.cspell
@@ -30,6 +30,8 @@ OSCPU
 Oversample
 Rebalance
 Reindex
+Rerank
+Reranker
 Rethrottle
 Rolespan
 Rollup
@@ -138,6 +140,7 @@ readingform
 rebalance
 recoverysource
 reindex
+rerank
 relo
 reloadcerts
 remotestore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `is_hidden` to `/{index}/_alias/{name}` and `/{index}/_aliases/{name}` ([#429](https://github.com/opensearch-project/opensearch-api-specification/pull/429))
 - Added `ignore_unmapped` to `GeoDistanceQuery` ([#427](https://github.com/opensearch-project/opensearch-api-specification/pull/427))
 - Added missing variants of `indices.put_alias` ([#434](https://github.com/opensearch-project/opensearch-api-specification/pull/434)) 
+- Added missing search response processors and new `sort` and `split` processors ([#440](https://github.com/opensearch-project/opensearch-api-specification/pull/440)) 
 
 ### Changed
 

--- a/spec/schemas/search_pipeline._common.yaml
+++ b/spec/schemas/search_pipeline._common.yaml
@@ -189,62 +189,62 @@ components:
         - sample_factor
     ResponseProcessor:
       oneOf:
-      - type: object
-        title: personalize_search_ranking
-        properties:
-          personalize_search_ranking:
-            "$ref": "#/components/schemas/PersonalizeSearchRankingResponseProcessor"
-        required:
-        - personalize_search_ranking
-      - type: object
-        title: retrieval_augmented_generation
-        properties:
-          retrieval_augmented_generation:
-            "$ref": "#/components/schemas/RetrievalAugmentedGenerationResponseProcessor"
-        required:
-        - retrieval_augmented_generation
-      - type: object
-        title: rename_field
-        properties:
-          rename_field:
-            "$ref": "#/components/schemas/RenameFieldResponseProcessor"
-        required:
-        - rename_field
-      - type: object
-        title: rerank
-        properties:
-          rerank:
-            "$ref": "#/components/schemas/RerankResponseProcessor"
-        required:
-        - rerank
-      - type: object
-        title: collapse
-        properties:
-          collapse:
-            "$ref": "#/components/schemas/CollapseResponseProcessor"
-        required:
-        - collapse
-      - type: object
-        title: truncate_hits
-        properties:
-          truncate_hits:
-            "$ref": "#/components/schemas/TruncateHitsResponseProcessor"
-        required:
-        - truncate_hits
-      - type: object
-        title: sort
-        properties:
-          sort:
-            "$ref": "#/components/schemas/SortResponseProcessor"
-        required:
-        - truncate_hits
-      - type: object
-        title: split
-        properties:
-          split:
-            "$ref": "#/components/schemas/SplitResponseProcessor"
-        required:
-        - truncate_hits
+        - type: object
+          title: personalize_search_ranking
+          properties:
+            personalize_search_ranking:
+              $ref: '#/components/schemas/PersonalizeSearchRankingResponseProcessor'
+          required:
+          - personalize_search_ranking
+        - type: object
+          title: retrieval_augmented_generation
+          properties:
+            retrieval_augmented_generation:
+              $ref: '#/components/schemas/RetrievalAugmentedGenerationResponseProcessor'
+          required:
+          - retrieval_augmented_generation
+        - type: object
+          title: rename_field
+          properties:
+            rename_field:
+              $ref: '#/components/schemas/RenameFieldResponseProcessor'
+          required:
+          - rename_field
+        - type: object
+          title: rerank
+          properties:
+            rerank:
+              $ref: '#/components/schemas/RerankResponseProcessor'
+          required:
+          - rerank
+        - type: object
+          title: collapse
+          properties:
+            collapse:
+              $ref: '#/components/schemas/CollapseResponseProcessor'
+          required:
+          - collapse
+        - type: object
+          title: truncate_hits
+          properties:
+            truncate_hits:
+              $ref: '#/components/schemas/TruncateHitsResponseProcessor'
+          required:
+          - truncate_hits
+        - type: object
+          title: sort
+          properties:
+            sort:
+              $ref: '#/components/schemas/SortResponseProcessor'
+          required:
+          - truncate_hits
+        - type: object
+          title: split
+          properties:
+            split:
+              $ref: '#/components/schemas/SplitResponseProcessor'
+          required:
+          - truncate_hits
     PersonalizeSearchRankingResponseProcessor:
       type: object
       properties:
@@ -331,9 +331,9 @@ components:
         ignore_failure:
           type: boolean
         ml_opensearch:
-          "$ref": "#/components/schemas/MLOpenSearchReranker"
+          $ref: '#/components/schemas/MLOpenSearchReranker'
         context:
-          "$ref": "#/components/schemas/RerankContext"
+          $ref: '#/components/schemas/RerankContext'
     CollapseResponseProcessor:
       type: object
       properties:

--- a/spec/schemas/search_pipeline._common.yaml
+++ b/spec/schemas/search_pipeline._common.yaml
@@ -195,56 +195,56 @@ components:
             personalize_search_ranking:
               $ref: '#/components/schemas/PersonalizeSearchRankingResponseProcessor'
           required:
-          - personalize_search_ranking
+            - personalize_search_ranking
         - type: object
           title: retrieval_augmented_generation
           properties:
             retrieval_augmented_generation:
               $ref: '#/components/schemas/RetrievalAugmentedGenerationResponseProcessor'
           required:
-          - retrieval_augmented_generation
+            - retrieval_augmented_generation
         - type: object
           title: rename_field
           properties:
             rename_field:
               $ref: '#/components/schemas/RenameFieldResponseProcessor'
           required:
-          - rename_field
+            - rename_field
         - type: object
           title: rerank
           properties:
             rerank:
               $ref: '#/components/schemas/RerankResponseProcessor'
           required:
-          - rerank
+            - rerank
         - type: object
           title: collapse
           properties:
             collapse:
               $ref: '#/components/schemas/CollapseResponseProcessor'
           required:
-          - collapse
+            - collapse
         - type: object
           title: truncate_hits
           properties:
             truncate_hits:
               $ref: '#/components/schemas/TruncateHitsResponseProcessor'
           required:
-          - truncate_hits
+            - truncate_hits
         - type: object
           title: sort
           properties:
             sort:
               $ref: '#/components/schemas/SortResponseProcessor'
           required:
-          - truncate_hits
+            - sort
         - type: object
           title: split
           properties:
             split:
               $ref: '#/components/schemas/SplitResponseProcessor'
           required:
-          - truncate_hits
+            - split
     PersonalizeSearchRankingResponseProcessor:
       type: object
       properties:
@@ -266,9 +266,9 @@ components:
         iam_role_arn:
           type: string
       required:
-      - campaign_arn
-      - recipe
-      - weight
+        - campaign_arn
+        - recipe
+        - weight
     RetrievalAugmentedGenerationResponseProcessor:
       type: object
       properties:
@@ -287,8 +287,8 @@ components:
         user_instructions:
           type: string
       required:
-      - context_field_list
-      - model_id
+        - context_field_list
+        - model_id
     RenameFieldResponseProcessor:
       type: object
       properties:
@@ -303,8 +303,8 @@ components:
         target_field:
           type: string
       required:
-      - field
-      - target_field
+        - field
+        - target_field
     RerankContext:
       type: object
       properties:
@@ -313,14 +313,14 @@ components:
           items:
             type: string
       required:
-      - document_fields
+        - document_fields
     MLOpenSearchReranker:
       type: object
       properties:
         model_id:
           type: string
       required:
-      - model_id
+        - model_id
     RerankResponseProcessor:
       type: object
       properties:
@@ -348,7 +348,7 @@ components:
         context_prefix:
           type: string
       required:
-      - field
+        - field
     TruncateHitsResponseProcessor:
       type: object
       properties:
@@ -379,7 +379,7 @@ components:
         target_field:
           type: string
       required:
-      - field
+        - field
     SplitResponseProcessor:
       type: object
       properties:
@@ -398,8 +398,8 @@ components:
         target_field:
           type: string
       required:
-      - field
-      - separator
+        - field
+        - separator
     PhaseResultsProcessor:
       oneOf:
         - type: object

--- a/spec/schemas/search_pipeline._common.yaml
+++ b/spec/schemas/search_pipeline._common.yaml
@@ -23,7 +23,7 @@ components:
         response_processors:
           type: array
           items:
-            $ref: '#/components/schemas/RequestProcessor'
+            $ref: '#/components/schemas/ResponseProcessor'
         phase_results_processors:
           type: array
           items:
@@ -187,6 +187,168 @@ components:
           type: string
       required:
         - sample_factor
+    ResponseProcessor:
+      oneOf:
+      - type: object
+        title: personalize_search_ranking
+        properties:
+          personalize_search_ranking:
+            "$ref": "#/components/schemas/PersonalizeSearchRankingResponseProcessor"
+        required:
+        - personalize_search_ranking
+      - type: object
+        title: retrieval_augmented_generation
+        properties:
+          retrieval_augmented_generation:
+            "$ref": "#/components/schemas/RetrievalAugmentedGenerationResponseProcessor"
+        required:
+        - retrieval_augmented_generation
+      - type: object
+        title: rename_field
+        properties:
+          rename_field:
+            "$ref": "#/components/schemas/RenameFieldResponseProcessor"
+        required:
+        - rename_field
+      - type: object
+        title: rerank
+        properties:
+          rerank:
+            "$ref": "#/components/schemas/RerankResponseProcessor"
+        required:
+        - rerank
+      - type: object
+        title: collapse
+        properties:
+          collapse:
+            "$ref": "#/components/schemas/CollapseResponseProcessor"
+        required:
+        - collapse
+      - type: object
+        title: truncate_hits
+        properties:
+          truncate_hits:
+            "$ref": "#/components/schemas/TruncateHitsResponseProcessor"
+        required:
+        - truncate_hits
+    PersonalizeSearchRankingResponseProcessor:
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean
+        campaign_arn:
+          type: string
+        recipe:
+          type: string
+        weight:
+          type: number
+          format: float
+        item_id_field:
+          type: string
+        iam_role_arn:
+          type: string
+      required:
+      - campaign_arn
+      - recipe
+      - weight
+    RetrievalAugmentedGenerationResponseProcessor:
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        model_id:
+          type: string
+        context_field_list:
+          type: array
+          items:
+            type: string
+        system_prompt:
+          type: string
+        user_instructions:
+          type: string
+      required:
+      - context_field_list
+      - model_id
+    RenameFieldResponseProcessor:
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean
+        field:
+          type: string
+        target_field:
+          type: string
+      required:
+      - field
+      - target_field
+    RerankContext:
+      type: object
+      properties:
+        document_fields:
+          type: array
+          items:
+            type: string
+      required:
+      - document_fields
+    MLOpenSearchReranker:
+      type: object
+      properties:
+        model_id:
+          type: string
+      required:
+      - model_id
+    RerankResponseProcessor:
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean
+        ml_opensearch:
+          "$ref": "#/components/schemas/MLOpenSearchReranker"
+        context:
+          "$ref": "#/components/schemas/RerankContext"
+    CollapseResponseProcessor:
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean
+        field:
+          type: string
+        context_prefix:
+          type: string
+      required:
+      - field
+    TruncateHitsResponseProcessor:
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean
+        target_size:
+          type: integer
+          format: int32
+        context_prefix:
+          type: string
     PhaseResultsProcessor:
       oneOf:
         - type: object

--- a/spec/schemas/search_pipeline._common.yaml
+++ b/spec/schemas/search_pipeline._common.yaml
@@ -231,6 +231,20 @@ components:
             "$ref": "#/components/schemas/TruncateHitsResponseProcessor"
         required:
         - truncate_hits
+      - type: object
+        title: sort
+        properties:
+          sort:
+            "$ref": "#/components/schemas/SortResponseProcessor"
+        required:
+        - truncate_hits
+      - type: object
+        title: split
+        properties:
+          split:
+            "$ref": "#/components/schemas/SplitResponseProcessor"
+        required:
+        - truncate_hits
     PersonalizeSearchRankingResponseProcessor:
       type: object
       properties:
@@ -349,6 +363,43 @@ components:
           format: int32
         context_prefix:
           type: string
+    SortResponseProcessor:
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean
+        field:
+          type: string
+        order:
+          type: string
+        target_field:
+          type: string
+      required:
+      - field
+    SplitResponseProcessor:
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean
+        field:
+          type: string
+        separator:
+          type: string
+        preserve_trailing:
+          type: boolean
+        target_field:
+          type: string
+      required:
+      - field
+      - separator
     PhaseResultsProcessor:
       oneOf:
         - type: object

--- a/tests/_core/search/pipeline.yaml
+++ b/tests/_core/search/pipeline.yaml
@@ -17,13 +17,13 @@ chapters:
       payload:
         response_processors:
           - sort:
-              field: 'message'
-              order: 'asc'
-              target_field: 'sorted_message'
+              field: message
+              order: asc
+              target_field: sorted_message
           - split:
-              field: 'message'
+              field: message
               separator: ', '
-              target_field: 'split_message'
+              target_field: split_message
     response:
       status: 200
       payload:

--- a/tests/_core/search/pipeline.yaml
+++ b/tests/_core/search/pipeline.yaml
@@ -1,4 +1,4 @@
-$schema: ../../json_schemas/test_story.schema.yaml
+$schema: ../../../json_schemas/test_story.schema.yaml
 
 description: |
   Test the creation of a search pipeline with sort and split response processors.
@@ -17,13 +17,13 @@ chapters:
       payload:
         response_processors:
           - sort:
-              field: "message"
-              order: "asc"
-              target_field: "sorted_message"
+              field: 'message'
+              order: 'asc'
+              target_field: 'sorted_message'
           - split:
-              field: "message"
-              separator: ", "
-              target_field: "split_message"
+              field: 'message'
+              separator: ', '
+              target_field: 'split_message'
     response:
       status: 200
       payload:

--- a/tests/_core/search/pipeline.yaml
+++ b/tests/_core/search/pipeline.yaml
@@ -1,0 +1,37 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: |
+  Test the creation of a search pipeline with sort and split response processors.
+epilogues:
+  - path: /_search/pipeline/sorting_pipeline
+    method: DELETE
+    status: [200, 404]
+version: '>= 2.16'
+chapters:
+  - synopsis: Create search pipeline for sorting and splitting.
+    path: /_search/pipeline/{id}
+    method: PUT
+    parameters:
+      id: sorting_pipeline
+    request_body:
+      payload:
+        response_processors:
+          - sort:
+              field: "message"
+              order: "asc"
+              target_field: "sorted_message"
+          - split:
+              field: "message"
+              separator: ", "
+              target_field: "split_message"
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Query created pipeline.
+    path: /_search/pipeline/{id}
+    method: GET
+    parameters:
+      id: sorting_pipeline
+    response:
+      status: 200


### PR DESCRIPTION
### Description

- Adds the missing Search Response Processors from Smithy spec migration
- Adds new processors for Sort and Split
  - https://github.com/opensearch-project/OpenSearch/pull/14785
  - https://github.com/opensearch-project/OpenSearch/pull/14800

### Issues Resolved

Fixes #437

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
