### PR TITLE
Fix the documentation urls of alias related APIs

### DIFF
--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -26,7 +26,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::query.cluster_manager_timeout'
         - $ref: '#/components/parameters/indices.put_alias::query.master_timeout'
@@ -75,7 +75,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.name'
         - $ref: '#/components/parameters/indices.put_alias::query.cluster_manager_timeout'
@@ -92,7 +92,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.name'
         - $ref: '#/components/parameters/indices.put_alias::query.cluster_manager_timeout'
@@ -110,7 +110,7 @@ paths:
       x-version-added: '1.0'
       description: Updates index aliases.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/alias/
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/alias/
       parameters:
         - $ref: '#/components/parameters/indices.update_aliases::query.cluster_manager_timeout'
         - $ref: '#/components/parameters/indices.update_aliases::query.master_timeout'
@@ -127,7 +127,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.name'
         - $ref: '#/components/parameters/indices.put_alias::query.cluster_manager_timeout'
@@ -144,7 +144,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.name'
         - $ref: '#/components/parameters/indices.put_alias::query.cluster_manager_timeout'
@@ -1049,7 +1049,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.index'
         - $ref: '#/components/parameters/indices.put_alias::query.cluster_manager_timeout'
@@ -1101,7 +1101,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.index'
         - $ref: '#/components/parameters/indices.put_alias::path.name'
@@ -1119,7 +1119,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.index'
         - $ref: '#/components/parameters/indices.put_alias::path.name'
@@ -1154,7 +1154,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.index'
         - $ref: '#/components/parameters/indices.put_alias::query.cluster_manager_timeout'
@@ -1172,7 +1172,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.index'
         - $ref: '#/components/parameters/indices.put_alias::path.name'
@@ -1190,7 +1190,7 @@ paths:
       x-version-added: '1.0'
       description: Creates or updates an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#create-aliases
+        url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
       parameters:
         - $ref: '#/components/parameters/indices.put_alias::path.index'
         - $ref: '#/components/parameters/indices.put_alias::path.name'


### PR DESCRIPTION
### Description

After this [documentation PR](https://github.com/opensearch-project/documentation-website/pull/7641) is merged, we now have the official documentation for the Create or Update alias API, we need to correct the documentation url in this repo.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
