### PR TITLE
Fix: durations are not always integers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `/_mapping` with `index` in query ([#385](https://github.com/opensearch-project/opensearch-api-specification/pull/385))
 - Fixed duplicate `/_nodes/{node_id}` path ([#416](https://github.com/opensearch-project/opensearch-api-specification/pull/416))
 - Fixed `_source` accepting an array of fields in `/_search` ([#430](https://github.com/opensearch-project/opensearch-api-specification/pull/430))
-- Fixed `_update_by_query` with a simple term ([451](https://github.com/opensearch-project/opensearch-api-specification/pull/451))
+- Fixed `_update_by_query` with a simple term ([#451](https://github.com/opensearch-project/opensearch-api-specification/pull/451))
+- Fixed `Duration` to allow for non-integers ([#479](https://github.com/opensearch-project/opensearch-api-specification/pull/479))
 
 ### Security
 

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -38,7 +38,7 @@ components:
       description: |-
         A duration. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and
         `d` (days). Also accepts "0" without a unit and "-1" to indicate an unspecified value.
-      pattern: ^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$
+      pattern: ^([0-9\.]+)(?:d|h|m|s|ms|micros|nanos)$
       type: string
     Metadata:
       type: object

--- a/tools/tests/tester/fixtures/specs/excerpt.yaml
+++ b/tools/tests/tester/fixtures/specs/excerpt.yaml
@@ -286,5 +286,5 @@ components:
       description: |-
         A duration. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and
         `d` (days). Also accepts "0" without a unit and "-1" to indicate an unspecified value.
-      pattern: ^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$
+      pattern: ^([0-9\.]+)(?:d|h|m|s|ms|micros|nanos)$
       type: string


### PR DESCRIPTION
### Description

Testing with an OpenSearch 2.8 AOS instance I ran into a duration that was `2.4s` which seems valid. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
