### PR TITLE
Fix: _update_by_query with a term.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `/_mapping` with `index` in query ([#385](https://github.com/opensearch-project/opensearch-api-specification/pull/385))
 - Fixed duplicate `/_nodes/{node_id}` path ([#416](https://github.com/opensearch-project/opensearch-api-specification/pull/416))
 - Fixed `_source` accepting an array of fields in `/_search` ([#430](https://github.com/opensearch-project/opensearch-api-specification/pull/430))
+- Fixed `_update_by_query` with a simple term ([451](https://github.com/opensearch-project/opensearch-api-specification/pull/451))
 
 ### Security
 

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -182,7 +182,9 @@ components:
             To return a document, the query term must exactly match the queried field's value, including whitespace and capitalization.
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/TermQuery'
+            anyOf:
+              - $ref: '#/components/schemas/TermQuery'
+              - $ref: '_common.yaml#/components/schemas/FieldValue'
           minProperties: 1
           maxProperties: 1
         terms:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -416,8 +416,7 @@ components:
             Specifies any named parameters that are passed into the script as variables.
             Use parameters instead of hard-coded values to decrease compile time.
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
     StoredScriptId:
       allOf:
         - $ref: '#/components/schemas/ScriptBase'

--- a/tests/_core/reindex.yaml
+++ b/tests/_core/reindex.yaml
@@ -11,28 +11,7 @@ epilogues:
   - path: /videos
     method: DELETE
     status: [200, 404]
-  - path: /_ingest/pipeline/transform-and-count
-    method: DELETE
-    status: [200, 404]
 prologues:
-  - path: /_ingest/pipeline/transform-and-count
-    method: PUT
-    request_body:
-      payload:
-        description: |
-          Splits the `title`` field into a `words` list.
-          Computes the length of the title field and stores it in a new `length` field.
-          Removes the `year` field.
-        processors:
-          - split:
-              field: title
-              separator: '\s+'
-              target_field: words
-          - script:
-              lang: painless
-              source: ctx.length = ctx.words.length
-          - remove:
-              field: year
   - path: /{index}/_doc
     method: POST
     parameters:
@@ -135,56 +114,6 @@ chapters:
       status: 200
       payload:
         total: 1
-  - synopsis: Transform documents using a pipeline.
-    path: /_reindex
-    method: POST
-    request_body:
-      payload:
-        source:
-          index: movies
-        dest:
-          index: videos
-          pipeline: transform-and-count
-    response:
-      status: 200
-  - synopsis: Refresh the index.
-    path: /{index}/_refresh
-    method: POST
-    parameters:
-      index: videos
-  - synopsis: Get all videos.
-    path: /{index}/_search
-    method: POST
-    parameters:
-      index: videos
-    request_body:
-      payload:
-        query:
-          match_all: {}
-    response:
-      status: 200
-      payload:
-        hits:
-          hits:
-            - _index: videos
-              _source:
-                words:
-                  - Beauty
-                  - and
-                  - the
-                  # eslint-disable-next-line yml/sort-sequence-values
-                  - Beast
-                length: 4
-                title: Beauty and the Beast
-  - synopsis: Update documents in the current index.
-    path: /{index}/_update_by_query
-    method: POST
-    parameters:
-      index: videos
-    response:
-      status: 200
-      payload:
-        updated: 1
   - synopsis: Reindex from movies to films with all options.
     path: /_reindex
     method: POST

--- a/tests/_core/reindex/pipeline.yaml
+++ b/tests/_core/reindex/pipeline.yaml
@@ -1,0 +1,84 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test reindex with a Search pipeline.
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+  - path: /videos
+    method: DELETE
+    status: [200, 404]
+  - path: /_ingest/pipeline/transform-and-count
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /_ingest/pipeline/transform-and-count
+    method: PUT
+    request_body:
+      payload:
+        description: |
+          Splits the `title`` field into a `words` list.
+          Computes the length of the title field and stores it in a new `length` field.
+          Removes the `year` field.
+        processors:
+          - split:
+              field: title
+              separator: '\s+'
+              target_field: words
+          - script:
+              lang: painless
+              source: ctx.length = ctx.words.length
+          - remove:
+              field: year
+  - path: /{index}/_doc
+    method: POST
+    parameters:
+      index: movies
+      refresh: true
+    request_body:
+      payload:
+        title: Beauty and the Beast
+        year: 91
+    status: [201]
+chapters:
+  - synopsis: Transform documents using a pipeline.
+    path: /_reindex
+    method: POST
+    request_body:
+      payload:
+        source:
+          index: movies
+        dest:
+          index: videos
+          pipeline: transform-and-count
+    response:
+      status: 200
+  - synopsis: Refresh the index.
+    path: /{index}/_refresh
+    method: POST
+    parameters:
+      index: videos
+  - synopsis: Get all videos.
+    path: /{index}/_search
+    method: POST
+    parameters:
+      index: videos
+    request_body:
+      payload:
+        query:
+          match_all: {}
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _index: videos
+              _source:
+                words:
+                  - Beauty
+                  - and
+                  - the
+                  # eslint-disable-next-line yml/sort-sequence-values
+                  - Beast
+                length: 4
+                title: Beauty and the Beast

--- a/tests/indices/update_by_query.yaml
+++ b/tests/indices/update_by_query.yaml
@@ -1,0 +1,72 @@
+$schema: ../../json_schemas/test_story.schema.yaml
+
+description: Test reindex.
+epilogues:
+  - path: /books
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request_body:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: books, _id: book_1392214}}
+        - {author: Harper Lee, title: To Kill a Mockingbird, year: 60}
+        - {create: {_index: books, _id: book_1392215}}
+        - {author: Elizabeth Rudnick, title: Beauty and the Beast, year: 91}
+chapters:
+  - synopsis: Update documents in the index.
+    path: /{index}/_update_by_query
+    method: POST
+    parameters:
+      index: books
+      refresh: true
+    response:
+      status: 200
+      payload:
+        updated: 2
+  - synopsis: Update documents in the index (full query term, script).
+    path: /{index}/_update_by_query
+    method: POST
+    parameters:
+      index: books
+    request_body:
+      payload:
+        query:
+          term:
+            title:
+              _name: title
+              value: beauty
+              case_insensitive: true
+              boost: 1
+        script:
+          source: ctx._source.year += params.century
+          lang: painless
+          params:
+            century: 1900
+    response:
+      status: 200
+      payload:
+        updated: 1
+  - synopsis: Update documents in the index (simple term, script).
+    path: /{index}/_update_by_query
+    method: POST
+    parameters:
+      index: books
+    request_body:
+      payload:
+        query:
+          term:
+            year: 60
+        script:
+          source: ctx._source.year += params.century
+          lang: painless
+          params:
+            century: 1900
+    response:
+      status: 200
+      payload:
+        updated: 1


### PR DESCRIPTION
### Description

The `{index}/_update_by_query` API also can take an arbitrary term per [the docs](https://opensearch.org/docs/latest/api-reference/document-apis/update-by-query/).

What's the right fix for this? Removing `additionalProperties` with `TermQuery` doesn't seem right, but I'm not sure how to turn `TermQuery` into something generic at the same time as not.

```
          additionalProperties:
            $ref: '#/components/schemas/TermQuery'
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
