### PR TITLE
Replaced docker-compose (v1) with docker compose (v2).

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run OpenSearch Cluster
         working-directory: .github/opensearch-cluster
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Run Tests
         run: |

--- a/.github/workflows/test-tools-integ.yml
+++ b/.github/workflows/test-tools-integ.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run OpenSearch Cluster
         working-directory: .github/opensearch-cluster
         run: |
-          docker-compose up -d
+          docker compose up -d
           sleep 15
 
       - name: Setup Node.js

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -20,7 +20,7 @@ Set up an OpenSearch cluster with Docker:
 ```bash
 export OPENSEARCH_PASSWORD=<<your_password>>
 cd .github/opensearch-cluster
-docker-compose up -d
+docker compose up -d
 ```
 
 Run the tests (use `--opensearch-insecure` for a local cluster running in Docker that does not have a valid SSL certificate):


### PR DESCRIPTION
### Description

Per https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/, replaces `docker-compose` with `docker compose`.

### Issues Resolved

Closes #457.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
