### PR TITLE
Add experimental features flag option for tests

### DIFF
--- a/.github/opensearch-cluster/docker-compose.yml
+++ b/.github/opensearch-cluster/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - '9600:9600'
     environment:
       - 'OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_PASSWORD:-myStrongPassword123!}'
+      - OPENSEARCH_JAVA_OPTS=${OPENSEARCH_JAVA_OPTS}
       - discovery.type=single-node
       - path.repo=/tmp/opensearch/repo
       - plugins.index_state_management.job_interval=1

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -26,7 +26,9 @@ jobs:
           - {version: 1.3.17, admin_password: admin}
           - {version: 2.0.0, admin_password: admin}
           - {version: 2.15.0}
-          - {version: 2.16.0, hub: opensearchstaging, ref: '@sha256:50fbfe3b95c41e92a113ada3e80513ba4524dfc8a25dc6aaeff2bbe1e1145d5f'}
+          - version: 2.16.0
+            hub: opensearchstaging
+            ref: '@sha256:50fbfe3b95c41e92a113ada3e80513ba4524dfc8a25dc6aaeff2bbe1e1145d5f'
 
     name: test-opensearch-spec (version=${{ matrix.entry.version }}, hub=${{ matrix.entry.hub || 'opensearchproject' }})
     runs-on: ubuntu-latest
@@ -36,6 +38,7 @@ jobs:
       OPENSEARCH_DOCKER_REF: ${{ matrix.entry.ref }}
       OPENSEARCH_VERSION: ${{ matrix.entry.version }}
       OPENSEARCH_PASSWORD: ${{ matrix.entry.admin_password || 'myStrongPassword123!' }}
+      OPENSEARCH_JAVA_OPTS: ${{ matrix.entry.opts }}
 
     steps:
       - name: Checkout Repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added test coverage ([#443](https://github.com/opensearch-project/opensearch-api-specification/pull/443))
 - Added `--opensearch-version` to `merger` that excludes schema elements per semver ([#428](https://github.com/opensearch-project/opensearch-api-specification/pull/428))
 - Added `retry` to `tester` to support asynchronous tasks ([453](https://github.com/opensearch-project/opensearch-api-specification/pull/453))
+- Added passing OPENSEARCH_JAVA_OPTS into the docker container used for tests ([#454](https://github.com/opensearch-project/opensearch-api-specification/pull/454))
 
 ### Changed
 


### PR DESCRIPTION
### Description
As of now, there is no way in the tests to turn on the experimental feature flags for the tests, this pr aims to address it.

### Issues Resolved
Related prs: https://github.com/opensearch-project/opensearch-api-specification/pull/368

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
