### PR TITLE
Request sort in rest_total_hits_as_int tests

### DIFF
--- a/tests/default/_core/search/rest_total_hits_as_int.yaml
+++ b/tests/default/_core/search/rest_total_hits_as_int.yaml
@@ -11,6 +11,7 @@ prologues:
         director: Bennett Miller
         title: Moneyball
         year: 2011
+        order: 1
     status: [201]
   - path: /movies/_doc
     method: POST
@@ -21,6 +22,7 @@ prologues:
         director: Nicolas Winding Refn
         title: Drive
         year: 2011
+        order: 2
     status: [201]
 epilogues:
   - path: /movies
@@ -37,26 +39,26 @@ chapters:
       payload:
         query:
           match_all: {}
+        sort: order
     response:
       status: 200
       payload:
         timed_out: false
         hits:
           total: 2
-          max_score: 1
           hits:
             - _index: movies
-              _score: 1
               _source:
                 director: Bennett Miller
                 title: Moneyball
                 year: 2011
+                order: 1
             - _index: movies
-              _score: 1
               _source:
                 director: Nicolas Winding Refn
                 title: Drive
                 year: 2011
+                order: 2
   - synopsis: Search with rest_total_hits_as_int=false.
     path: /{index}/_search
     parameters:
@@ -67,6 +69,7 @@ chapters:
       payload:
         query:
           match_all: {}
+        sort: order
     response:
       status: 200
       payload:
@@ -75,20 +78,19 @@ chapters:
           total:
             value: 2
             relation: eq
-          max_score: 1
           hits:
             - _index: movies
-              _score: 1
               _source:
                 director: Bennett Miller
                 title: Moneyball
                 year: 2011
+                order: 1
             - _index: movies
-              _score: 1
               _source:
                 director: Nicolas Winding Refn
                 title: Drive
                 year: 2011
+                order: 2
   - synopsis: Search with rest_total_hits_as_int=false track_total_hits=1.
     path: /{index}/_search
     parameters:
@@ -100,6 +102,7 @@ chapters:
         track_total_hits: 1
         query:
           match_all: {}
+        sort: order
     response:
       status: 200
       payload:
@@ -108,18 +111,17 @@ chapters:
           total:
             value: 1
             relation: gte
-          max_score: 1
           hits:
             - _index: movies
-              _score: 1
               _source:
                 director: Bennett Miller
                 title: Moneyball
                 year: 2011
+                order: 1
             - _index: movies
-              _score: 1
               _source:
                 director: Nicolas Winding Refn
                 title: Drive
                 year: 2011
+                order: 2
   


### PR DESCRIPTION
### Description
Request sort in queries since @dblock said some tests were failing because result order wasn't guaranteed. Had to add a new order field to sort against. Could have made one of the current fields a keyword, but would have required setting a mapping.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
