### PR TITLE
Fix: refresh index to get a consistent total.

### DIFF
--- a/tests/default/_core/reindex.yaml
+++ b/tests/default/_core/reindex.yaml
@@ -39,6 +39,8 @@ chapters:
   - synopsis: Reindex a subset of documents (match).
     path: /_reindex
     method: POST
+    parameters:
+      refresh: true
     request:
       payload:
         source:
@@ -82,7 +84,7 @@ chapters:
     response:
       status: 200
       payload:
-        total: 1
+        total: 2
   - synopsis: Reindex only unique documents.
     path: /_reindex
     method: POST


### PR DESCRIPTION
### Description

When testing against AOS 2.7 I was getting 2 as the total number of records reindexed. This is the correct result if you wait for a refresh interval after inserting records that get reindexed subsequently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
