### PR TITLE
Get jvm and fs metric node stats with multiple nodes.

### DIFF
--- a/tests/nodes/stats.yaml
+++ b/tests/nodes/stats.yaml
@@ -52,6 +52,18 @@ chapters:
         - jvm
     response:
       status: 200
+  - synopsis: Get jvm and fs metric node stats with multiple nodes.
+    path: /_nodes/{node_id}/stats/{metric}
+    method: GET
+    parameters:
+      node_id:
+        - cluster_manager:false
+        - data:true
+      metric:
+        - fs
+        - jvm
+    response:
+      status: 200
   - synopsis: Get statistics for the request_cache.
     path: /_nodes/stats/{metric}/{index_metric}
     method: GET


### PR DESCRIPTION
### Description

Adds one more example from https://github.com/opensearch-project/opensearch-api-specification/pull/377 which can be closed.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/pull/377.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
