### PR TITLE
Run tests against stable OpenSearch 2.16.

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -27,17 +27,17 @@ jobs:
             admin_password: admin
           - version: 2.0.0
             admin_password: admin
-          - version: 2.15.0
-          - version: 2.15.0
-            tests: plugins/index_state_management
-          - version: 2.15.0
-            tests: snapshot
           - version: 2.16.0
+          - version: 2.16.0
+            tests: plugins/index_state_management
+          - version: 2.16.0
+            tests: snapshot
+          - version: 2.17.0
             hub: opensearchstaging
-            ref: '@sha256:bcd7f5d5d30231f24f266064248cc8d3306574948190f7bf93016dff29acf17e'
+            ref: '@sha256:6398c27d7560626ed6b0ba28b3d6b20b7f00c6d94abf45ad3a820f8eeb3d61a3'
           - version: 3.0.0
             hub: opensearchstaging
-            ref: '@sha256:db1918b2b8f7ef6c22dd6ff54a0640877c3d395a392a53864745024933981e3b'
+            ref: '@sha256:101681eea630393f8caf5987dd023a975a9656b63090a07bfdfe6ad2f73f0640'
 
     name: test-opensearch-spec (version=${{ matrix.entry.version }}, hub=${{ matrix.entry.hub || 'opensearchproject' }}, tests=${{ matrix.entry.tests || 'default' }})
     runs-on: ubuntu-latest

--- a/.github/workflows/test-tools-integ.yml
+++ b/.github/workflows/test-tools-integ.yml
@@ -24,7 +24,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      OPENSEARCH_VERSION: 2.15.0
+      OPENSEARCH_VERSION: 2.16.0
       OPENSEARCH_PASSWORD: myStrongPassword123!
       OPENSEARCH_URL: https://localhost:9200
     steps:

--- a/spec/_info.yaml
+++ b/spec/_info.yaml
@@ -2,4 +2,4 @@ $schema: ./json_schemas/_info.schema.yaml
 
 title: OpenSearch API Specification
 version: 1.0.0
-x-api-version: 2.15.0
+x-api-version: 2.16.0

--- a/tools/tests/tester/fixtures/evals/passed.yaml
+++ b/tools/tests/tester/fixtures/evals/passed.yaml
@@ -175,7 +175,7 @@ chapters:
   - title: This GET /_cat/health should be skipped (> 2.999.0).
     overall:
       result: SKIPPED
-      message: Skipped because version 2.15.0 does not satisfy >= 2.999.0.
+      message: Skipped because version 2.16.0 does not satisfy >= 2.999.0.
 epilogues:
   - title: DELETE /books
     overall:

--- a/tools/tests/tester/fixtures/evals/skipped/semver.yaml
+++ b/tools/tests/tester/fixtures/evals/skipped/semver.yaml
@@ -3,5 +3,5 @@ full_path: tools/tests/tester/fixtures/stories/skipped/semver.yaml
 
 result: SKIPPED
 description: This story should be skipped because of version.
-message: Skipped because version 2.15.0 does not satisfy >= 2.999.0.
+message: Skipped because version 2.16.0 does not satisfy >= 2.999.0.
 

--- a/tools/tests/tester/helpers.ts
+++ b/tools/tests/tester/helpers.ts
@@ -141,5 +141,5 @@ export async function load_actual_evaluation (evaluator: StoryEvaluator, name: s
     full_path,
     display_path: `${name}.yaml`,
     story: read_yaml(full_path)
-  }, process.env.OPENSEARCH_VERSION ?? '2.15.0'))
+  }, process.env.OPENSEARCH_VERSION ?? '2.16.0'))
 }


### PR DESCRIPTION
### Description

OpenSearch 2.16 has been released 🎉 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
