### PR TITLE
Fixed schema refs for ml.yaml

### DIFF
--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -159,8 +159,8 @@ components:
               task_id:
                 type: string
             required:
-              - task_id
               - status
+              - task_id
     ml.delete_model@200:
       content:
         application/json:

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -152,7 +152,15 @@ components:
       content:
         application/json:
           schema:
-            $ref: '../schemas/ml._common.yaml#/components/schemas/Task'
+            type: object
+            properties:
+              task_id:
+                type: string
+              status:
+                type: string
+            required:
+              - task_id
+              - status
     ml.delete_model@200:
       content:
         application/json:

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -147,7 +147,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroup'
+            $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
     ml.register_model@200:
       content:
         application/json:
@@ -157,7 +157,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroup'
+            $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
     ml.get_task@200:
       content:
         application/json:

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -154,9 +154,9 @@ components:
           schema:
             type: object
             properties:
-              task_id:
-                type: string
               status:
+                type: string
+              task_id:
                 type: string
             required:
               - task_id

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -130,36 +130,44 @@ components:
     ml.search_models:
       content:
         application/json:
-          $ref: '../schemas/ml._common.yaml#/components/schemas/SearchModelsQuery'
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/SearchModelsQuery'
   responses:
     ml.register_model_group@200:
       content:
         application/json:
-          $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroupRegistration'
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroupRegistration'
     ml.get_model_group@200:
       content:
         application/json:
-          $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroup'
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroup'
     ml.delete_model_group@200:
       content:
         application/json:
-          $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroup'
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroup'
     ml.register_model@200:
       content:
         application/json:
-          $ref: '../schemas/ml._common.yaml#/components/schemas/Task'
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/Task'
     ml.delete_model@200:
       content:
         application/json:
-          $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroup'
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/ModelGroup'
     ml.get_task@200:
       content:
         application/json:
-          $ref: '../schemas/ml._common.yaml#/components/schemas/Task'
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/Task'
     ml.search_models@200:
       content:
         application/json:
-          $ref: '../schemas/ml._common.yaml#/components/schemas/SearchModelsResponse'
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/SearchModelsResponse'
   parameters:
     ml.get_model_group::path.model_group_id:
       name: model_group_id

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -108,10 +108,10 @@ components:
       properties:
         model_id:
           type: string
-          description: The model ID.
-        state:
+        task_id:
           type: string
-          description: The state.
+        status:
+          type: string
           enum:
             - CANCELLED
             - COMPLETED
@@ -124,6 +124,7 @@ components:
           description: Task type.
           enum:
             - DEPLOY_MODEL
+            - REGISTER_MODEL
         function_name:
           type: string
         worker_node:
@@ -139,4 +140,4 @@ components:
         is_async:
           type: boolean
       required:
-        - state
+        - status

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -110,7 +110,7 @@ components:
           type: string
         task_id:
           type: string
-        status:
+        state:
           type: string
           enum:
             - CANCELLED
@@ -140,4 +140,4 @@ components:
         is_async:
           type: boolean
       required:
-        - status
+        - state

--- a/tests/default/ml/models.yaml
+++ b/tests/default/ml/models.yaml
@@ -11,6 +11,8 @@ prologues:
           plugins:
             ml_commons:
               only_run_on_ml_node: false
+  - path: /_plugins/_ml/tasks/*
+    method: DELETE
 chapters:
   - synopsis: Create model.
     id: create_model
@@ -26,6 +28,7 @@ chapters:
     output:
       task_id: payload.task_id
   - synopsis: Wait for task.
+    id: register_model
     path: /_plugins/_ml/tasks/{task_id}
     method: GET
     warnings:
@@ -36,6 +39,13 @@ chapters:
       status: 200
       payload:
         state: COMPLETED
+    output:
+      model_id: payload.model_id
     retry:
-      count: 3
+      count: 5
       wait: 30000
+  - synopsis: Delete model.
+    path: /_plugins/_ml/models/{model_id}
+    parameters:
+      model_id: ${register_model.model_id}
+    method: DELETE

--- a/tests/default/ml/models.yaml
+++ b/tests/default/ml/models.yaml
@@ -11,8 +11,6 @@ prologues:
           plugins:
             ml_commons:
               only_run_on_ml_node: false
-  - path: /_plugins/_ml/tasks/*
-    method: DELETE
 chapters:
   - synopsis: Create model.
     id: create_model

--- a/tests/default/ml/models.yaml
+++ b/tests/default/ml/models.yaml
@@ -12,8 +12,8 @@ prologues:
             ml_commons:
               only_run_on_ml_node: false
 chapters:
-  - synopsis: Create model.
-    id: create_model
+  - synopsis: Register model.
+    id: register_model
     path: /_plugins/_ml/models/_register
     method: POST
     request:
@@ -25,14 +25,14 @@ chapters:
       status: 200
     output:
       task_id: payload.task_id
-  - synopsis: Wait for task.
-    id: register_model
+  - synopsis: Wait to get completed task.
+    id: get_completed_task
     path: /_plugins/_ml/tasks/{task_id}
     method: GET
     warnings:
       multiple-paths-detected: false
     parameters:
-      task_id: ${create_model.task_id}
+      task_id: ${register_model.task_id}
     response:
       status: 200
       payload:
@@ -45,5 +45,5 @@ chapters:
   - synopsis: Delete model.
     path: /_plugins/_ml/models/{model_id}
     parameters:
-      model_id: ${register_model.model_id}
+      model_id: ${get_completed_task.model_id}
     method: DELETE


### PR DESCRIPTION
The body schemas for some bodies in the `ml` namespace were incorrectly referenced to the content-type instead of their respective `schema` property.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
