### PR TITLE
Porter stem

### DIFF
--- a/tests/_core/search/porter_stem_token_filter.yaml
+++ b/tests/_core/search/porter_stem_token_filter.yaml
@@ -1,0 +1,55 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test Porter filter
+prologues:
+  - path: /movies
+    method: PUT
+    request_body:
+      payload:
+        settings:
+          analysis:
+            analyzer:
+              my_analyzer:
+                tokenizer: whitespace
+                filter: ['lowercase', 'porter_stem']
+    status: [200]
+  - path: /movies/_doc
+    method: POST
+    parameters:
+      refresh: true
+    request_body:
+      payload:
+        director: Consolingly
+        title: Moneyball
+        year: 2011
+    status: [201]
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Search with a match query field.
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request_body:
+      payload:
+        size: 1
+        query:
+          match:
+            director: Consolingli
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 1
+            relation: eq
+          hits:
+            - _index: movies
+              _source:
+                director: Consolingly
+                title: Moneyball
+                year: 2011


### PR DESCRIPTION
@dblock Following #444 let's add a test for a currently available filter.

Actually I wasn't familiar with the testing system and so and it was fun!

This one currently fails with the following as I haven't figured out how to hook any filter. As far as I know I should configure an analyzer but not sure how and couldn't find something similar so I can learn from but the whole thing looks nice!

```
FAILED  _core/search/porter_stem_token_filter.yaml (/Users/ebrahim/opensearch-api-specification/tests/_core/search/porter_stem_token_filter.yaml)
    FAILED  CHAPTERS
        FAILED  Search with a match query field.
            PASSED  PARAMETERS
                PASSED  index
            PASSED  REQUEST BODY
            PASSED  RESPONSE STATUS
            FAILED  RESPONSE PAYLOAD BODY (expected hits.total.value='1', got '0', missing hits.hits[0]='[object Object]')
            PASSED  RESPONSE PAYLOAD SCHEMA
```