### PR TITLE
Catch response deserialization errors.

### DIFF
--- a/tools/src/tester/ChapterEvaluator.ts
+++ b/tools/src/tester/ChapterEvaluator.ts
@@ -122,7 +122,7 @@ export default class ChapterEvaluator {
 
   #evaluate_status(chapter: Chapter, response: ActualResponse): Evaluation {
     const expected_status = chapter.response?.status ?? 200
-    if (response.status === expected_status) return { result: Result.PASSED }
+    if (response.status === expected_status && response.error === undefined) return { result: Result.PASSED }
 
     let result: Evaluation = {
       result: Result.ERROR,

--- a/tools/src/tester/ChapterEvaluator.ts
+++ b/tools/src/tester/ChapterEvaluator.ts
@@ -124,13 +124,15 @@ export default class ChapterEvaluator {
     const expected_status = chapter.response?.status ?? 200
     if (response.status === expected_status) return { result: Result.PASSED }
 
-    const result: Evaluation = {
+    let result: Evaluation = {
       result: Result.ERROR,
       message: _.join(_.compact([
-        `Expected status ${expected_status}, but received ${response.status}: ${response.content_type}.`,
+        expected_status == response.status ?
+          `Received ${response.status ?? 'none'}: ${response.content_type ?? 'unknown'}.` :
+          `Expected status ${expected_status}, but received ${response.status ?? 'none'}: ${response.content_type ?? 'unknown'}.`,
         response.message
       ]), ' ')
-    };
+    }
 
     if (response.error !== undefined) {
       result.error = response.error as Error

--- a/tools/src/tester/ChapterReader.ts
+++ b/tools/src/tester/ChapterReader.ts
@@ -54,7 +54,7 @@ export default class ChapterReader {
       if (payload !== undefined) response.payload = payload
       this.logger.info(`<= ${r.status} (${r.headers['content-type']}) | ${to_json(response.payload)}`)
     }).catch(e => {
-      if (e.response === undefined) {
+      if (e.response == null) {
         this.logger.info(`<= ERROR: ${e}`)
         response.message = e.message
         response.error = e
@@ -64,7 +64,6 @@ export default class ChapterReader {
         const payload = this.#deserialize_payload(e.response.data, response.content_type)
         if (payload !== undefined) response.payload = payload.error
         response.message = payload.error?.reason ?? e.response.statusText
-        response.error = e
         this.logger.info(`<= ${response.status} (${response.content_type}) | ${response.payload !== undefined ? to_json(response.payload) : response.message}`)
       }
     })

--- a/tools/src/tester/ChapterReader.ts
+++ b/tools/src/tester/ChapterReader.ts
@@ -54,18 +54,19 @@ export default class ChapterReader {
       if (payload !== undefined) response.payload = payload
       this.logger.info(`<= ${r.status} (${r.headers['content-type']}) | ${to_json(response.payload)}`)
     }).catch(e => {
-      if (e.response == null) {
+      if (e.response === undefined) {
         this.logger.info(`<= ERROR: ${e}`)
-        throw e
+        response.message = e.message
+        response.error = e
+      } else {
+        response.status = e.response.status
+        response.content_type = e.response.headers['content-type']?.split(';')[0]
+        const payload = this.#deserialize_payload(e.response.data, response.content_type)
+        if (payload !== undefined) response.payload = payload.error
+        response.message = payload.error?.reason ?? e.response.statusText
+        response.error = e
+        this.logger.info(`<= ${response.status} (${response.content_type}) | ${response.payload !== undefined ? to_json(response.payload) : response.message}`)
       }
-      response.status = e.response.status
-      response.content_type = e.response.headers['content-type']?.split(';')[0]
-      const payload = this.#deserialize_payload(e.response.data, response.content_type)
-      if (payload !== undefined) response.payload = payload.error
-      response.message = payload.error?.reason ?? e.response.statusText
-      response.error = e
-
-      this.logger.info(`<= ${response.status} (${response.content_type}) | ${response.payload !== undefined ? to_json(response.payload) : response.message}`)
     })
     return response as ActualResponse
   }

--- a/tools/src/tester/StoryEvaluator.ts
+++ b/tools/src/tester/StoryEvaluator.ts
@@ -86,24 +86,12 @@ export default class StoryEvaluator {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
         evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because version ${version} does not satisfy ${chapter.version}.`, error: undefined } })
       } else {
-        try {
-          const evaluation = await this._chapter_evaluator.evaluate(chapter, has_errors, story_outputs)
-          has_errors = has_errors || evaluation.overall.result === Result.ERROR
-          if (evaluation.output !== undefined && chapter.id !== undefined) {
-            story_outputs.set_chapter_output(chapter.id, evaluation.output)
-          }
-          evaluations.push(evaluation)
-        } catch (e) {
-          has_errors = true
-          const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
-          const error = e as Error
-          evaluations.push({
-            title,
-            overall: {
-              result: Result.ERROR, message: error.message, error
-            }
-          })
+        const evaluation = await this._chapter_evaluator.evaluate(chapter, has_errors, story_outputs)
+        has_errors = has_errors || evaluation.overall.result === Result.ERROR
+        if (evaluation.output !== undefined && chapter.id !== undefined) {
+          story_outputs.set_chapter_output(chapter.id, evaluation.output)
         }
+        evaluations.push(evaluation)
       }
     }
     return evaluations

--- a/tools/src/tester/StoryEvaluator.ts
+++ b/tools/src/tester/StoryEvaluator.ts
@@ -86,12 +86,24 @@ export default class StoryEvaluator {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
         evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because version ${version} does not satisfy ${chapter.version}.`, error: undefined } })
       } else {
-        const evaluation = await this._chapter_evaluator.evaluate(chapter, has_errors, story_outputs)
-        has_errors = has_errors || evaluation.overall.result === Result.ERROR
-        if (evaluation.output !== undefined && chapter.id !== undefined) {
-          story_outputs.set_chapter_output(chapter.id, evaluation.output)
+        try {
+          const evaluation = await this._chapter_evaluator.evaluate(chapter, has_errors, story_outputs)
+          has_errors = has_errors || evaluation.overall.result === Result.ERROR
+          if (evaluation.output !== undefined && chapter.id !== undefined) {
+            story_outputs.set_chapter_output(chapter.id, evaluation.output)
+          }
+          evaluations.push(evaluation)
+        } catch (e) {
+          has_errors = true
+          const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
+          const error = e as Error
+          evaluations.push({
+            title,
+            overall: {
+              result: Result.ERROR, message: error.message, error
+            }
+          })
         }
-        evaluations.push(evaluation)
       }
     }
     return evaluations

--- a/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
+++ b/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
@@ -33,7 +33,6 @@ chapters:
         result: ERROR
         message: 'Expected status 200, but received 404: application/json. no such index
           [undefined]'
-        error: Request failed with status code 404
       payload_body:
         result: SKIPPED
       payload_schema:

--- a/tools/tests/tester/fixtures/evals/error/prologue_error.yaml
+++ b/tools/tests/tester/fixtures/evals/error/prologue_error.yaml
@@ -16,7 +16,6 @@ prologues:
     overall:
       result: ERROR
       message: no such index [does_not_exists]
-      error: Request failed with status code 404
 
 chapters:
   - title: This chapter be skipped.

--- a/tools/tests/tester/fixtures/stories/failed/not_found.yaml
+++ b/tools/tests/tester/fixtures/stories/failed/not_found.yaml
@@ -29,4 +29,3 @@ chapters:
       index: movies
     response:
       status: 404
-


### PR DESCRIPTION
### Description

After doing #476 I ran tests against AOS 2.7 and ran into an error deserializing CBOR. The implementation here will catch deserialization errors and bubble them up instead of failing unexpectedly.

Before:

```
$ npm run test:spec -- --tests tests/default/cat/health.yaml 

> opensearch_api_tools@1.0.0 test:spec
> ts-node tools/src/tester/test.ts --tests tests/default/cat/health.yaml

OpenSearch 2.7.0

/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/node_modules/cbor/lib/decoder.js:469
          throw new Error(`Additional info not implemented: ${ai}`)
                ^
Error: Additional info not implemented: 29
    at Decoder._parse (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/node_modules/cbor/lib/decoder.js:469:17)
    at _parse.next (<anonymous>)
    at Object.decodeFirstSync (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/node_modules/cbor/lib/decoder.js:228:22)
    at ChapterReader.#deserialize_payload (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/ChapterReader.ts:112:69)
    at /Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/ChapterReader.ts:53:48
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ChapterReader.read (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/ChapterReader.ts:41:5)
    at async ChapterEvaluator.#evaluate (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/ChapterEvaluator.ts:65:22)
    at async ChapterEvaluator.evaluate (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/ChapterEvaluator.ts:50:16)
    at async StoryEvaluator.#evaluate_chapters (/Users/dblock/source/opensearch-project/opensearch-api-specification/dblock-opensearch-api-specification/tools/src/tester/StoryEvaluator.ts:89:28)
```

After:

```
$ npm run test:spec -- --tests tests/default/cat/health.yaml 

> opensearch_api_tools@1.0.0 test:spec
> ts-node tools/src/tester/test.ts --tests tests/default/cat/health.yaml

OpenSearch 2.7.0


        ERROR   Cat in different formats (format=cbor).
            PASSED  PARAMETERS
                PASSED  format
            PASSED  REQUEST BODY
            ERROR   RESPONSE STATUS (Expected status 200, but failed to read the response. Additional info not implemented: 29)
            SKIPPED RESPONSE PAYLOAD BODY
            SKIPPED RESPONSE PAYLOAD SCHEMA
            SKIPPED RESPONSE OUTPUT VALUES
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
