### PR TITLE
Added rudimentary test coverage counting paths being tested.

### DIFF
--- a/.cspell
+++ b/.cspell
@@ -47,6 +47,7 @@ aarch
 actiongroup
 actiongroups
 aggregatable
+argjson
 asciifolding
 authc
 authinfo

--- a/.github/pr-comment-templates/pr-test-coverage-analysis.template.md
+++ b/.github/pr-comment-templates/pr-test-coverage-analysis.template.md
@@ -1,0 +1,8 @@
+## Spec Test Coverage Analysis
+{{with .test_coverage}}
+
+| Total             | Tested                      |
+|-------------------|-----------------------------|
+| {{.paths_count}}  | {{.evaluated_paths_count}}  |
+
+{{end}}

--- a/.github/pr-comment-templates/pr-test-coverage-analysis.template.md
+++ b/.github/pr-comment-templates/pr-test-coverage-analysis.template.md
@@ -1,8 +1,8 @@
 ## Spec Test Coverage Analysis
 {{with .test_coverage}}
 
-| Total             | Tested                      |
-|-------------------|-----------------------------|
-| {{.paths_count}}  | {{.evaluated_paths_count}}  |
+| Total             | Tested                                                   |
+|-------------------|----------------------------------------------------------|
+| {{.paths_count}}  | {{.evaluated_paths_count}} ({{.evaluated_paths_pct}} %)  |
 
 {{end}}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - Analyze PR Changes
+      - Test Spec
     types:
       - completed
 

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -54,10 +54,61 @@ jobs:
         run: docker-compose up -d
 
       - name: Run Tests
-        run: npm run test:spec -- --opensearch-insecure --coverage test-spec-coverage-${{ matrix.entry.version }}.json
+        run: |
+          npm run test:spec -- --opensearch-insecure --coverage coverage/test-spec-coverage-${{ matrix.entry.version }}.json
 
       - name: Upload Test Coverage Results
         uses: actions/upload-artifact@v4
         with:
-          name: test-spec-coverage-${{ matrix.entry.version }}
-          path: test-spec-coverage-${{ matrix.entry.version }}.json      
+          name: coverage-${{ matrix.entry.version }}
+          path: coverage/test-spec-coverage-${{ matrix.entry.version }}.json
+
+  merge-coverage:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: test-opensearch-spec
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download Spec Coverage Data
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage
+
+      - name: Combine Test Coverage Data
+        shell: bash -eo pipefail {0}
+        run: |
+          jq -sc '
+            map(to_entries) |
+            flatten |
+            group_by(.key) |
+            map({key: .[0].key, value: map(.value) | max}) |
+            from_entries |
+            .' $(find ./coverage -name "test-spec-coverage-*.json") > ./coverage/coverage.json
+
+          cat ./coverage/coverage.json
+
+      - name: Construct Comment Data Payload
+        shell: bash -eo pipefail {0}
+        run: |
+          jq \
+            --arg pr_number ${PR_NUMBER} \
+            --slurpfile test_coverage ./coverage/coverage.json \
+            --null-input '
+            {
+              "pr_number": ($pr_number),
+              "comment_identifier": "# Test Coverage Analysis",
+              "template_name": "pr-test-coverage-analysis",
+              "template_data": {
+                "test_coverage": ($test_coverage[0])
+              }
+            }
+            ' | tee pr-comment.json
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Upload PR Comment Payload
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-comment
+          path: pr-comment.json

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -54,4 +54,10 @@ jobs:
         run: docker-compose up -d
 
       - name: Run Tests
-        run: npm run test:spec -- --opensearch-insecure
+        run: npm run test:spec -- --opensearch-insecure --coverage test-spec-coverage-${{ matrix.entry.version }}.json
+
+      - name: Upload Test Coverage Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-spec-coverage-${{ matrix.entry.version }}
+          path: test-spec-coverage-${{ matrix.entry.version }}.json      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `ignore_unmapped` to `GeoDistanceQuery` ([#427](https://github.com/opensearch-project/opensearch-api-specification/pull/427))
 - Added missing variants of `indices.put_alias` ([#434](https://github.com/opensearch-project/opensearch-api-specification/pull/434)) 
 - Added `plugins` to NodeInfoSettings ([#442](https://github.com/opensearch-project/opensearch-api-specification/pull/442)) 
+- Added test coverage ([#443](https://github.com/opensearch-project/opensearch-api-specification/pull/443))
 
 ### Changed
 

--- a/tools/src/tester/ChapterEvaluator.ts
+++ b/tools/src/tester/ChapterEvaluator.ts
@@ -48,6 +48,7 @@ export default class ChapterEvaluator {
     const output_values = ChapterOutput.extract_output_values(response, chapter.output)
     return {
       title: chapter.synopsis,
+      path: `${chapter.method} ${chapter.path}`,
       overall: { result: overall_result(Object.values(params).concat([
         request_body, status, payload_body_evaluation, payload_schema_evaluation
       ]).concat(output_values ? [output_values] : [])) },

--- a/tools/src/tester/MergedOpenApiSpec.ts
+++ b/tools/src/tester/MergedOpenApiSpec.ts
@@ -9,9 +9,10 @@
 
 import { OpenAPIV3 } from 'openapi-types'
 import { Logger } from '../Logger'
-import { determine_possible_schema_types, SpecificationContext } from '../_utils';
+import { determine_possible_schema_types, HTTP_METHODS, SpecificationContext } from '../_utils';
 import { SchemaVisitor } from '../_utils/SpecificationVisitor';
 import OpenApiMerger from '../merger/OpenApiMerger';
+import _ from 'lodash';
 
 // An augmented spec with additionalProperties: false.
 export default class MergedOpenApiSpec {
@@ -35,6 +36,16 @@ export default class MergedOpenApiSpec {
 
   api_version(): string {
     return (this.spec().info as any)['x-api-version']
+  }
+
+  paths(): Record<string, string[]> {
+    var obj: Record<string, string[]> = {}
+    _.entries(this.spec().paths).forEach(([path, ops]) => {
+      obj[path] = _.entries(_.pick(ops, HTTP_METHODS)).map(([verb, _]) => {
+        return verb
+      })
+    })
+    return obj
   }
 
   private inject_additional_properties(ctx: SpecificationContext, spec: OpenAPIV3.Document): void {

--- a/tools/src/tester/ResultLogger.ts
+++ b/tools/src/tester/ResultLogger.ts
@@ -7,20 +7,19 @@
 * compatible open source license.
 */
 
-import { type StoryEvaluations, type ChapterEvaluation, type Evaluation, Result, type StoryEvaluation } from './types/eval.types'
+import { type ChapterEvaluation, type Evaluation, Result, type StoryEvaluation } from './types/eval.types'
 import { overall_result } from './helpers'
 import * as ansi from './Ansi'
-import _ from 'lodash'
-import MergedOpenApiSpec from './MergedOpenApiSpec'
+import TestResults from './TestResults'
 
 export interface ResultLogger {
   log: (evaluation: StoryEvaluation) => void
-  log_coverage: (_spec: MergedOpenApiSpec, evaluations: StoryEvaluations) => void
+  log_coverage: (_results: TestResults) => void
 }
 
 export class NoOpResultLogger implements ResultLogger {
   log (_: StoryEvaluation): void { }
-  log_coverage(_spec: MergedOpenApiSpec, _evaluations: StoryEvaluations): void { }
+  log_coverage(_results: TestResults): void { }
 }
 
 export class ConsoleResultLogger implements ResultLogger {
@@ -42,14 +41,9 @@ export class ConsoleResultLogger implements ResultLogger {
     if (with_padding) console.log()
   }
 
-  log_coverage(spec: MergedOpenApiSpec, evaluations: StoryEvaluations): void {
-    const evaluated_paths = _.uniq(_.compact(_.flatten(_.map(evaluations.evaluations, (evaluation) =>
-      _.map(evaluation.chapters, (chapter) => chapter.path)
-    ))))
-
-    const total_paths = Object.values(spec.paths()).reduce((acc, methods) => acc + methods.length, 0);
+  log_coverage(results: TestResults): void {
     console.log()
-    console.log(`Tested ${evaluated_paths.length}/${total_paths} paths.`)
+    console.log(`Tested ${results.evaluated_paths_count()}/${results.spec_paths_count()} paths.`)
   }
 
   #log_story ({ result, full_path, display_path, message }: StoryEvaluation): void {

--- a/tools/src/tester/ResultLogger.ts
+++ b/tools/src/tester/ResultLogger.ts
@@ -7,16 +7,20 @@
 * compatible open source license.
 */
 
-import { type ChapterEvaluation, type Evaluation, Result, type StoryEvaluation } from './types/eval.types'
+import { type StoryEvaluations, type ChapterEvaluation, type Evaluation, Result, type StoryEvaluation } from './types/eval.types'
 import { overall_result } from './helpers'
 import * as ansi from './Ansi'
+import _ from 'lodash'
+import MergedOpenApiSpec from './MergedOpenApiSpec'
 
 export interface ResultLogger {
   log: (evaluation: StoryEvaluation) => void
+  log_coverage: (_spec: MergedOpenApiSpec, evaluations: StoryEvaluations) => void
 }
 
 export class NoOpResultLogger implements ResultLogger {
   log (_: StoryEvaluation): void { }
+  log_coverage(_spec: MergedOpenApiSpec, _evaluations: StoryEvaluations): void { }
 }
 
 export class ConsoleResultLogger implements ResultLogger {
@@ -36,6 +40,16 @@ export class ConsoleResultLogger implements ResultLogger {
     this.#log_chapters(evaluation.chapters ?? [], 'CHAPTERS')
     this.#log_chapters(evaluation.epilogues ?? [], 'EPILOGUES')
     if (with_padding) console.log()
+  }
+
+  log_coverage(spec: MergedOpenApiSpec, evaluations: StoryEvaluations): void {
+    const evaluated_paths = _.uniq(_.compact(_.flatten(_.map(evaluations.evaluations, (evaluation) =>
+      _.map(evaluation.chapters, (chapter) => chapter.path)
+    ))))
+
+    const total_paths = Object.values(spec.paths()).reduce((acc, methods) => acc + methods.length, 0);
+    console.log()
+    console.log(`Tested ${evaluated_paths.length}/${total_paths} paths.`)
   }
 
   #log_story ({ result, full_path, display_path, message }: StoryEvaluation): void {

--- a/tools/src/tester/StoryEvaluator.ts
+++ b/tools/src/tester/StoryEvaluator.ts
@@ -25,8 +25,8 @@ export default class StoryEvaluator {
     this._supplemental_chapter_evaluator = supplemental_chapter_evaluator
   }
 
-  async evaluate({ story, display_path, full_path }: StoryFile, version: string, dry_run: boolean = false): Promise<StoryEvaluation> {
-    if (story.version !== undefined && !semver.satisfies(version, story.version)) {
+  async evaluate({ story, display_path, full_path }: StoryFile, version?: string, dry_run: boolean = false): Promise<StoryEvaluation> {
+    if (version != undefined && story.version !== undefined && !semver.satisfies(version, story.version)) {
       return {
         result: Result.SKIPPED,
         display_path,
@@ -42,7 +42,7 @@ export default class StoryEvaluator {
     }
     const story_outputs = new StoryOutputs()
     const { evaluations: prologues, has_errors: prologue_errors } = await this.#evaluate_supplemental_chapters(story.prologues ?? [], dry_run, story_outputs)
-    const chapters = await this.#evaluate_chapters(story.chapters, prologue_errors, version, dry_run, story_outputs)
+    const chapters = await this.#evaluate_chapters(story.chapters, prologue_errors, dry_run, story_outputs, version)
     const { evaluations: epilogues } = await this.#evaluate_supplemental_chapters(story.epilogues ?? [], dry_run, story_outputs)
     return {
       display_path,
@@ -55,13 +55,13 @@ export default class StoryEvaluator {
     }
   }
 
-  async #evaluate_chapters(chapters: Chapter[], has_errors: boolean, version: string, dry_run: boolean, story_outputs: StoryOutputs): Promise<ChapterEvaluation[]> {
+  async #evaluate_chapters(chapters: Chapter[], has_errors: boolean, dry_run: boolean, story_outputs: StoryOutputs, version?: string): Promise<ChapterEvaluation[]> {
     const evaluations: ChapterEvaluation[] = []
     for (const chapter of chapters) {
       if (dry_run) {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
         evaluations.push({ title, overall: { result: Result.SKIPPED, message: 'Dry Run', error: undefined } })
-      } else if (chapter.version !== undefined && !semver.satisfies(version, chapter.version)) {
+      } else if (version != undefined && chapter.version !== undefined && !semver.satisfies(version, chapter.version)) {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
         evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because version ${version} does not satisfy ${chapter.version}.`, error: undefined } })
       } else {

--- a/tools/src/tester/TestResults.ts
+++ b/tools/src/tester/TestResults.ts
@@ -10,6 +10,8 @@
 import _ from "lodash";
 import MergedOpenApiSpec from "./MergedOpenApiSpec";
 import { StoryEvaluations } from "./types/eval.types";
+import { SpecTestCoverage } from "./types/test.types";
+import { write_json } from "../helpers";
 
 export default class TestResults {
   protected _spec: MergedOpenApiSpec
@@ -28,5 +30,16 @@ export default class TestResults {
 
   spec_paths_count(): number {
     return Object.values(this._spec.paths()).reduce((acc, methods) => acc + methods.length, 0);
+  }
+
+  test_coverage(): SpecTestCoverage {
+    return {
+      evaluated_paths_count: this.evaluated_paths_count(),
+      paths_count: this.spec_paths_count()
+    }
+  }
+
+  write_coverage(file_path: string): void {
+    write_json(file_path, this.test_coverage())
   }
 }

--- a/tools/src/tester/TestResults.ts
+++ b/tools/src/tester/TestResults.ts
@@ -1,0 +1,32 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+import _ from "lodash";
+import MergedOpenApiSpec from "./MergedOpenApiSpec";
+import { StoryEvaluations } from "./types/eval.types";
+
+export default class TestResults {
+  protected _spec: MergedOpenApiSpec
+  protected _evaluations: StoryEvaluations
+
+  constructor(spec: MergedOpenApiSpec, evaluations: StoryEvaluations) {
+    this._spec = spec
+    this._evaluations = evaluations
+  }
+
+  evaluated_paths_count(): number {
+    return _.uniq(_.compact(_.flatten(_.map(this._evaluations.evaluations, (evaluation) =>
+      _.map(evaluation.chapters, (chapter) => chapter.path)
+    )))).length
+  }
+
+  spec_paths_count(): number {
+    return Object.values(this._spec.paths()).reduce((acc, methods) => acc + methods.length, 0);
+  }
+}

--- a/tools/src/tester/TestResults.ts
+++ b/tools/src/tester/TestResults.ts
@@ -35,7 +35,10 @@ export default class TestResults {
   test_coverage(): SpecTestCoverage {
     return {
       evaluated_paths_count: this.evaluated_paths_count(),
-      paths_count: this.spec_paths_count()
+      paths_count: this.spec_paths_count(),
+      evaluated_paths_pct: this.spec_paths_count() > 0 ? Math.round(
+        this.evaluated_paths_count() / this.spec_paths_count() * 100 * 100
+      ) / 100 : 0,
     }
   }
 

--- a/tools/src/tester/test.ts
+++ b/tools/src/tester/test.ts
@@ -65,8 +65,14 @@ const runner = new TestRunner(http_client, story_validator, story_evaluator, res
 runner.run(opts.testsPath, spec.api_version(), opts.dryRun)
   .then(
     ({ results, failed }) => {
+
       const test_results = new TestResults(spec, results)
       result_logger.log_coverage(test_results)
+      if (opts.coverage !== undefined) {
+        console.log(`Writing ${opts.coverage} ...`)
+        test_results.write_coverage(opts.coverage)
+      }
+
       if (failed) process.exit(1)
     },
     err => { throw err })

--- a/tools/src/tester/test.ts
+++ b/tools/src/tester/test.ts
@@ -28,6 +28,7 @@ import * as process from 'node:process'
 import SupplementalChapterEvaluator from './SupplementalChapterEvaluator'
 import MergedOpenApiSpec from './MergedOpenApiSpec'
 import StoryValidator from "./StoryValidator";
+import TestResults from './TestResults'
 
 const command = new Command()
   .description('Run test stories against the OpenSearch spec.')
@@ -44,6 +45,7 @@ const command = new Command()
   .addOption(OPENSEARCH_USERNAME_OPTION)
   .addOption(OPENSEARCH_PASSWORD_OPTION)
   .addOption(OPENSEARCH_INSECURE_OPTION)
+  .addOption(new Option('--coverage <path>', 'path to write test coverage results to'))
   .allowExcessArguments(false)
   .parse()
 
@@ -63,7 +65,8 @@ const runner = new TestRunner(http_client, story_validator, story_evaluator, res
 runner.run(opts.testsPath, spec.api_version(), opts.dryRun)
   .then(
     ({ results, failed }) => {
-      result_logger.log_coverage(spec, results)
+      const test_results = new TestResults(spec, results)
+      result_logger.log_coverage(test_results)
       if (failed) process.exit(1)
     },
     err => { throw err })

--- a/tools/src/tester/test.ts
+++ b/tools/src/tester/test.ts
@@ -62,7 +62,8 @@ const runner = new TestRunner(http_client, story_validator, story_evaluator, res
 
 runner.run(opts.testsPath, spec.api_version(), opts.dryRun)
   .then(
-    ({ failed }) => {
+    ({ results, failed }) => {
+      result_logger.log_coverage(spec, results)
       if (failed) process.exit(1)
     },
     err => { throw err })

--- a/tools/src/tester/types/eval.types.ts
+++ b/tools/src/tester/types/eval.types.ts
@@ -28,9 +28,14 @@ export interface StoryEvaluation {
   prologues?: ChapterEvaluation[]
 }
 
+export interface StoryEvaluations {
+  evaluations: StoryEvaluation[]
+}
+
 export interface ChapterEvaluation {
-  title: string
-  overall: Evaluation
+  title: string,
+  overall: Evaluation,
+  path?: string,
   request?: {
     parameters?: Record<string, Evaluation>
     request_body?: Evaluation

--- a/tools/src/tester/types/test.types.ts
+++ b/tools/src/tester/types/test.types.ts
@@ -1,0 +1,13 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+export interface SpecTestCoverage {
+  paths_count: number
+  evaluated_paths_count: number
+}

--- a/tools/src/tester/types/test.types.ts
+++ b/tools/src/tester/types/test.types.ts
@@ -9,5 +9,6 @@
 
 export interface SpecTestCoverage {
   paths_count: number
-  evaluated_paths_count: number
+  evaluated_paths_count: number,
+  evaluated_paths_pct: number
 }

--- a/tools/tests/tester/MergedOpenApiSpec.test.ts
+++ b/tools/tests/tester/MergedOpenApiSpec.test.ts
@@ -10,36 +10,47 @@
 import { Logger } from 'Logger'
 import MergedOpenApiSpec from "tester/MergedOpenApiSpec"
 
-describe('unevaluatedProperties', () => {
+describe('merged API spec', () => {
   const spec = new MergedOpenApiSpec('tools/tests/tester/fixtures/specs/complete', new Logger())
-  const responses: any = spec.spec().components?.responses
 
   test('has an api version', () => {
     expect(spec.api_version()).toEqual('1.2.3')
   })
 
-  test('is added with required fields', () => {
-    const schema = responses['info@200'].content['application/json'].schema
-    expect(schema.unevaluatedProperties).toEqual({ not: true, errorMessage: 'property is not defined in the spec' })
+  test('paths', () => {
+    expect(spec.paths()).toEqual({
+      '/_nodes/{id}': ['get', 'post'],
+      '/index': ['get'],
+      '/nodes': ['get']
+    })
   })
 
-  test('is added when no required fields', () => {
-    const schema = responses['info@500'].content['application/json'].schema
-    expect(schema.unevaluatedProperties).toEqual({ not: true, errorMessage: 'property is not defined in the spec' })
-  })
+  describe('unevaluatedProperties', () => {
+    const responses: any = spec.spec().components?.responses
 
-  test('is not added to empty object schema', () => {
-    const schema = responses['info@503'].content['application/json'].schema
-    expect(schema.unevaluatedProperties).toBeUndefined()
-  })
+    test('is added with required fields', () => {
+      const schema = responses['info@200'].content['application/json'].schema
+      expect(schema.unevaluatedProperties).toEqual({ not: true, errorMessage: 'property is not defined in the spec' })
+    })
 
-  test('is not added when true', () => {
-    const schema = responses['info@201'].content['application/json'].schema
-    expect(schema.unevaluatedProperties).toEqual(true)
-  })
+    test('is added when no required fields', () => {
+      const schema = responses['info@500'].content['application/json'].schema
+      expect(schema.unevaluatedProperties).toEqual({ not: true, errorMessage: 'property is not defined in the spec' })
+    })
 
-  test('is not added when object', () => {
-    const schema = responses['info@404'].content['application/json'].schema
-    expect(schema.unevaluatedProperties).toEqual({ type: 'object' })
+    test('is not added to empty object schema', () => {
+      const schema = responses['info@503'].content['application/json'].schema
+      expect(schema.unevaluatedProperties).toBeUndefined()
+    })
+
+    test('is not added when true', () => {
+      const schema = responses['info@201'].content['application/json'].schema
+      expect(schema.unevaluatedProperties).toEqual(true)
+    })
+
+    test('is not added when object', () => {
+      const schema = responses['info@404'].content['application/json'].schema
+      expect(schema.unevaluatedProperties).toEqual({ type: 'object' })
+    })
   })
 })

--- a/tools/tests/tester/ResultLogger.test.ts
+++ b/tools/tests/tester/ResultLogger.test.ts
@@ -10,6 +10,8 @@
 import { ConsoleResultLogger } from "tester/ResultLogger"
 import { Result } from "tester/types/eval.types"
 import * as ansi from 'tester/Ansi'
+import MergedOpenApiSpec from "tester/MergedOpenApiSpec"
+import TestResults from "tester/TestResults"
 
 describe('ConsoleResultLogger', () => {
   let log: jest.Mock
@@ -50,6 +52,30 @@ describe('ConsoleResultLogger', () => {
         [`   ${ansi.green('PASSED ')} CHAPTERS`],
         [`      ${ansi.green('PASSED ')} ${ansi.i('title')}`],
         []
+      ])
+    })
+
+    test('log_coverage', () => {
+      const spec = new MergedOpenApiSpec('tools/tests/tester/fixtures/specs/complete')
+      const test_results = new TestResults(spec, { evaluations: [{
+        result: Result.PASSED,
+        display_path: 'path',
+        full_path: 'path',
+        description: 'description',
+        chapters: [
+          {
+            title: 'title',
+            overall: { result: Result.PASSED },
+            path: 'path'
+          }
+        ]
+      }] })
+
+      logger.log_coverage(test_results)
+
+      expect(log.mock.calls).toEqual([
+        [],
+        ['Tested 1/4 paths.']
       ])
     })
   })

--- a/tools/tests/tester/TestResults.test.ts
+++ b/tools/tests/tester/TestResults.test.ts
@@ -1,0 +1,43 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+import MergedOpenApiSpec from "tester/MergedOpenApiSpec"
+import TestResults from "tester/TestResults"
+import { Result } from "tester/types/eval.types"
+
+describe('TestResults', () => {
+  const spec = new MergedOpenApiSpec('tools/tests/tester/fixtures/specs/complete')
+
+  const evaluations = [{
+    result: Result.PASSED,
+    display_path: 'path',
+    full_path: 'full_path',
+    description: 'description',
+    message: 'message',
+    chapters: [{
+      title: 'title',
+      overall: {
+        result: Result.PASSED
+      },
+      path: 'path'
+    }],
+    epilogues: [],
+    prologues: []
+  }]
+
+  const test_results = new TestResults(spec, { evaluations })
+
+  test('evaluated_paths_count', () => {
+    expect(test_results.evaluated_paths_count()).toEqual(1)
+  })
+
+  test('spec_paths_count', () => {
+    expect(test_results.spec_paths_count()).toEqual(4)
+  })
+})

--- a/tools/tests/tester/TestResults.test.ts
+++ b/tools/tests/tester/TestResults.test.ts
@@ -10,6 +10,7 @@
 import MergedOpenApiSpec from "tester/MergedOpenApiSpec"
 import TestResults from "tester/TestResults"
 import { Result } from "tester/types/eval.types"
+import fs from 'fs'
 
 describe('TestResults', () => {
   const spec = new MergedOpenApiSpec('tools/tests/tester/fixtures/specs/complete')
@@ -39,5 +40,15 @@ describe('TestResults', () => {
 
   test('spec_paths_count', () => {
     expect(test_results.spec_paths_count()).toEqual(4)
+  })
+
+  test('write_coverage', () => {
+    const filename = 'coverage.json'
+    test_results.write_coverage(filename)
+    expect(JSON.parse(fs.readFileSync(filename, 'utf8'))).toEqual({
+      evaluated_paths_count: 1,
+      paths_count: 4
+    })
+    fs.unlinkSync(filename)
   })
 })

--- a/tools/tests/tester/TestResults.test.ts
+++ b/tools/tests/tester/TestResults.test.ts
@@ -47,6 +47,7 @@ describe('TestResults', () => {
     test_results.write_coverage(filename)
     expect(JSON.parse(fs.readFileSync(filename, 'utf8'))).toEqual({
       evaluated_paths_count: 1,
+      evaluated_paths_pct: 25,
       paths_count: 4
     })
     fs.unlinkSync(filename)

--- a/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
+++ b/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
@@ -17,6 +17,7 @@ chapters:
   - title: This chapter show throw an error.
     overall:
       result: ERROR
+    path: DELETE /{index}
     request:
       parameters: {}
       request_body:

--- a/tools/tests/tester/fixtures/evals/failed/invalid_data.yaml
+++ b/tools/tests/tester/fixtures/evals/failed/invalid_data.yaml
@@ -10,6 +10,7 @@ chapters:
   - title: This chapter should fail because the parameter is invalid.
     overall:
       result: FAILED
+    path: PUT /{index}
     request:
       parameters:
         index:
@@ -27,6 +28,7 @@ chapters:
   - title: This chapter should fail because the request body is invalid.
     overall:
       result: FAILED
+    path: PUT /{index}
     request:
       parameters:
         index:
@@ -44,6 +46,7 @@ chapters:
   - title: This chapter should fail because the response content type does not match.
     overall:
       result: FAILED
+    path: GET /_cat/indices/{index}
     request:
       parameters:
         format:
@@ -63,6 +66,7 @@ chapters:
   - title: This chapter should fail because the response data and schema are invalid.
     overall:
       result: FAILED
+    path: DELETE /{index}
     request:
       parameters:
         index:
@@ -81,6 +85,7 @@ chapters:
   - title: This chapter should fail because the response status does not match.
     overall:
       result: ERROR
+    path: PUT /{index}
     request:
       parameters:
         index:

--- a/tools/tests/tester/fixtures/evals/failed/not_found.yaml
+++ b/tools/tests/tester/fixtures/evals/failed/not_found.yaml
@@ -14,6 +14,7 @@ chapters:
   - title: This chapter should fail because the parameter is not defined in the spec.
     overall:
       result: FAILED
+    path: PUT /{index}
     request:
       parameters:
         index:
@@ -33,6 +34,7 @@ chapters:
   - title: This chapter should fail because the request body is not defined in the spec.
     overall:
       result: FAILED
+    path: HEAD /{index}
     request:
       parameters:
         index:
@@ -50,6 +52,7 @@ chapters:
   - title: This chapter should fail because the response is not defined in the spec.
     overall:
       result: FAILED
+    path: DELETE /{index}
     request:
       parameters:
         index:

--- a/tools/tests/tester/fixtures/evals/passed.yaml
+++ b/tools/tests/tester/fixtures/evals/passed.yaml
@@ -10,6 +10,7 @@ chapters:
   - title: This PUT /{index} chapter should pass.
     overall:
       result: PASSED
+    path: PUT /{index}
     request:
       parameters:
         index:
@@ -26,6 +27,7 @@ chapters:
   - title: This GET /_cat chapter returns text/plain and should pass.
     overall:
       result: PASSED
+    path: GET /_cat
     request:
       parameters: {}
       request_body:
@@ -40,6 +42,7 @@ chapters:
   - title: This GET /_cat/health chapter returns application/json and should pass.
     overall:
       result: PASSED
+    path: GET /_cat/health
     request:
       parameters:
         format:
@@ -56,6 +59,7 @@ chapters:
   - title: This GET /_cat/health chapter returns application/yaml and should pass.
     overall:
       result: PASSED
+    path: GET /_cat/health
     request:
       parameters:
         format:
@@ -72,6 +76,7 @@ chapters:
   - title: This GET /_cat/health chapter returns application/cbor and should pass.
     overall:
       result: PASSED
+    path: GET /_cat/health
     request:
       parameters:
         format:
@@ -88,6 +93,7 @@ chapters:
   - title: This GET /_cat/health chapter returns application/smile and should pass.
     overall:
       result: PASSED
+    path: GET /_cat/health
     request:
       parameters:
         format:
@@ -104,6 +110,7 @@ chapters:
   - title: This GET /_cat/health should run (default).
     overall:
       result: PASSED
+    path: GET /_cat/health
     request:
       parameters:
         format:
@@ -120,6 +127,7 @@ chapters:
   - title: This GET /_cat/health should run (~> 2.x).
     overall:
       result: PASSED
+    path: GET /_cat/health
     request:
       parameters:
         format:

--- a/tools/tests/tester/fixtures/specs/complete/namespaces/nodes.yaml
+++ b/tools/tests/tester/fixtures/specs/complete/namespaces/nodes.yaml
@@ -1,0 +1,61 @@
+openapi: 3.1.0
+info:
+  title: OpenSearch API
+  description: OpenSearch API
+  version: 1.0.0
+paths:
+  /nodes:
+    get:
+      operationId: nodes.0
+      responses:
+        '200':
+          $ref: '#/components/responses/nodes.info@200'
+  /_nodes/{id}:
+    get:
+      operationId: nodes.info.1
+      x-operation-group: nodes.info
+      x-version-added: '1.0'
+      description: Returns information about nodes in the cluster.
+      parameters:
+        - $ref: '#/components/parameters/nodes.info::path.id'
+      responses:
+        '200':
+          $ref: '#/components/responses/nodes.info@200'
+    post:
+      operationId: nodes.info.1
+      x-operation-group: nodes.info
+      x-version-added: '1.0'
+      description: Returns information about nodes in the cluster.
+      parameters:
+        - $ref: '#/components/parameters/nodes.info::path.id'
+      requestBody:
+        $ref: '#/components/requestBodies/nodes.info'
+      responses:
+        '200':
+          $ref: '#/components/responses/nodes.info@200'
+components:
+  requestBodies:
+    nodes.info:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              _all:
+                type: boolean
+            description: Nodes options.
+  parameters:
+    nodes.info::path.id:
+      in: path
+      name: id
+      description: Node ID.
+      required: true
+      schema:
+        type: string
+  responses:
+    nodes.info@200:
+      description: All nodes.
+      content:
+        application/json:
+          schema:
+            type: object

--- a/tools/tests/tester/integ/TestRunner.test.ts
+++ b/tools/tests/tester/integ/TestRunner.test.ts
@@ -16,13 +16,13 @@ test('stories folder', async () => {
   const info = await opensearch_http_client.wait_until_available()
   expect(info.version).toBeDefined()
 
-  const result = await test_runner.run('tools/tests/tester/fixtures/stories')
+  const run = await test_runner.run('tools/tests/tester/fixtures/stories')
 
-  expect(result.failed).toBeTruthy()
+  expect(run.failed).toBeTruthy()
 
   const actual_evaluations: Array<Omit<StoryEvaluation, 'full_path'>> = []
 
-  for (const evaluation of result.evaluations) {
+  for (const evaluation of run.results.evaluations) {
     const { full_path, ...rest } = flatten_errors(evaluation)
     expect(full_path.endsWith(rest.display_path)).toBeTruthy()
     actual_evaluations.push(rest)


### PR DESCRIPTION
### Description

Adds rudimentary test coverage. Not quite codecov integration, but it's a start ;) Counts the total number of paths in the spec vs. the number of paths being tested by test runner, takes the max from the runs against multiple version of OpenSearch. Appends a coverage analysis using the existing PR comment mechanism.

Demo in https://github.com/dblock/opensearch-api-specification/pull/13.

<img width="938" alt="Screenshot 2024-07-19 at 6 22 16 PM" src="https://github.com/user-attachments/assets/bfc7bf83-a289-4ceb-b0d6-b22e5b716514">

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/issues/406.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
