### PR TITLE
Added distributions/included and excluded.

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -228,13 +228,16 @@ OpenSearch consists of plugins that may or may not be present in various distrib
     description: Returns basic information about the cluster.
 ```
 
-Similarly, skip tests that are not applicable to a distribution by listing the distributions that support it.
+Similarly, skip tests that are not applicable to a distribution by listing the distributions that support or do not support it.
 
 ```yaml
 description: Test root endpoint.
 distributions:
-  - amazon-managed
-  - opensearch.org
+  included:
+    - amazon-managed
+    - opensearch.org
+  excluded:
+    - amazon-serverless
 chapters:
   - synopsis: Get server info.
     path: /

--- a/json_schemas/test_story.schema.yaml
+++ b/json_schemas/test_story.schema.yaml
@@ -113,6 +113,16 @@ definitions:
   Distributions:
     description: |
       The list of distributions that support this API.
+    type: object
+    properties:
+      included:
+        $ref: '#/definitions/DistributionsList'
+      excluded:
+        $ref: '#/definitions/DistributionsList'
+        
+  DistributionsList:
+    description: |
+      The list of distributions that support this API.
     type: array
     items:
       type: string

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -291,6 +291,9 @@ paths:
       operationId: cat.nodeattrs.0
       x-operation-group: cat.nodeattrs
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Returns information about custom node attributes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cat/cat-nodeattrs/

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -189,6 +189,9 @@ paths:
       operationId: indices.clear_cache.0
       x-operation-group: indices.clear_cache
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Clears all or specific caches for one or more indices.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/clear-index-cache/
@@ -319,6 +322,9 @@ paths:
       operationId: indices.forcemerge.0
       x-operation-group: indices.forcemerge
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Performs the force merge operation on one or more indices.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -589,6 +595,9 @@ paths:
       operationId: indices.segments.0
       x-operation-group: indices.segments
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Provides low-level information about segments in a Lucene index.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -605,6 +614,9 @@ paths:
       operationId: indices.get_settings.0
       x-operation-group: indices.get_settings
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Returns settings for one or more indices.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/get-settings/
@@ -1564,6 +1576,9 @@ paths:
       operationId: indices.segments.1
       x-operation-group: indices.segments
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Provides low-level information about segments in a Lucene index.
       externalDocs:
         url: https://opensearch.org/docs/latest

--- a/spec/namespaces/security.yaml
+++ b/spec/namespaces/security.yaml
@@ -22,6 +22,9 @@ paths:
       operationId: security.authinfo.0
       x-operation-group: security.authinfo
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Returns the authentication information.
       parameters:
         - $ref: '#/components/parameters/security.authinfo::query.auth_type'
@@ -35,6 +38,9 @@ paths:
       operationId: security.authinfo.1
       x-operation-group: security.authinfo
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Returns the authentication information.
       parameters:
         - $ref: '#/components/parameters/security.authinfo::query.auth_type'
@@ -49,6 +55,9 @@ paths:
       operationId: security.get_dashboards_info.0
       x-operation-group: security.get_dashboards_info
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves the current security-dashboards plugin configuration.
       responses:
         '200':
@@ -59,6 +68,9 @@ paths:
       operationId: security.post_dashboards_info.1
       x-operation-group: security.post_dashboards_info
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Updates the current security-dashboards plugin configuration.
       responses:
         '200':
@@ -70,6 +82,9 @@ paths:
       operationId: security.health.0
       x-operation-group: security.health
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Checks to see if the Security plugin is up and running.
       parameters:
         - $ref: '#/components/parameters/security.health::query.mode'
@@ -82,6 +97,9 @@ paths:
       operationId: security.health.1
       x-operation-group: security.health
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Checks to see if the Security plugin is up and running.
       parameters:
         - $ref: '#/components/parameters/security.health::query.mode'
@@ -95,6 +113,9 @@ paths:
       operationId: security.tenant_info.0
       x-operation-group: security.tenant_info
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves the tenant names if any exist. Only accessible to super admins or kibanaserver user.
       responses:
         '200':
@@ -107,6 +128,9 @@ paths:
       operationId: security.tenant_info.1
       x-operation-group: security.tenant_info
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves the tenant names if any exist. Only accessible to super admins or kibanaserver user.
       responses:
         '200':
@@ -120,6 +144,9 @@ paths:
       operationId: security.who_am_i.0
       x-operation-group: security.who_am_i
       x-version-added: '2.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Gets the user identity related information for currently logged in user.
       responses:
         '200':
@@ -130,6 +157,9 @@ paths:
       operationId: security.who_am_i.1
       x-operation-group: security.who_am_i
       x-version-added: '2.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Gets the user identity related information for currently logged in user.
       responses:
         '200':
@@ -141,6 +171,9 @@ paths:
       operationId: security.who_am_i_protected.0
       x-operation-group: security.who_am_i_protected
       x-version-added: '2.11'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Gets the user identity related information for currently logged in user. User needs to have access to this endpoint when authorization at REST layer is enabled.
       responses:
         '200':
@@ -152,6 +185,9 @@ paths:
       operationId: security.config_upgrade_check.0
       x-operation-group: security.config_upgrade_check
       x-version-added: '2.14'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Check whether or not an upgrade can be performed and what resources can be updated.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#configuration-upgrade-check
@@ -163,6 +199,9 @@ paths:
       operationId: security.config_upgrade_perform.0
       x-operation-group: security.config_upgrade_perform
       x-version-added: '2.14'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Helps cluster operator upgrade missing defaults and stale default definitions.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#configuration-upgrade
@@ -178,6 +217,9 @@ paths:
       operationId: security.get_account_details.0
       x-operation-group: security.get_account_details
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Returns account details for the current user.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-account-details
@@ -188,6 +230,9 @@ paths:
       operationId: security.change_password.0
       x-operation-group: security.change_password
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Changes the password for the current user.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#change-password
@@ -203,6 +248,9 @@ paths:
       operationId: security.get_action_groups.0
       x-operation-group: security.get_action_groups
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves all action groups.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-action-groups
@@ -213,6 +261,9 @@ paths:
       operationId: security.patch_action_groups.1
       x-operation-group: security.patch_action_groups
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates, updates, or deletes multiple action groups in a single call.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-action-groups
@@ -226,6 +277,9 @@ paths:
       operationId: security.get_action_group.0
       x-operation-group: security.get_action_group
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves one action group.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-action-group
@@ -238,6 +292,9 @@ paths:
       operationId: security.create_action_group.0
       x-operation-group: security.create_action_group
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates or replaces the specified action group.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#create-action-group
@@ -254,6 +311,9 @@ paths:
       operationId: security.patch_action_group.0
       x-operation-group: security.patch_action_group
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Updates individual attributes of an action group.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-action-group
@@ -268,6 +328,9 @@ paths:
       operationId: security.delete_action_group.0
       x-operation-group: security.delete_action_group
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Delete a specified action group.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#delete-action-group
@@ -281,6 +344,9 @@ paths:
       operationId: security.get_allowlist.0
       x-operation-group: security.get_allowlist
       x-version-added: '2.1'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves the current list of allowed API accessible to normal user.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#access-control-for-the-api
@@ -293,6 +359,9 @@ paths:
       operationId: security.create_allowlist.0
       x-operation-group: security.create_allowlist
       x-version-added: '2.1'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates or replaces the allowlisted APIs. Accessible via Super Admin certificate or REST API permission.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#access-control-for-the-api
@@ -307,6 +376,9 @@ paths:
       operationId: security.patch_allowlist.0
       x-operation-group: security.patch_allowlist
       x-version-added: '2.1'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Updates the current list of allowed API accessible to normal user. 
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#access-control-for-the-api
@@ -322,6 +394,9 @@ paths:
       operationId: security.get_audit_configuration.0
       x-operation-group: security.get_audit_configuration
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves the audit configuration.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#audit-logs
@@ -332,6 +407,9 @@ paths:
       operationId: security.patch_audit_configuration.0
       x-operation-group: security.patch_audit_configuration
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: A PATCH call is used to update specified fields in the audit configuration.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#audit-logs
@@ -345,6 +423,9 @@ paths:
       operationId: security.update_audit_configuration.0
       x-operation-group: security.update_audit_configuration
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Updates the audit configuration.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#audit-logs
@@ -358,6 +439,9 @@ paths:
       operationId: security.authtoken.0
       x-operation-group: security.authtoken
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Returns the authorization token.
       responses:
         '200':
@@ -368,6 +452,9 @@ paths:
       x-operation-group: security.cache
       x-ignorable: true
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Not supported for cache API.
       responses:
         '501':
@@ -376,6 +463,9 @@ paths:
       operationId: security.cache.2
       x-operation-group: security.cache
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       x-ignorable: true
       description: Not supported for cache API.
       responses:
@@ -385,6 +475,9 @@ paths:
       operationId: security.cache.3
       x-operation-group: security.cache
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       x-ignorable: true
       description: Not supported for cache API.
       responses:
@@ -394,6 +487,9 @@ paths:
       operationId: security.flush_cache.0
       x-operation-group: security.flush_cache
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Flushes the Security plugin user, authentication, and authorization cache.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#flush-cache
@@ -405,6 +501,9 @@ paths:
       operationId: security.get_all_certificates.0
       x-operation-group: security.get_all_certificates
       x-version-added: '2.15'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves the cluster security certificates.
       parameters:
         - $ref: '#/components/parameters/security.get_all_certificates::query.cert_type'
@@ -421,6 +520,9 @@ paths:
       operationId: security.get_node_certificates.0
       x-operation-group: security.get_node_certificates
       x-version-added: '2.15'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves the given node's security certificates.
       parameters:
         - $ref: '#/components/parameters/security.get_node_certificates::path.node_id'
@@ -438,6 +540,9 @@ paths:
       operationId: security.generate_obo_token.0
       x-operation-group: security.generate_obo_token
       x-version-added: '2.12'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Generates On-Behalf-Of token for the current user.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/authentication-tokens/#api-endpoint
@@ -453,6 +558,9 @@ paths:
       operationId: security.get_users.0
       x-operation-group: security.get_users
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieve all internal users.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-users
@@ -463,6 +571,9 @@ paths:
       operationId: security.patch_users.0
       x-operation-group: security.patch_users
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates, updates, or deletes multiple internal users in a single call.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-users
@@ -476,6 +587,9 @@ paths:
       operationId: security.get_user.0
       x-operation-group: security.get_user
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieve one internal user.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-user
@@ -488,6 +602,9 @@ paths:
       operationId: security.create_user.0
       x-operation-group: security.create_user
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates or replaces the specified user.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#create-user
@@ -502,6 +619,9 @@ paths:
       operationId: security.patch_user.0
       x-operation-group: security.patch_user
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Updates individual attributes of an internal user.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-user
@@ -516,6 +636,9 @@ paths:
       operationId: security.delete_user.0
       x-operation-group: security.delete_user
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Delete the specified user.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#delete-user
@@ -529,6 +652,9 @@ paths:
       operationId: security.generate_user_token.0
       x-operation-group: security.generate_user_token
       x-version-added: '2.7'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Generates authorization token for the given user.
       parameters:
         - $ref: '#/components/parameters/security.generate_user_token::path.username'
@@ -542,6 +668,9 @@ paths:
       operationId: security.migrate.0
       x-operation-group: security.migrate
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Migrates security configuration from v6 to v7.
       responses:
         '200':
@@ -553,6 +682,9 @@ paths:
       operationId: security.get_distinguished_names.0
       x-operation-group: security.get_distinguished_names
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves distinguished names. Only accessible to super-admins and with rest-api permissions when enabled.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-distinguished-names
@@ -569,6 +701,9 @@ paths:
       operationId: security.patch_distinguished_names.0
       x-operation-group: security.patch_distinguished_names
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Bulk update of distinguished names. Only accessible to super-admins and with rest-api permissions when enabled.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#update-all-distinguished-names
@@ -586,6 +721,9 @@ paths:
       operationId: security.get_distinguished_name.0
       x-operation-group: security.get_distinguished_name
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves distinguished names. Only accessible to super-admins and with rest-api permissions when enabled.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-distinguished-names
@@ -603,6 +741,9 @@ paths:
       operationId: security.update_distinguished_name.0
       x-operation-group: security.update_distinguished_name
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Adds or updates the specified distinguished names in the cluster or node allow list. Only accessible to super-admins and with rest-api permissions when enabled.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#update-distinguished-names
@@ -621,6 +762,9 @@ paths:
       operationId: security.patch_distinguished_name.0
       x-operation-group: security.patch_distinguished_name
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Updates a distinguished cluster name for a specific cluster. Only accessible to super-admins and with rest-api permissions when enabled.
       parameters:
         - $ref: '#/components/parameters/security.patch_distinguished_name::path.cluster_name'
@@ -637,6 +781,9 @@ paths:
       operationId: security.delete_distinguished_name.0
       x-operation-group: security.delete_distinguished_name
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Deletes all distinguished names in the specified cluster or node allow list. Only accessible to super-admins and with rest-api permissions when enabled.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#delete-distinguished-names
@@ -654,6 +801,9 @@ paths:
       operationId: security.get_permissions_info.0
       x-operation-group: security.get_permissions_info
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Gets the evaluated REST API permissions for the currently logged in user.
       responses:
         '200':
@@ -665,6 +815,9 @@ paths:
       operationId: security.get_roles.0
       x-operation-group: security.get_roles
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves all roles.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-roles
@@ -675,6 +828,9 @@ paths:
       operationId: security.patch_roles.0
       x-operation-group: security.patch_roles
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates, updates, or deletes multiple roles in a single call.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-roles
@@ -690,6 +846,9 @@ paths:
       operationId: security.get_role.0
       x-operation-group: security.get_role
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves one role.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-role
@@ -702,6 +861,9 @@ paths:
       operationId: security.create_role.0
       x-operation-group: security.create_role
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates or replaces the specified role.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#create-role
@@ -718,6 +880,9 @@ paths:
       operationId: security.patch_role.0
       x-operation-group: security.patch_role
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Updates individual attributes of a role.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-role
@@ -734,6 +899,9 @@ paths:
       operationId: security.delete_role.0
       x-operation-group: security.delete_role
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Delete the specified role.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#delete-role
@@ -747,6 +915,9 @@ paths:
       operationId: security.get_role_mappings.0
       x-operation-group: security.get_role_mappings
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves all role mappings.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-role-mappings
@@ -757,6 +928,9 @@ paths:
       operationId: security.patch_role_mappings.0
       x-operation-group: security.patch_role_mappings
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates or updates multiple role mappings in a single call.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-role-mappings
@@ -772,6 +946,9 @@ paths:
       operationId: security.get_role_mapping.0
       x-operation-group: security.get_role_mapping
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves one role mapping.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-role-mapping
@@ -784,6 +961,9 @@ paths:
       operationId: security.create_role_mapping.0
       x-operation-group: security.create_role_mapping
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates or replaces the specified role mapping.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#create-role-mapping
@@ -800,6 +980,9 @@ paths:
       operationId: security.patch_role_mapping.0
       x-operation-group: security.patch_role_mapping
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Updates individual attributes of a role mapping.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-role-mapping
@@ -816,6 +999,9 @@ paths:
       operationId: security.delete_role_mapping.0
       x-operation-group: security.delete_role_mapping
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Deletes the specified role mapping.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#delete-role-mapping
@@ -829,6 +1015,9 @@ paths:
       operationId: security.get_configuration.0
       x-operation-group: security.get_configuration
       x-version-added: '2.10'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Returns the current Security plugin configuration in JSON format.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-configuration
@@ -839,6 +1028,9 @@ paths:
       operationId: security.patch_configuration.0
       x-operation-group: security.patch_configuration
       x-version-added: '2.10'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: A PATCH call is used to update the existing configuration using the REST API. Only accessible by admins and users with rest api access and only when put or patch is enabled.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-configuration
@@ -854,6 +1046,9 @@ paths:
       operationId: security.update_configuration.0
       x-operation-group: security.update_configuration
       x-version-added: '2.10'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Adds or updates the existing configuration using the REST API. Only accessible by admins and users with rest api access and only when put or patch is enabled.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#update-configuration
@@ -869,6 +1064,9 @@ paths:
       operationId: security.get_certificates.0
       x-operation-group: security.get_certificates
       x-version-added: '2.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves the cluster security certificates.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-certificates
@@ -884,6 +1082,9 @@ paths:
       operationId: security.reload_http_certificates.0
       x-operation-group: security.reload_http_certificates
       x-version-added: '2.8'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Reload HTTP layer communication certificates.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#reload-http-certificates
@@ -899,6 +1100,9 @@ paths:
       operationId: security.reload_transport_certificates.0
       x-operation-group: security.reload_transport_certificates
       x-version-added: '2.8'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Reload Transport layer communication certificates.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#reload-transport-certificates
@@ -914,6 +1118,9 @@ paths:
       operationId: security.get_tenancy_config.0
       x-operation-group: security.get_tenancy_config
       x-version-added: '2.7'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves multi-tenancy configuration. Only accessible to admins and users with REST API permissions.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/multi-tenancy/dynamic-config/#configuring-multi-tenancy-with-the-rest-api
@@ -926,6 +1133,9 @@ paths:
       operationId: security.create_update_tenancy_config.0
       x-operation-group: security.create_update_tenancy_config
       x-version-added: '2.7'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates or replaces the multi-tenancy configuration. Only accessible to admins and users with REST API permissions.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/multi-tenancy/dynamic-config/#configuring-multi-tenancy-with-the-rest-api
@@ -941,6 +1151,9 @@ paths:
       operationId: security.get_tenants.0
       x-operation-group: security.get_tenants
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves all tenants.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-tenants
@@ -953,6 +1166,9 @@ paths:
       operationId: security.patch_tenants.0
       x-operation-group: security.patch_tenants
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Add, delete, or modify multiple tenants in a single call.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-tenants
@@ -968,6 +1184,9 @@ paths:
       operationId: security.get_tenant.0
       x-operation-group: security.get_tenant
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieves one tenant.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#get-tenant
@@ -980,6 +1199,9 @@ paths:
       operationId: security.create_tenant.0
       x-operation-group: security.create_tenant
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates or replaces the specified tenant.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#create-tenant
@@ -998,6 +1220,9 @@ paths:
       operationId: security.patch_tenant.0
       x-operation-group: security.patch_tenant
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Add, delete, or modify a single tenant.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#patch-tenant
@@ -1014,6 +1239,9 @@ paths:
       operationId: security.delete_tenant.0
       x-operation-group: security.delete_tenant
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Delete the specified tenant.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#delete-action-group
@@ -1029,6 +1257,9 @@ paths:
       operationId: security.get_users_legacy.0
       x-operation-group: security.get_users_legacy
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieve all internal users. Legacy API.
       responses:
         '200':
@@ -1038,6 +1269,9 @@ paths:
       operationId: security.get_user_legacy.0
       x-operation-group: security.get_user_legacy
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Retrieve one user. Legacy API.
       parameters:
         - $ref: '#/components/parameters/security.get_user_legacy::path.username'
@@ -1048,6 +1282,9 @@ paths:
       operationId: security.create_user_legacy.0
       x-operation-group: security.create_user_legacy
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Creates or replaces the specified user. Legacy API.
       parameters:
         - $ref: '#/components/parameters/security.create_user_legacy::path.username'
@@ -1062,6 +1299,9 @@ paths:
       operationId: security.delete_user_legacy.0
       x-operation-group: security.delete_user_legacy
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Delete the specified user. Legacy API.
       parameters:
         - $ref: '#/components/parameters/security.delete_user_legacy::path.username'
@@ -1073,6 +1313,9 @@ paths:
       operationId: security.generate_user_token_legacy.0
       x-operation-group: security.generate_user_token_legacy
       x-version-added: '2.7'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Generates authorization token for the given user. Legacy API.  Not Implemented.
       parameters:
         - $ref: '#/components/parameters/security.generate_user_token_legacy::path.username'
@@ -1084,6 +1327,9 @@ paths:
       operationId: security.validate.0
       x-operation-group: security.validate
       x-version-added: '1.0'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
       description: Checks whether the v6 security configuration is valid and ready to be migrated to v7.
       parameters:
         - $ref: '#/components/parameters/security.validate::query.accept_invalid'

--- a/spec/schemas/security._common.yaml
+++ b/spec/schemas/security._common.yaml
@@ -622,10 +622,10 @@ components:
           items:
             type: string
         ssl_protocol:
-          type: string
+          type: ['null',string]
           description: Protocol for this ssl setup.
         ssl_cipher:
-          type: string
+          type: ['null',string]
           description: Cipher for this ssl setup.
         ssl_openssl_available:
           type: boolean
@@ -646,7 +646,7 @@ components:
           type: boolean
           description: Indicates whether hostname validation is supported.
         ssl_provider_http:
-          type: string
+          type: ['null',string]
           description: Returns http provider's name.
         ssl_provider_transport_server:
           type: string

--- a/tests/default/_core/info.yaml
+++ b/tests/default/_core/info.yaml
@@ -3,8 +3,8 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test root endpoint.
 distributions:
-  - amazon-managed
-  - opensearch.org
+  excluded:
+    - amazon-serverless
 chapters:
   - synopsis: Get server info.
     path: /

--- a/tests/default/cat/health.yaml
+++ b/tests/default/cat/health.yaml
@@ -93,7 +93,9 @@ chapters:
           node.data: '1'
   - synopsis: Cat in different formats (format=cbor).
     distributions:
-      - opensearch.org
+      excluded:
+        - amazon-managed
+        - amazon-serverless
     method: GET
     path: /_cat/health
     parameters:
@@ -106,7 +108,9 @@ chapters:
           node.data: '1'
   - synopsis: Cat in different formats (format=smile).
     distributions:
-      - opensearch.org
+      excluded:
+        - amazon-managed
+        - amazon-serverless
     method: GET
     path: /_cat/health
     parameters:

--- a/tests/default/cat/indices.yaml
+++ b/tests/default/cat/indices.yaml
@@ -72,7 +72,9 @@ chapters:
       content_type: application/yaml
   - synopsis: Cat in different formats (format=cbor).
     distributions:
-      - opensearch.org
+      excluded:
+        - amazon-managed
+        - amazon-serverless
     method: GET
     path: /_cat/indices
     parameters:
@@ -82,7 +84,9 @@ chapters:
       content_type: application/cbor
   - synopsis: Cat in different formats (format=smile).
     distributions:
-      - opensearch.org
+      excluded:
+        - amazon-managed
+        - amazon-serverless
     method: GET
     path: /_cat/indices
     parameters:

--- a/tests/default/cat/master.yaml
+++ b/tests/default/cat/master.yaml
@@ -1,9 +1,9 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test cat/master endpoints.
+version: < 2.0
 chapters:
   - synopsis: Cat with a json response.
-    version: < 2.0
     path: /_cat/master
     method: GET
     parameters:

--- a/tests/default/cat/nodeattrs.yaml
+++ b/tests/default/cat/nodeattrs.yaml
@@ -4,7 +4,9 @@ description: Test cat/nodeattrs endpoints.
 chapters:
   - synopsis: Cat with a json response.
     distributions:
-      - opensearch.org
+      excluded:
+        - amazon-managed
+        - amazon-serverless
     path: /_cat/nodeattrs
     method: GET
     parameters:

--- a/tests/default/cat/nodeattrs.yaml
+++ b/tests/default/cat/nodeattrs.yaml
@@ -1,12 +1,12 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test cat/nodeattrs endpoints.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Cat with a json response.
-    distributions:
-      excluded:
-        - amazon-managed
-        - amazon-serverless
     path: /_cat/nodeattrs
     method: GET
     parameters:

--- a/tests/default/indices/cache.yaml
+++ b/tests/default/indices/cache.yaml
@@ -2,7 +2,9 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test index clear cache.
 distributions:
-  - opensearch.org
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 prologues:
   - path: /movies
     method: PUT

--- a/tests/default/indices/dangling.yaml
+++ b/tests/default/indices/dangling.yaml
@@ -2,7 +2,9 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test dangling indexes.
 distributions:
-  - opensearch.org
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Get dangling indexes.
     path: /_dangling

--- a/tests/default/indices/forcemerge.yaml
+++ b/tests/default/indices/forcemerge.yaml
@@ -3,7 +3,9 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test force merging an index.
 distributions:
-  - opensearch.org
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 prologues:
   - path: /movies
     method: PUT

--- a/tests/default/indices/segments.yaml
+++ b/tests/default/indices/segments.yaml
@@ -2,7 +2,9 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: This story tests the Segments API.
 distributions:
-  - opensearch.org
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 prologues:
   - path: /movies
     method: PUT

--- a/tests/default/indices/settings.yaml
+++ b/tests/default/indices/settings.yaml
@@ -12,7 +12,9 @@ epilogues:
 chapters:
   - synopsis: Get global settings.
     distributions:
-      - opensearch.org
+      excluded:
+        - amazon-managed
+        - amazon-serverless
     path: /_settings
     method: GET
     parameters:
@@ -26,7 +28,9 @@ chapters:
       status: 200
   - synopsis: Get global settings (cluster_manager_timeout).
     distributions:
-      - opensearch.org
+      excluded:
+        - amazon-managed
+        - amazon-serverless
     path: /_settings
     method: GET
     version: '>= 2.0'

--- a/tests/default/ingest/pipeline/neural_search.yaml
+++ b/tests/default/ingest/pipeline/neural_search.yaml
@@ -1,6 +1,11 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test the creation a neural search ingest pipeline.
+distributions:
+  # requires an ML node to be provisioned, disabling with only_run_on_ml_node is not possible
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 prologues:
   - path: /_cluster/settings
     method: PUT

--- a/tests/default/ml/model_groups.yaml
+++ b/tests/default/ml/model_groups.yaml
@@ -2,7 +2,9 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test the creation of model groups.
 distributions:
-  - opensearch.org
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 version: '>= 2.11'
 prologues:
   - path: /_cluster/settings

--- a/tests/default/ml/models.yaml
+++ b/tests/default/ml/models.yaml
@@ -2,7 +2,9 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test the creation of models.
 distributions:
-  - opensearch.org
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 version: '>= 2.11'
 prologues:
   - path: /_cluster/settings

--- a/tests/default/query/datasources.yaml
+++ b/tests/default/query/datasources.yaml
@@ -2,7 +2,10 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test various operations of the OpenSearch Query Datasources API.
 version: '>=2.7'
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 prologues:
   - path: /_plugins/_query/_datasources/{datasource_name}
     method: DELETE

--- a/tests/default/security/api/account.yaml
+++ b/tests/default/security/api/account.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test account endpoint.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Get account details.

--- a/tests/default/security/api/actiongroups.yaml
+++ b/tests/default/security/api/actiongroups.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test actiongroups endpoints.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Create action group.

--- a/tests/default/security/api/allowlist.yaml
+++ b/tests/default/security/api/allowlist.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test allowlist endpoints.
 version: '> 2.0'
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # ADMIN-CERT only. These tests require explicit rest api admin privileges.
 chapters:

--- a/tests/default/security/api/audit.yaml
+++ b/tests/default/security/api/audit.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test audit endpoints.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Get an audit config.

--- a/tests/default/security/api/audit/config.yaml
+++ b/tests/default/security/api/audit/config.yaml
@@ -1,7 +1,10 @@
 $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test audit/config endpoint.
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Create an audit config.
     path: /_plugins/_security/api/audit/config

--- a/tests/default/security/api/authtoken.yaml
+++ b/tests/default/security/api/authtoken.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test authtoken endpoint.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Create an auth token.

--- a/tests/default/security/api/cache.yaml
+++ b/tests/default/security/api/cache.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test cache endpoint.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Get cache.

--- a/tests/default/security/api/certificates.yaml
+++ b/tests/default/security/api/certificates.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test certificates endpoints.
 version: '> 2.14'
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # ADMIN-CERT only. These tests require explicit rest api admin privileges.
 prologues:

--- a/tests/default/security/api/generateonbehalfoftoken.yaml
+++ b/tests/default/security/api/generateonbehalfoftoken.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test generateonbehalfoftoken endpoint.
 version: '> 2.11'
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Create an On-Behalf-Of token.

--- a/tests/default/security/api/internalusers.yaml
+++ b/tests/default/security/api/internalusers.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test internalusers endpoints.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Get internal users bulk.

--- a/tests/default/security/api/internalusers/authtoken.yaml
+++ b/tests/default/security/api/internalusers/authtoken.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test internalusers/authtoken endpoint.
 version: '> 2.16' # Fixed via https://github.com/opensearch-project/security/pull/4628
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 prologues:
   - path: /_plugins/_security/api/internalusers/{username}

--- a/tests/default/security/api/migrate.yaml
+++ b/tests/default/security/api/migrate.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test migrate endpoint.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # BAD_REQUEST. Can not migrate configuration because it was already migrated.
 chapters:

--- a/tests/default/security/api/nodesdn.yaml
+++ b/tests/default/security/api/nodesdn.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test nodesdn endpoints.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # ADMIN-CERT only. These tests require explicit rest api admin privileges.
 # The setting `plugins. security. nodes_dn_dynamic_config_enabled` must be enabled.

--- a/tests/default/security/api/permissionsinfo.yaml
+++ b/tests/default/security/api/permissionsinfo.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test permissionsinfo endpoint.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Get evaluated permissions for currently logged in user.

--- a/tests/default/security/api/roles.yaml
+++ b/tests/default/security/api/roles.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test roles endpoints.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Create role.

--- a/tests/default/security/api/rolesmapping.yaml
+++ b/tests/default/security/api/rolesmapping.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test rolesmapping endpoint.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 prologues:
   - path: /_plugins/_security/api/roles/{role}

--- a/tests/default/security/api/securityconfig.yaml
+++ b/tests/default/security/api/securityconfig.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test securityconfig endpoints.
 version: '> 2.9'
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # ADMIN-CERT only (except GET). These tests require explicit rest api admin privileges.
 chapters:

--- a/tests/default/security/api/securityconfig/config.yaml
+++ b/tests/default/security/api/securityconfig/config.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test securityconfig/config endpoint.
 version: '> 2.9'
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # ADMIN-CERT only (except GET). These tests require explicit rest api admin privileges.
 chapters:

--- a/tests/default/security/api/ssl/certs.yaml
+++ b/tests/default/security/api/ssl/certs.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test ssl/certs endpoint.
 version: '>= 2.0'
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # ADMIN-CERT only. These tests require explicit rest api admin privileges.
 chapters:

--- a/tests/default/security/api/ssl/http/reloadcerts.yaml
+++ b/tests/default/security/api/ssl/http/reloadcerts.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../../../json_schemas/test_story.schema.yaml
 
 description: Test ssl/http/reloadcerts endpoint.
 version: '> 2.7'
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # ADMIN-CERT only. These tests require explicit rest api admin privileges.
 chapters:

--- a/tests/default/security/api/ssl/transport/reloadcerts.yaml
+++ b/tests/default/security/api/ssl/transport/reloadcerts.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../../../json_schemas/test_story.schema.yaml
 
 description: Test ssl/transport/reloadcerts endpoint.
 version: '> 2.7'
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # ADMIN-CERT only. These tests require explicit rest api admin privileges.
 chapters:

--- a/tests/default/security/api/tenancy/config.yaml
+++ b/tests/default/security/api/tenancy/config.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test tenancy/config endpoints.
 version: '> 2.6'
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Get tenancy config.

--- a/tests/default/security/api/tenants.yaml
+++ b/tests/default/security/api/tenants.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test tenants endpoints.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Create tenant.

--- a/tests/default/security/api/upgrade_check.yaml
+++ b/tests/default/security/api/upgrade_check.yaml
@@ -2,7 +2,10 @@ $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test _upgrade_check endpoint.
 version: '> 2.13'
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Check whether an upgrade can be performed.
     path: /_plugins/_security/api/_upgrade_check

--- a/tests/default/security/api/upgrade_perform.yaml
+++ b/tests/default/security/api/upgrade_perform.yaml
@@ -2,7 +2,10 @@ $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test _upgrade_perform endpoint.
 version: '> 2.13'
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Perform the upgrade.
     path: /_plugins/_security/api/_upgrade_perform

--- a/tests/default/security/api/user.yaml
+++ b/tests/default/security/api/user.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test user endpoints.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 chapters:
   - synopsis: Get user bulk.

--- a/tests/default/security/api/user/authtoken.yaml
+++ b/tests/default/security/api/user/authtoken.yaml
@@ -2,6 +2,10 @@ $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test authtoken endpoints for user.
 version: '> 2.16' # Fixed via https://github.com/opensearch-project/security/pull/4628
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 prologues:
   - path: /_plugins/_security/api/user/{username}

--- a/tests/default/security/api/validate.yaml
+++ b/tests/default/security/api/validate.yaml
@@ -1,6 +1,10 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test validate endpoint.
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 
 # BAD_REQUEST. Can not migrate configuration because it was already migrated.
 chapters:

--- a/tests/default/security/authinfo.yaml
+++ b/tests/default/security/authinfo.yaml
@@ -1,7 +1,10 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test authinfo endpoint.
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Get auth info.
     path: /_plugins/_security/authinfo

--- a/tests/default/security/dashboardsinfo.yaml
+++ b/tests/default/security/dashboardsinfo.yaml
@@ -1,7 +1,10 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test dashboardsinfo endpoint.
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Get dashboards info.
     path: /_plugins/_security/dashboardsinfo

--- a/tests/default/security/health.yaml
+++ b/tests/default/security/health.yaml
@@ -1,7 +1,10 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test health endpoint.
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Get security health info.
     path: /_plugins/_security/health

--- a/tests/default/security/sslinfo.yaml
+++ b/tests/default/security/sslinfo.yaml
@@ -1,7 +1,6 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test sslinfo endpoint.
-
 chapters:
   - synopsis: Get ssl info.
     path: /_opendistro/_security/sslinfo
@@ -13,13 +12,11 @@ chapters:
       payload:
         principal: null
         peer_certificates: '0'
-        ssl_protocol: TLSv1.3
         ssl_openssl_available: false
         ssl_openssl_version: -1
         ssl_openssl_version_string: null
         ssl_openssl_non_available_cause: 'java.lang.ClassNotFoundException: io.netty.internal.tcnative.SSLContext'
         ssl_openssl_supports_key_manager_factory: false
         ssl_openssl_supports_hostname_validation: false
-        ssl_provider_http: JDK
         ssl_provider_transport_server: JDK
         ssl_provider_transport_client: JDK

--- a/tests/default/security/tenantinfo.yaml
+++ b/tests/default/security/tenantinfo.yaml
@@ -1,7 +1,10 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test tenantinfo endpoint.
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Get tenant info.
     path: /_plugins/_security/tenantinfo

--- a/tests/default/security/whoami.yaml
+++ b/tests/default/security/whoami.yaml
@@ -2,7 +2,10 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test whoami endpoints.
 version: '>= 2.0'
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Get current user info.
     path: /_plugins/_security/whoami

--- a/tests/default/security/whoamiprotected.yaml
+++ b/tests/default/security/whoamiprotected.yaml
@@ -2,7 +2,10 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test whoamiprotected endpoint.
 version: '> 2.10'
-
+distributions:
+  excluded:
+    - amazon-managed
+    - amazon-serverless
 chapters:
   - synopsis: Get current user info from protected endpoint.
     path: /_plugins/_security/whoamiprotected

--- a/tools/src/tester/ChapterEvaluator.ts
+++ b/tools/src/tester/ChapterEvaluator.ts
@@ -87,13 +87,16 @@ export default class ChapterEvaluator {
       path: `${chapter.method} ${chapter.path}`,
       overall: { result: overall_result(evaluations) },
       request: { parameters: params, request },
-      retries,
       response: {
         status,
         payload_body: payload_body_evaluation,
         payload_schema: payload_schema_evaluation,
         output_values: output_values_evaluation.evaluation
       }
+    }
+
+    if (retries !== undefined) {
+      result.retries = retries
     }
 
     if (output_values_evaluation?.output !== undefined) {

--- a/tools/src/tester/StoryEvaluator.ts
+++ b/tools/src/tester/StoryEvaluator.ts
@@ -27,16 +27,6 @@ export default class StoryEvaluator {
   }
 
   async evaluate({ story, display_path, full_path }: StoryFile, version?: string, distribution?: string, dry_run: boolean = false): Promise<StoryEvaluation> {
-    if (version !== undefined && story.version !== undefined && !semver.satisfies(version, story.version)) {
-      return {
-        result: Result.SKIPPED,
-        display_path,
-        full_path,
-        description: story.description,
-        message: `Skipped because version ${version} does not satisfy ${story.version}.`
-      }
-    }
-
     if (distribution != undefined && story.distributions?.included !== undefined && story.distributions?.included.length > 0 && !story.distributions.included.includes(distribution)) {
       return {
         result: Result.SKIPPED,
@@ -54,6 +44,16 @@ export default class StoryEvaluator {
         full_path,
         description: story.description,
         message: `Skipped because distribution ${distribution} is ${story.distributions.excluded.length > 1 ? 'one of ' : ''}${story.distributions.excluded.join(', ')}.`
+      }
+    }
+
+    if (version !== undefined && story.version !== undefined && !semver.satisfies(version, story.version)) {
+      return {
+        result: Result.SKIPPED,
+        display_path,
+        full_path,
+        description: story.description,
+        message: `Skipped because version ${version} does not satisfy ${story.version}.`
       }
     }
 
@@ -109,15 +109,15 @@ export default class StoryEvaluator {
       if (dry_run) {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
         evaluations.push({ title, overall: { result: Result.SKIPPED, message: 'Dry Run' } })
-      } else if (version != undefined && chapter.version !== undefined && !semver.satisfies(version, chapter.version)) {
-        const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
-        evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because version ${version} does not satisfy ${chapter.version}.` } })
       } else if (distribution != undefined && chapter.distributions?.included !== undefined && chapter.distributions?.included.length > 0 && !chapter.distributions.included.includes(distribution)) {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
         evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because distribution ${distribution} is not ${chapter.distributions.included.length > 1 ? 'one of ' : ''}${chapter.distributions.included.join(', ')}.` } })
       } else if (distribution != undefined && chapter.distributions?.excluded !== undefined && chapter.distributions?.excluded.length > 0 && chapter.distributions.excluded.includes(distribution)) {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
         evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because distribution ${distribution} is ${chapter.distributions.excluded.length > 1 ? 'one of ' : ''}${chapter.distributions.excluded.join(', ')}.` } })
+      } else if (version != undefined && chapter.version !== undefined && !semver.satisfies(version, chapter.version)) {
+        const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
+        evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because version ${version} does not satisfy ${chapter.version}.` } })
       } else {
         const evaluation = await this._chapter_evaluator.evaluate(chapter, has_errors, story_outputs)
         has_errors = has_errors || evaluation.overall.result === Result.ERROR

--- a/tools/src/tester/StoryEvaluator.ts
+++ b/tools/src/tester/StoryEvaluator.ts
@@ -37,13 +37,23 @@ export default class StoryEvaluator {
       }
     }
 
-    if (distribution != undefined && story.distributions !== undefined && !story.distributions.includes(distribution)) {
+    if (distribution != undefined && story.distributions?.included !== undefined && story.distributions?.included.length > 0 && !story.distributions.included.includes(distribution)) {
       return {
         result: Result.SKIPPED,
         display_path,
         full_path,
         description: story.description,
-        message: `Skipped because distribution ${distribution} is not ${story.distributions.length > 1 ? 'one of ' : ''}${story.distributions.join(', ')}.`
+        message: `Skipped because distribution ${distribution} is not ${story.distributions.included.length > 1 ? 'one of ' : ''}${story.distributions.included.join(', ')}.`
+      }
+    }
+
+    if (distribution != undefined && story.distributions?.excluded !== undefined && story.distributions?.excluded.length > 0 && story.distributions.excluded.includes(distribution)) {
+      return {
+        result: Result.SKIPPED,
+        display_path,
+        full_path,
+        description: story.description,
+        message: `Skipped because distribution ${distribution} is ${story.distributions.excluded.length > 1 ? 'one of ' : ''}${story.distributions.excluded.join(', ')}.`
       }
     }
 
@@ -55,7 +65,8 @@ export default class StoryEvaluator {
     const { evaluations: prologues, has_errors: prologue_errors } = await this.#evaluate_supplemental_chapters(story.prologues ?? [], dry_run, story_outputs)
     const chapters = await this.#evaluate_chapters(story.chapters, prologue_errors, dry_run, story_outputs, version, distribution)
     const { evaluations: epilogues } = await this.#evaluate_supplemental_chapters(story.epilogues ?? [], dry_run, story_outputs)
-    return {
+
+    const result: StoryEvaluation = {
       display_path,
       full_path,
       description: story.description,
@@ -63,8 +74,14 @@ export default class StoryEvaluator {
       prologues,
       epilogues,
       result: overall_result(prologues.concat(chapters).concat(epilogues).concat(prologues).map(e => e.overall)),
-      warnings: this.#chapter_warnings(story.chapters)
     }
+
+    const warnings = this.#chapter_warnings(story.chapters)
+    if (warnings !== undefined) {
+      result.warnings = warnings
+    }
+
+    return result
   }
 
   #chapter_warnings(chapters: Chapter[]): string[] | undefined {
@@ -91,13 +108,16 @@ export default class StoryEvaluator {
     for (const chapter of chapters) {
       if (dry_run) {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
-        evaluations.push({ title, overall: { result: Result.SKIPPED, message: 'Dry Run', error: undefined } })
+        evaluations.push({ title, overall: { result: Result.SKIPPED, message: 'Dry Run' } })
       } else if (version != undefined && chapter.version !== undefined && !semver.satisfies(version, chapter.version)) {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
-        evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because version ${version} does not satisfy ${chapter.version}.`, error: undefined } })
-      } else if (distribution != undefined && chapter.distributions !== undefined && !chapter.distributions.includes(distribution)) {
+        evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because version ${version} does not satisfy ${chapter.version}.` } })
+      } else if (distribution != undefined && chapter.distributions?.included !== undefined && chapter.distributions?.included.length > 0 && !chapter.distributions.included.includes(distribution)) {
         const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
-        evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because distribution ${distribution} is not ${chapter.distributions.length > 1 ? 'one of ' : ''}${chapter.distributions.join(', ')}.`, error: undefined } })
+        evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because distribution ${distribution} is not ${chapter.distributions.included.length > 1 ? 'one of ' : ''}${chapter.distributions.included.join(', ')}.` } })
+      } else if (distribution != undefined && chapter.distributions?.excluded !== undefined && chapter.distributions?.excluded.length > 0 && chapter.distributions.excluded.includes(distribution)) {
+        const title = chapter.synopsis || `${chapter.method} ${chapter.path}`
+        evaluations.push({ title, overall: { result: Result.SKIPPED, message: `Skipped because distribution ${distribution} is ${chapter.distributions.excluded.length > 1 ? 'one of ' : ''}${chapter.distributions.excluded.join(', ')}.` } })
       } else {
         const evaluation = await this._chapter_evaluator.evaluate(chapter, has_errors, story_outputs)
         has_errors = has_errors || evaluation.overall.result === Result.ERROR
@@ -116,7 +136,7 @@ export default class StoryEvaluator {
     for (const chapter of chapters) {
       const title = `${chapter.method} ${chapter.path}`
       if (dry_run) {
-        evaluations.push({ title, overall: { result: Result.SKIPPED, message: 'Dry Run', error: undefined } })
+        evaluations.push({ title, overall: { result: Result.SKIPPED, message: 'Dry Run' } })
       } else {
         const { evaluation, evaluation_error } = await this._supplemental_chapter_evaluator.evaluate(chapter, story_outputs)
         has_errors = has_errors || evaluation_error

--- a/tools/src/tester/SupplementalChapterEvaluator.ts
+++ b/tools/src/tester/SupplementalChapterEvaluator.ts
@@ -12,7 +12,7 @@ import { ChapterOutput } from "./ChapterOutput";
 import ChapterReader from "./ChapterReader";
 import { StoryOutputs } from "./StoryOutputs";
 import { overall_result } from "./helpers";
-import { ChapterEvaluation, Result } from "./types/eval.types";
+import { ChapterEvaluation, Evaluation, Result } from "./types/eval.types";
 import { SupplementalChapter } from "./types/story.types";
 import { Logger } from "../Logger";
 import { to_json } from "../helpers";
@@ -71,9 +71,11 @@ export default class SupplementalChapterEvaluator {
 
       const message = message_segments.join('\n')
 
+      var overall: Evaluation = { result: Result.ERROR, message }
+      if (response.error !== undefined) overall.error = response.error as Error
+
       var evaluation: ChapterEvaluation = {
-        title,
-        overall: { result: Result.ERROR, message, error: response.error as Error }
+        title, overall
       }
 
       if (output_values_evaluation.output) {

--- a/tools/src/tester/types/story.types.ts
+++ b/tools/src/tester/types/story.types.ts
@@ -55,9 +55,9 @@ export type Version = string;
  *
  *
  * This interface was referenced by `Story`'s JSON-Schema
- * via the `definition` "Distributions".
+ * via the `definition` "DistributionsList".
  */
-export type Distributions = string[];
+export type DistributionsList = string[];
 /**
  * Number of times to retry on error.
  *
@@ -149,6 +149,17 @@ export interface Request {
  */
 export interface Output {
   [k: string]: string;
+}
+/**
+ * The list of distributions that support this API.
+ *
+ *
+ * This interface was referenced by `Story`'s JSON-Schema
+ * via the `definition` "Distributions".
+ */
+export interface Distributions {
+  included?: DistributionsList;
+  excluded?: DistributionsList;
 }
 /**
  * This interface was referenced by `Story`'s JSON-Schema

--- a/tools/tests/tester/fixtures/evals/skipped/distributions.yaml
+++ b/tools/tests/tester/fixtures/evals/skipped/distributions.yaml
@@ -1,6 +1,0 @@
-display_path: skipped/distributions.yaml
-full_path: tools/tests/tester/fixtures/stories/skipped/distributions.yaml
-
-result: SKIPPED
-description: This story should be skipped because of distributions.
-message: Skipped because distribution opensearch.org is not one of another, some.

--- a/tools/tests/tester/fixtures/evals/skipped/distributions/chapters.yaml
+++ b/tools/tests/tester/fixtures/evals/skipped/distributions/chapters.yaml
@@ -1,0 +1,16 @@
+display_path: skipped/distributions/chapters.yaml
+full_path: tools/tests/tester/fixtures/stories/skipped/distributions/chapters.yaml
+
+description: This story has chapters with distributions.
+prologues: []
+epilogues: []
+result: SKIPPED
+chapters:
+  - title: This chapter is excluded because of excluded distributions (opensearch.org).
+    overall:
+      message: Skipped because distribution opensearch.org is opensearch.org.
+      result: SKIPPED
+  - title: This chapter is excluded because of included distributions (opensearch.org).
+    overall:
+      message: Skipped because distribution opensearch.org is not amazon-managed.
+      result: SKIPPED

--- a/tools/tests/tester/fixtures/evals/skipped/distributions/excluded.yaml
+++ b/tools/tests/tester/fixtures/evals/skipped/distributions/excluded.yaml
@@ -1,0 +1,6 @@
+display_path: skipped/distributions/excluded.yaml
+full_path: tools/tests/tester/fixtures/stories/skipped/distributions/excluded.yaml
+
+result: SKIPPED
+description: This story should be skipped because of distributions (excluded).
+message: Skipped because distribution opensearch.org is one of amazon-managed, opensearch.org.

--- a/tools/tests/tester/fixtures/evals/skipped/distributions/included.yaml
+++ b/tools/tests/tester/fixtures/evals/skipped/distributions/included.yaml
@@ -1,0 +1,6 @@
+display_path: skipped/distributions/included.yaml
+full_path: tools/tests/tester/fixtures/stories/skipped/distributions/included.yaml
+
+result: SKIPPED
+description: This story should be skipped because of distributions (included).
+message: Skipped because distribution opensearch.org is not amazon-managed.

--- a/tools/tests/tester/fixtures/stories/skipped/distributions.yaml
+++ b/tools/tests/tester/fixtures/stories/skipped/distributions.yaml
@@ -1,9 +1,0 @@
-$schema: ../../../../../../json_schemas/test_story.schema.yaml
-
-description: This story should be skipped because of distributions.
-distributions:
-  - another
-  - some
-prologues: []
-epilogues: []
-chapters: []

--- a/tools/tests/tester/fixtures/stories/skipped/distributions/chapters.yaml
+++ b/tools/tests/tester/fixtures/stories/skipped/distributions/chapters.yaml
@@ -1,0 +1,22 @@
+$schema: ../../../../../../../json_schemas/test_story.schema.yaml
+
+description: This story has chapters with distributions.
+prologues: []
+epilogues: []
+chapters:
+  - synopsis: This chapter is excluded because of excluded distributions (opensearch.org).
+    distributions:
+      excluded:
+        - opensearch.org
+    path: /{index}
+    method: PUT
+    parameters:
+      index: index
+  - synopsis: This chapter is excluded because of included distributions (opensearch.org).
+    distributions:
+      included:
+        - amazon-managed
+    path: /{index}
+    method: PUT
+    parameters:
+      index: index

--- a/tools/tests/tester/fixtures/stories/skipped/distributions/excluded.yaml
+++ b/tools/tests/tester/fixtures/stories/skipped/distributions/excluded.yaml
@@ -1,0 +1,10 @@
+$schema: ../../../../../../../json_schemas/test_story.schema.yaml
+
+description: This story should be skipped because of distributions (excluded).
+distributions:
+  excluded:
+    - amazon-managed
+    - opensearch.org
+prologues: []
+epilogues: []
+chapters: []

--- a/tools/tests/tester/fixtures/stories/skipped/distributions/included.yaml
+++ b/tools/tests/tester/fixtures/stories/skipped/distributions/included.yaml
@@ -1,0 +1,9 @@
+$schema: ../../../../../../../json_schemas/test_story.schema.yaml
+
+description: This story should be skipped because of distributions (included).
+distributions:
+  included:
+    - amazon-managed
+prologues: []
+epilogues: []
+chapters: []

--- a/tools/tests/tester/helpers.ts
+++ b/tools/tests/tester/helpers.ts
@@ -122,12 +122,13 @@ export function flatten_errors (evaluation: StoryEvaluation): StoryEvaluation {
     }) as T
   }
 
-  return {
-    ...evaluation,
-    chapters: flatten_chapters(evaluation.chapters),
-    epilogues: flatten_chapters(evaluation.epilogues),
-    prologues: flatten_chapters(evaluation.prologues)
-  }
+  const result = evaluation
+
+  if (evaluation.chapters !== undefined) result.chapters = flatten_chapters(evaluation.chapters)
+  if (evaluation.epilogues !== undefined) result.epilogues = flatten_chapters(evaluation.epilogues)
+  if (evaluation.prologues !== undefined) result.prologues = flatten_chapters(evaluation.prologues)
+
+  return result
 }
 
 export function load_expected_evaluation (name: string, exclude_full_path: boolean = false): Omit<StoryEvaluation, 'full_path'> & { full_path?: string } {

--- a/tools/tests/tester/integ/TestRunner.test.ts
+++ b/tools/tests/tester/integ/TestRunner.test.ts
@@ -28,17 +28,20 @@ test('stories folder', async () => {
     actual_evaluations.push(rest)
   }
 
-  const passed = load_expected_evaluation('passed', true)
-  const skipped_semver = load_expected_evaluation('skipped/semver', true)
-  const skipped_distributions = load_expected_evaluation('skipped/distributions', true)
-  const not_found = load_expected_evaluation('failed/not_found', true)
-  const invalid_data = load_expected_evaluation('failed/invalid_data', true)
-  const chapter_error = load_expected_evaluation('error/chapter_error', true)
-  const output_error = load_expected_evaluation('error/output_error', true)
-  const prologue_error = load_expected_evaluation('error/prologue_error', true)
+  const expected_evaluations = [
+    'passed',
+    'error/chapter_error',
+    'error/output_error',
+    'error/prologue_error',
+    'failed/invalid_data',
+    'failed/not_found',
+    'skipped/semver',
+    'skipped/distributions/chapters',
+    'skipped/distributions/excluded',
+    'skipped/distributions/included'
+  ].map((fixture) => { return load_expected_evaluation(fixture, true) })
 
-  const expected_evaluations = [passed, chapter_error, output_error, prologue_error, invalid_data, not_found, skipped_distributions, skipped_semver]
-  expect(actual_evaluations).toEqual(expected_evaluations)
+  expect(actual_evaluations).toStrictEqual(expected_evaluations)
 })
 
 describe('story_files', () => {


### PR DESCRIPTION
### Description

Following up on #483, added `distributions` with `included` and `excluded`. I prefer to manage exclusions in tests so that a potential new distribution can run this with all tests enabled the first time, which makes it possible to immediately see what is broken. 

Removed `undefined` values from results, and use an exact comparison in integration tests, making it much easier to see what scenarios failed.

Passing `npm run test:spec -- --opensearch-distribution=amazon-managed` against Amazon Managed OpenSearch 2.13. The values of `ssl_provider_http`, `ssl_cipher` and `ssl_protocol` are coming back `null` from `sslinfo` and most security APIs are disabled. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
