### PR TITLE
Add additionalProperties to ErrorCause and fix creation_date type for list_dangling_indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `/_plugins/_ppl`, `explain` and `stats` ([#460](https://github.com/opensearch-project/opensearch-api-specification/pull/460))
 - Added tests against OpenSearch 3.0 ([#459](https://github.com/opensearch-project/opensearch-api-specification/pull/459))
 - Added support for request headers in tests [#461](https://github.com/opensearch-project/opensearch-api-specification/pull/461)
-
+- Added metadata additionalProperties to `ErrorCause` ([#462](https://github.com/opensearch-project/opensearch-api-specification/pull/462))
+- Added `creation_date` field to `DanglingIndex` ([#462](https://github.com/opensearch-project/opensearch-api-specification/pull/462))
+ 
 ### Changed
 
 - Replaced Smithy with a native OpenAPI spec ([#189](https://github.com/opensearch-project/opensearch-api-specification/issues/189))

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -139,6 +139,7 @@ components:
     UnitMillis:
       description: Time unit for milliseconds.
       type: number
+      format: int64
     DurationLarge:
       description: |-
         A date histogram interval. Similar to `Duration` with additional units: `w` (week), `M` (month), `q` (quarter) and `y` (year).
@@ -314,6 +315,9 @@ components:
             $ref: '#/components/schemas/ErrorCause'
       required:
         - type
+      additionalProperties:
+        title: metadata
+        description: Additional details about the error.
     DurationValueUnitNanos:
       allOf:
         - $ref: '#/components/schemas/UnitNanos'

--- a/spec/schemas/dangling_indices.list_dangling_indices.yaml
+++ b/spec/schemas/dangling_indices.list_dangling_indices.yaml
@@ -13,6 +13,8 @@ components:
           type: string
         index_uuid:
           type: string
+        creation_date:
+          $ref: '_common.yaml#/components/schemas/DateTime'
         creation_date_millis:
           $ref: '_common.yaml#/components/schemas/EpochTimeUnitMillis'
         node_ids:

--- a/tools/src/_utils/index.ts
+++ b/tools/src/_utils/index.ts
@@ -53,7 +53,7 @@ export function determine_possible_schema_types (doc: OpenAPIV3.Document, schema
   if (schema?.anyOf !== undefined) return collect_all(schema.anyOf)
   if (schema?.oneOf !== undefined) return collect_all(schema.oneOf)
 
-  if (schema == null || Object.keys(schema).filter(k => k !== 'description').length == 0) return SCHEMA_OBJECT_TYPES
+  if (schema == null || Object.keys(schema).filter(k => k !== 'description' && k !== 'title').length == 0) return SCHEMA_OBJECT_TYPES
 
   throw new Error(`Unable to determine possible types of schema: ${to_json(schema)}`)
 }


### PR DESCRIPTION
### Description
Add additionalProperties to ErrorCause and fix creation_date type for list_dangling_indices

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
