### PR TITLE
Fixes NeuralQuery Schema

### DIFF
--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -1237,7 +1237,6 @@ components:
           type: string
         query_image:
           type: string
-          format: binary
         model_id:
           type: string
         k:
@@ -1248,8 +1247,9 @@ components:
           type: number
         filter:
           $ref: '#/components/schemas/QueryContainer'
-      required:
-        - model_id
+      anyOf:
+        - required: query_text
+        - required: query_image
     ParentIdQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'


### PR DESCRIPTION
### Description
Fixes NeuralQuery definition based on the documentation (and usage of OpenSearch).

### Issues Resolved
- query_image: format is not required since this is Base64 encoded image.
- model_id: is required if there is no default. thus we cannot enforce it here.
- query_text or query_image: at least one of them needs to be specified (both allowed).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
