### PR TITLE
Increase memory allocated to OpenSearch in GHA.

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -43,7 +43,7 @@ jobs:
       OPENSEARCH_DOCKER_REF: ${{ matrix.entry.ref }}
       OPENSEARCH_VERSION: ${{ matrix.entry.version }}
       OPENSEARCH_PASSWORD: ${{ matrix.entry.admin_password || 'myStrongPassword123!' }}
-      OPENSEARCH_JAVA_OPTS: ${{ matrix.entry.opts }}
+      OPENSEARCH_JAVA_OPTS: ${{ matrix.entry.opts }} -Xms2g -Xmx2g
 
     steps:
       - name: Checkout Repo

--- a/tests/sql/close.yaml
+++ b/tests/sql/close.yaml
@@ -22,12 +22,6 @@ prologues:
     method: POST
     parameters:
       index: books
-  - path: _plugins/_query/settings
-    method: PUT
-    request:
-      payload:
-        transient:
-          plugins.query.memory_limit: 100%
   - id: sql_query
     path: /_plugins/_sql
     method: POST

--- a/tests/sql/explain.yaml
+++ b/tests/sql/explain.yaml
@@ -7,12 +7,6 @@ prologues:
     method: PUT
     request:
       payload: {}
-  - path: _plugins/_query/settings
-    method: PUT
-    request:
-      payload:
-        transient:
-          plugins.query.memory_limit: 100%
 epilogues:
   - path: /books
     method: DELETE

--- a/tests/sql/query.yaml
+++ b/tests/sql/query.yaml
@@ -9,12 +9,6 @@ prologues:
       index: books
     request:
       payload: {}
-  - path: _plugins/_query/settings
-    method: PUT
-    request:
-      payload:
-        transient:
-          plugins.query.memory_limit: 100%
 epilogues:
   - path: /books
     method: DELETE


### PR DESCRIPTION
### Description

Set the minimum amount of RAM to 2G.

Linux runners [have 16GB RAM](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/issues/468.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
