### PR TITLE
Skip only known or hidden files.

### DIFF
--- a/tools/src/tester/TestRunner.ts
+++ b/tools/src/tester/TestRunner.ts
@@ -64,10 +64,9 @@ export default class TestRunner {
   #collect_story_files (folder: string, file: string, prefix: string): StoryFile[] {
     const path = file === '' ? folder : `${folder}/${file}`
     const next_prefix = prefix === '' ? file : `${prefix}/${file}`
-    if (fs.statSync(path).isFile()) {
-      if (!path.endsWith('.yaml')) {
-        return []
-      }
+    if (file.startsWith('.') || file == 'docker-compose.yml') {
+      return []
+    } else if (fs.statSync(path).isFile()) {
       const story: Story = read_yaml(path)
       return [{
         display_path: next_prefix === '' ? basename(path) : next_prefix,

--- a/tools/tests/tester/fixtures/stories/.ignore-dot-file
+++ b/tools/tests/tester/fixtures/stories/.ignore-dot-file
@@ -1,0 +1,1 @@
+Hidden file, ignored.

--- a/tools/tests/tester/fixtures/stories/docker-compose.yml
+++ b/tools/tests/tester/fixtures/stories/docker-compose.yml
@@ -1,0 +1,1 @@
+# A docker-compose.yml file, ignored.

--- a/tools/tests/tester/fixtures/stories/ignore.wrong.extension
+++ b/tools/tests/tester/fixtures/stories/ignore.wrong.extension
@@ -1,1 +1,0 @@
-Not a .yaml file, should be ignored


### PR DESCRIPTION
### Description

One of the unfortunate side effects of https://github.com/opensearch-project/opensearch-api-specification/pull/473 is that it's very easy to miss a test file that is misnamed. For example in https://github.com/opensearch-project/opensearch-api-specification/pull/497 we have .yml, or files that aren't yml at all but get skipped.

In this PR we only skip known and hidden things.

cc: @awick 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
