### PR TITLE
Add resolve API test

### DIFF
--- a/tests/default/indices/index.yaml
+++ b/tests/default/indices/index.yaml
@@ -85,4 +85,15 @@ chapters:
     parameters:
       index: books,games
       cluster_manager_timeout: 10s
+
+  - synopsis: Check if the index `books` exists. It should.
+    path: /_resolve/index/books
+    method: GET
+    parameters:
+      allow_no_indices: true
+      expand_wildcards: none
+      ignore_unavailable: true
+      allow_partial_search_results: true
+    response:
+      status: 200    
       

--- a/tests/default/indices/index.yaml
+++ b/tests/default/indices/index.yaml
@@ -84,16 +84,4 @@ chapters:
     version: '>= 2.0'
     parameters:
       index: books,games
-      cluster_manager_timeout: 10s
-
-  - synopsis: Check if the index `books` exists. It should.
-    path: /_resolve/index/books
-    method: GET
-    parameters:
-      allow_no_indices: true
-      expand_wildcards: none
-      ignore_unavailable: true
-      allow_partial_search_results: true
-    response:
-      status: 200    
-      
+      cluster_manager_timeout: 10s     

--- a/tests/default/indices/resolve.yaml
+++ b/tests/default/indices/resolve.yaml
@@ -18,10 +18,3 @@ chapters:
       expand_wildcards: none
     response:
       status: 200
-  - synopsis: See if index `books` exists. It shouldn't.
-    path: /_resolve/index/{name}
-    parameters:
-      name: books
-    method: GET
-    response:
-      status: 404

--- a/tests/default/indices/resolve.yaml
+++ b/tests/default/indices/resolve.yaml
@@ -1,0 +1,24 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Tests to see if the specified index exits using the `_resolve` endpoint.
+prologues:
+  - path: /movies
+    method: PUT
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+
+chapters:
+  - synopsis: See if index `movies` exists. It should.
+    path: /_resolve/index/movies
+    method: GET
+    parameters:
+      expand_wildcards: none
+    response:
+      status: 200
+  - synopsis: See if index `books` exists. It shouldn't.
+    path: /_resolve/index/book
+    method: GET
+    response:
+      status: 404

--- a/tests/default/indices/resolve.yaml
+++ b/tests/default/indices/resolve.yaml
@@ -11,14 +11,17 @@ epilogues:
 
 chapters:
   - synopsis: See if index `movies` exists. It should.
-    path: /_resolve/index/movies
+    path: /_resolve/index/{name}
     method: GET
     parameters:
+      name: movies
       expand_wildcards: none
     response:
       status: 200
   - synopsis: See if index `books` exists. It shouldn't.
-    path: /_resolve/index/book
+    path: /_resolve/index/{name}
+    parameters:
+      name: books
     method: GET
     response:
       status: 404


### PR DESCRIPTION
### Description

Adds the test for the `_resolve` endpoint in the current index.yaml test. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
