### PR TITLE
Added detailed test coverage report.

### DIFF
--- a/.github/pr-comment-templates/pr-test-coverage-analysis.template.md
+++ b/.github/pr-comment-templates/pr-test-coverage-analysis.template.md
@@ -1,8 +1,8 @@
 ## Spec Test Coverage Analysis
 {{with .test_coverage}}
 
-| Total             | Tested                                                   |
-|-------------------|----------------------------------------------------------|
-| {{.paths_count}}  | {{.evaluated_paths_count}} ({{.evaluated_paths_pct}} %)  |
+| Total                        | Tested                                                        |
+|------------------------------|---------------------------------------------------------------|
+| {{.total_operations_count}}  | {{.evaluated_operations_count}} ({{.evaluated_paths_pct}} %)  |
 
 {{end}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `read_time`, `write_time`, `queue_size` and `io_time_in_millis` to `IoStatDevice` ([#483](https://github.com/opensearch-project/opensearch-api-specification/pull/483))
 - Added `total_rejections_breakup` to `ShardIndexingPressureStats` ([#483](https://github.com/opensearch-project/opensearch-api-specification/pull/483))
 - Added `cancelled_task_percentage` and `current_cancellation_eligible_tasks_count` to `ShardSearchBackpressureTaskCancellationStats` ([#483](https://github.com/opensearch-project/opensearch-api-specification/pull/483))
+- Added detailed test coverage report ([#513](https://github.com/opensearch-project/opensearch-api-specification/pull/513))
 
 ### Changed
 

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -16,6 +16,9 @@
     - [Warnings](#warnings)
       - [multiple-paths-detected](#multiple-paths-detected)
       - [Suppressing Warnings](#suppressing-warnings)
+  - [Collecting Test Coverage](#collecting-test-coverage)
+    - [Coverage Summary](#coverage-summary)
+    - [Coverage Report](#coverage-report)
 <!-- TOC -->
 
 # Spec Testing Guide
@@ -317,4 +320,33 @@ The test runner may generate warnings that can be suppressed with `warnings:`. F
   path: /{index}/_search
   parameters:
     index: movies
+```
+
+## Collecting Test Coverage
+
+### Coverage Summary
+
+The test tool can generate a test coverage summary using `--coverage <path>` with the number of evaluated verb + path combinations, a total number of paths and the % of paths tested. 
+
+```json
+{
+  "evaluated_paths_count": 214,
+  "paths_count": 550,
+  "evaluated_paths_pct": 38.91
+}
+```
+
+The report is then used by the [test-spec.yml](.github/workflows/test-spec.yml) workflow, uploaded with every run, combined across various versions of OpenSearch, and reported as a comment on each pull request.
+
+### Coverage Report
+
+The test tool can display detailed and hierarchal test coverage with `--coverage-report`. This is useful to identify untested paths. For example, the [put_alias.yaml](tests/default/indices/aliases/put_alias.yaml) test exercises `PUT /_alias/{name}`, but not the other verbs. The report produces the following output with the missing ones.
+
+```
+/_alias (4)
+  GET /_alias
+  /{name} (3)
+    GET /_alias/{name}
+    POST /_alias/{name}
+    HEAD /_alias/{name}
 ```

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -330,8 +330,8 @@ The test tool can generate a test coverage summary using `--coverage <path>` wit
 
 ```json
 {
-  "evaluated_paths_count": 214,
-  "paths_count": 550,
+  "evaluated_operations_count": 214,
+  "operations_count": 550,
   "evaluated_paths_pct": 38.91
 }
 ```

--- a/tools/src/tester/ChapterEvaluator.ts
+++ b/tools/src/tester/ChapterEvaluator.ts
@@ -84,6 +84,10 @@ export default class ChapterEvaluator {
 
     var result: ChapterEvaluation = {
       title: chapter.synopsis,
+      operation: {
+        method: chapter.method,
+        path: chapter.path
+      },
       path: `${chapter.method} ${chapter.path}`,
       overall: { result: overall_result(evaluations) },
       request: { parameters: params, request },

--- a/tools/src/tester/ResultLogger.ts
+++ b/tools/src/tester/ResultLogger.ts
@@ -7,7 +7,7 @@
 * compatible open source license.
 */
 
-import { type ChapterEvaluation, type Evaluation, Result, type StoryEvaluation } from './types/eval.types'
+import { type ChapterEvaluation, type Evaluation, Operation, Result, type StoryEvaluation } from './types/eval.types'
 import { overall_result } from './helpers'
 import * as ansi from './Ansi'
 import TestResults from './TestResults'
@@ -44,29 +44,29 @@ export class ConsoleResultLogger implements ResultLogger {
 
   log_coverage(results: TestResults): void {
     console.log()
-    console.log(`Tested ${results.evaluated_paths().length}/${results.spec_paths().length} paths.`)
+    console.log(`Tested ${results.evaluated_operations().length}/${results.operations().length} paths.`)
   }
 
   log_coverage_report(results: TestResults): void {
     console.log()
-    console.log(`${results.unevaluated_paths().length} paths remaining.`)
-    const groups = _.groupBy(results.unevaluated_paths(), (path) => path.split(' ', 2)[1].split('/')[1])
-    Object.entries(groups).forEach(([root, paths]) => {
-      this.#log_coverage_group(root, paths)
+    console.log(`${results.unevaluated_operations().length} paths remaining.`)
+    const groups = _.groupBy(results.unevaluated_operations(), (operation) => operation.path.split('/')[1])
+    Object.entries(groups).forEach(([root, operations]) => {
+      this.#log_coverage_group(root, operations)
     });
   }
 
-  #log_coverage_group(key: string, paths: string[], index: number = 2): void {
-    if (paths.length == 0 || key == undefined) return
-    console.log(`${' '.repeat(index)}/${key} (${paths.length})`)
-    const current_level_paths = paths.filter((path) => path.split('/').length == index)
-    current_level_paths.forEach((path) => {
-      console.log(`${' '.repeat(index + 2)}${path}`)
+  #log_coverage_group(key: string, operations: Operation[], index: number = 2): void {
+    if (operations.length == 0 || key == undefined) return
+    console.log(`${' '.repeat(index)}/${key} (${operations.length})`)
+    const current_level_operations = operations.filter((operation) => operation.path.split('/').length == index)
+    current_level_operations.forEach((operation) => {
+      console.log(`${' '.repeat(index + 2)}${operation.method} ${operation.path}`)
     })
-    const next_level_paths = paths.filter((path) => path.split('/').length > index)
-    const subgroups = _.groupBy(next_level_paths, (path) => path.split('/')[index])
-    Object.entries(subgroups).forEach(([root, paths]) => {
-      this.#log_coverage_group(root, paths, index + 1)
+    const next_level_operations = operations.filter((operation) => operation.path.split('/').length > index)
+    const subgroups = _.groupBy(next_level_operations, (operation) => operation.path.split('/')[index])
+    Object.entries(subgroups).forEach(([root, operations]) => {
+      this.#log_coverage_group(root, operations, index + 1)
     });
   }
 

--- a/tools/src/tester/StoryEvaluator.ts
+++ b/tools/src/tester/StoryEvaluator.ts
@@ -97,8 +97,8 @@ export default class StoryEvaluator {
       if (multiple_paths_detected) return chapter.path
     }))
     const normalized_paths = _.map(paths, (path) => path.replaceAll(/\/\{[^}]+}/g, '').replaceAll('//', '/'))
-    const paths_counts: Record<string, number> = Object.assign((_.values(_.groupBy(normalized_paths)).map(p => { return { [p[0]] : p.length } })))
-    if (paths_counts.length > 1) {
+    const operations_counts: Record<string, number> = Object.assign((_.values(_.groupBy(normalized_paths)).map(p => { return { [p[0]] : p.length } })))
+    if (operations_counts.length > 1) {
       return `Multiple paths detected, please group similar tests together and move paths not being tested to prologues or epilogues.\n  ${_.join(_.uniq(paths), "\n  ")}\n`
     }
   }

--- a/tools/src/tester/TestResults.ts
+++ b/tools/src/tester/TestResults.ts
@@ -9,51 +9,59 @@
 
 import _ from "lodash";
 import MergedOpenApiSpec from "./MergedOpenApiSpec";
-import { StoryEvaluations } from "./types/eval.types";
+import { Operation, StoryEvaluations } from "./types/eval.types";
 import { SpecTestCoverage } from "./types/test.types";
 import { write_json } from "../helpers";
 
 export default class TestResults {
   protected _spec: MergedOpenApiSpec
   protected _evaluations: StoryEvaluations
-  protected _evaluated_paths?: string[]
-  protected _unevaluated_paths?: string[]
-  protected _spec_paths?: string[]
+  protected _evaluated_operations?: Operation[]
+  protected _unevaluated_operations?: Operation[]
+  protected _operations?: Operation[]
 
   constructor(spec: MergedOpenApiSpec, evaluations: StoryEvaluations) {
     this._spec = spec
     this._evaluations = evaluations
   }
 
-  evaluated_paths(): string[] {
-    if (this._evaluated_paths !== undefined) return this._evaluated_paths
-    this._evaluated_paths = _.uniq(_.compact(_.flatten(_.map(this._evaluations.evaluations, (evaluation) =>
-      _.map(evaluation.chapters, (chapter) => chapter.path)
-    ))))
-    return this._evaluated_paths
+  evaluated_operations(): Operation[] {
+    if (this._evaluated_operations !== undefined) return this._evaluated_operations
+    this._evaluated_operations = _.uniq(_.compact(_.flatMap(this._evaluations.evaluations, (evaluation) =>
+      _.map(evaluation.chapters, (chapter) => chapter.operation)
+    )))
+    return this._evaluated_operations
   }
 
-  unevaluated_paths(): string[] {
-    if (this._unevaluated_paths !== undefined) return this._unevaluated_paths
-    this._unevaluated_paths = this.spec_paths().filter((path => !this.evaluated_paths().includes(path)))
-    return this._unevaluated_paths
+  unevaluated_operations(): Operation[] {
+    if (this._unevaluated_operations !== undefined) return this._unevaluated_operations
+    this._unevaluated_operations = this.operations().filter((operation) =>
+      !_.find(this.evaluated_operations(),
+        (op) =>
+          operation.method == op.method &&
+          operation.path == op.path
+      )
+    )
+    return this._unevaluated_operations
   }
 
-  spec_paths(): string[] {
-    if (this._spec_paths !== undefined) return this._spec_paths
-    this._spec_paths = _.uniq(Object.entries(this._spec.paths()).flatMap(([path, path_item]) => {
-      return Object.values(path_item).map((method) => `${method.toUpperCase()} ${path}`)
+  operations(): Operation[] {
+    if (this._operations !== undefined) return this._operations
+    this._operations = _.uniq(Object.entries(this._spec.paths()).flatMap(([path, path_item]) => {
+      return Object.values(path_item).map((method) => {
+        return { method: method.toUpperCase(), path }
+      })
     }))
 
-    return this._spec_paths
+    return this._operations
   }
 
   test_coverage(): SpecTestCoverage {
     return {
-      evaluated_paths_count: this.evaluated_paths().length,
-      paths_count: this.spec_paths().length,
-      evaluated_paths_pct: this.spec_paths().length > 0 ? Math.round(
-        this.evaluated_paths().length / this.spec_paths().length * 100 * 100
+      evaluated_operations_count: this.evaluated_operations().length,
+      total_operations_count: this.operations().length,
+      evaluated_paths_pct: this.operations().length > 0 ? Math.round(
+        this.evaluated_operations().length / this.operations().length * 100 * 100
       ) / 100 : 0,
     }
   }

--- a/tools/src/tester/test.ts
+++ b/tools/src/tester/test.ts
@@ -60,6 +60,7 @@ const command = new Command()
   .addOption(AWS_REGION_OPTION)
   .addOption(AWS_SERVICE_OPTION)
   .addOption(new Option('--coverage <path>', 'path to write test coverage results to'))
+  .addOption(new Option('--coverage-report', 'display a detailed test coverage report'))
   .allowExcessArguments(false)
   .parse()
 
@@ -82,6 +83,7 @@ runner.run(opts.testsPath, spec.api_version(), opts.opensearchDistribution, opts
 
       const test_results = new TestResults(spec, results)
       result_logger.log_coverage(test_results)
+      if (opts.coverageReport) result_logger.log_coverage_report(test_results)
       if (opts.coverage !== undefined) {
         console.log(`Writing ${opts.coverage} ...`)
         test_results.write_coverage(opts.coverage)

--- a/tools/src/tester/types/eval.types.ts
+++ b/tools/src/tester/types/eval.types.ts
@@ -17,6 +17,11 @@ export interface StoryFile {
   story: Story
 }
 
+export interface Operation {
+  method: string
+  path: string
+}
+
 export interface StoryEvaluation {
   result: Result
   display_path: string
@@ -36,6 +41,7 @@ export interface StoryEvaluations {
 export interface ChapterEvaluation {
   title: string,
   overall: Evaluation,
+  operation?: Operation,
   path?: string,
   request?: {
     parameters?: Record<string, Evaluation>

--- a/tools/src/tester/types/test.types.ts
+++ b/tools/src/tester/types/test.types.ts
@@ -8,7 +8,7 @@
 */
 
 export interface SpecTestCoverage {
-  paths_count: number
-  evaluated_paths_count: number,
+  total_operations_count: number
+  evaluated_operations_count: number,
   evaluated_paths_pct: number
 }

--- a/tools/tests/tester/ResultLogger.test.ts
+++ b/tools/tests/tester/ResultLogger.test.ts
@@ -79,6 +79,41 @@ describe('ConsoleResultLogger', () => {
       ])
     })
 
+    test('log_coverage_report', () => {
+      const spec = new MergedOpenApiSpec('tools/tests/tester/fixtures/specs/complete')
+      const test_results = new TestResults(spec, { evaluations: [{
+        result: Result.PASSED,
+        display_path: 'path',
+        full_path: 'path',
+        description: 'description',
+        chapters: [
+          {
+            title: 'title',
+            overall: { result: Result.PASSED },
+            path: 'GET /_nodes/{id}'
+          }
+        ]
+      }] })
+
+      logger.log_coverage_report(test_results)
+
+      expect(log.mock.calls).not.toContain(["GET /_nodes/{id}"])
+      expect(log.mock.calls).toEqual([
+        [],
+        ["5 paths remaining."],
+        ["  /_nodes (1)"],
+        ["   /{id} (1)"],
+        ["     POST /_nodes/{id}"],
+        ["  /cluster_manager (2)"],
+        ["    GET /cluster_manager"],
+        ["    POST /cluster_manager"],
+        ["  /index (1)"],
+        ["    GET /index"],
+        ["  /nodes (1)"],
+        ["    GET /nodes"]
+      ])
+    })
+
     test('with retries', () => {
       logger.log({
         result: Result.PASSED,

--- a/tools/tests/tester/ResultLogger.test.ts
+++ b/tools/tests/tester/ResultLogger.test.ts
@@ -66,7 +66,11 @@ describe('ConsoleResultLogger', () => {
           {
             title: 'title',
             overall: { result: Result.PASSED },
-            path: 'path'
+            path: 'path',
+            operation: {
+              method: 'GET',
+              path: '/_nodes/{id}'
+            }
           }
         ]
       }] })
@@ -90,7 +94,11 @@ describe('ConsoleResultLogger', () => {
           {
             title: 'title',
             overall: { result: Result.PASSED },
-            path: 'GET /_nodes/{id}'
+            path: 'GET /_nodes/{id}',
+            operation: {
+              method: 'GET',
+              path: '/_nodes/{id}'
+            }
           }
         ]
       }] })

--- a/tools/tests/tester/TestResults.test.ts
+++ b/tools/tests/tester/TestResults.test.ts
@@ -17,7 +17,7 @@ describe('TestResults', () => {
 
   const evaluations = [{
     result: Result.PASSED,
-    display_path: 'path',
+    display_path: 'PUT /{index}',
     full_path: 'full_path',
     description: 'description',
     message: 'message',
@@ -26,7 +26,7 @@ describe('TestResults', () => {
       overall: {
         result: Result.PASSED
       },
-      path: 'path'
+      path: 'PUT /{index}'
     }],
     epilogues: [],
     prologues: []
@@ -34,12 +34,30 @@ describe('TestResults', () => {
 
   const test_results = new TestResults(spec, { evaluations })
 
-  test('evaluated_paths_count', () => {
-    expect(test_results.evaluated_paths_count()).toEqual(1)
+  test('unevaluated_paths', () => {
+    expect(test_results.unevaluated_paths()).toEqual([
+      "GET /_nodes/{id}",
+      "POST /_nodes/{id}",
+      "GET /cluster_manager",
+      "POST /cluster_manager",
+      "GET /index",
+      "GET /nodes"
+    ])
   })
 
-  test('spec_paths_count', () => {
-    expect(test_results.spec_paths_count()).toEqual(6)
+  test('evaluated_paths', () => {
+    expect(test_results.evaluated_paths()).toEqual(['PUT /{index}'])
+  })
+
+  test('spec_paths', () => {
+    expect(test_results.spec_paths()).toEqual([
+      "GET /_nodes/{id}",
+      "POST /_nodes/{id}",
+      "GET /cluster_manager",
+      "POST /cluster_manager",
+      "GET /index",
+      "GET /nodes"
+    ])
   })
 
   test('write_coverage', () => {

--- a/tools/tests/tester/TestResults.test.ts
+++ b/tools/tests/tester/TestResults.test.ts
@@ -23,6 +23,10 @@ describe('TestResults', () => {
     message: 'message',
     chapters: [{
       title: 'title',
+      operation: {
+        method: 'PUT',
+        path: '/{index}'
+      },
       overall: {
         result: Result.PASSED
       },
@@ -34,29 +38,31 @@ describe('TestResults', () => {
 
   const test_results = new TestResults(spec, { evaluations })
 
-  test('unevaluated_paths', () => {
-    expect(test_results.unevaluated_paths()).toEqual([
-      "GET /_nodes/{id}",
-      "POST /_nodes/{id}",
-      "GET /cluster_manager",
-      "POST /cluster_manager",
-      "GET /index",
-      "GET /nodes"
+  test('unevaluated_operations', () => {
+    expect(test_results.unevaluated_operations()).toEqual([
+      { method: "GET", path: "/_nodes/{id}" },
+      { method: "POST", path: "/_nodes/{id}" },
+      { method: "GET", path: "/cluster_manager" },
+      { method: "POST", path: "/cluster_manager" },
+      { method: "GET", path: "/index" },
+      { method: "GET", path: "/nodes" }
     ])
   })
 
-  test('evaluated_paths', () => {
-    expect(test_results.evaluated_paths()).toEqual(['PUT /{index}'])
+  test('evaluated_operations', () => {
+    expect(test_results.evaluated_operations()).toStrictEqual([
+      { method: 'PUT', path: '/{index}' }
+    ])
   })
 
-  test('spec_paths', () => {
-    expect(test_results.spec_paths()).toEqual([
-      "GET /_nodes/{id}",
-      "POST /_nodes/{id}",
-      "GET /cluster_manager",
-      "POST /cluster_manager",
-      "GET /index",
-      "GET /nodes"
+  test('operations', () => {
+    expect(test_results.operations()).toEqual([
+      { method: "GET", path: "/_nodes/{id}" },
+      { method: "POST", path: "/_nodes/{id}" },
+      { method: "GET", path: "/cluster_manager" },
+      { method: "POST", path: "/cluster_manager" },
+      { method: "GET", path: "/index" },
+      { method: "GET", path: "/nodes" }
     ])
   })
 
@@ -64,9 +70,9 @@ describe('TestResults', () => {
     const filename = 'coverage.json'
     test_results.write_coverage(filename)
     expect(JSON.parse(fs.readFileSync(filename, 'utf8'))).toEqual({
-      evaluated_paths_count: 1,
+      evaluated_operations_count: 1,
       evaluated_paths_pct: 16.67,
-      paths_count: 6
+      total_operations_count: 6
     })
     fs.unlinkSync(filename)
   })

--- a/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
+++ b/tools/tests/tester/fixtures/evals/error/chapter_error.yaml
@@ -24,6 +24,9 @@ chapters:
     overall:
       result: ERROR
     path: DELETE /{index}
+    operation:
+      method: DELETE
+      path: /{index}
     request:
       parameters: {}
       request:

--- a/tools/tests/tester/fixtures/evals/error/output_error.yaml
+++ b/tools/tests/tester/fixtures/evals/error/output_error.yaml
@@ -11,6 +11,9 @@ chapters:
     overall:
       result: ERROR
     path: GET /_cat/health
+    operation:
+      method: GET
+      path: /_cat/health
     retries: 3
     request:
       parameters:

--- a/tools/tests/tester/fixtures/evals/failed/invalid_data.yaml
+++ b/tools/tests/tester/fixtures/evals/failed/invalid_data.yaml
@@ -9,6 +9,9 @@ chapters:
     overall:
       result: FAILED
     path: PUT /{index}
+    operation:
+      method: PUT
+      path: /{index}
     request:
       parameters:
         index:
@@ -29,6 +32,9 @@ chapters:
     overall:
       result: FAILED
     path: PUT /{index}
+    operation:
+      method: PUT
+      path: /{index}
     request:
       parameters:
         index:
@@ -49,6 +55,9 @@ chapters:
     overall:
       result: FAILED
     path: GET /_cat/indices/{index}
+    operation:
+      method: GET
+      path: /_cat/indices/{index}
     request:
       parameters:
         format:
@@ -71,6 +80,9 @@ chapters:
     overall:
       result: FAILED
     path: DELETE /{index}
+    operation:
+      method: DELETE
+      path: /{index}
     request:
       parameters:
         index:
@@ -92,6 +104,9 @@ chapters:
     overall:
       result: ERROR
     path: PUT /{index}
+    operation:
+      method: PUT
+      path: /{index}
     request:
       parameters:
         index:

--- a/tools/tests/tester/fixtures/evals/failed/not_found.yaml
+++ b/tools/tests/tester/fixtures/evals/failed/not_found.yaml
@@ -18,6 +18,9 @@ chapters:
     overall:
       result: FAILED
     path: PUT /{index}
+    operation:
+      method: PUT
+      path: /{index}
     request:
       parameters:
         index:
@@ -40,6 +43,9 @@ chapters:
     overall:
       result: FAILED
     path: HEAD /{index}
+    operation:
+      method: HEAD
+      path: /{index}
     request:
       parameters:
         index:
@@ -60,6 +66,9 @@ chapters:
     overall:
       result: FAILED
     path: DELETE /{index}
+    operation:
+      method: DELETE
+      path: /{index}
     request:
       parameters:
         index:

--- a/tools/tests/tester/fixtures/evals/passed.yaml
+++ b/tools/tests/tester/fixtures/evals/passed.yaml
@@ -9,6 +9,9 @@ chapters:
     overall:
       result: PASSED
     path: PUT /{index}
+    operation:
+      method: PUT
+      path: /{index}
     request:
       parameters:
         index:
@@ -28,6 +31,9 @@ chapters:
     overall:
       result: PASSED
     path: GET /_cat
+    operation:
+      method: GET
+      path: /_cat
     request:
       parameters: {}
       request:
@@ -45,6 +51,9 @@ chapters:
     overall:
       result: PASSED
     path: GET /_cat
+    operation:
+      method: GET
+      path: /_cat
     request:
       parameters: {}
       request:
@@ -62,6 +71,9 @@ chapters:
     overall:
       result: PASSED
     path: GET /_cat/health
+    operation:
+      method: GET
+      path: /_cat/health
     request:
       parameters:
         format:
@@ -81,6 +93,9 @@ chapters:
     overall:
       result: PASSED
     path: GET /_cat/health
+    operation:
+      method: GET
+      path: /_cat/health
     request:
       parameters:
         format:
@@ -100,6 +115,9 @@ chapters:
     overall:
       result: PASSED
     path: GET /_cat/health
+    operation:
+      method: GET
+      path: /_cat/health
     request:
       parameters:
         format:
@@ -119,6 +137,9 @@ chapters:
     overall:
       result: PASSED
     path: GET /_cat/health
+    operation:
+      method: GET
+      path: /_cat/health
     request:
       parameters:
         format:
@@ -138,6 +159,9 @@ chapters:
     overall:
       result: PASSED
     path: GET /_cat/health
+    operation:
+      method: GET
+      path: /_cat/health
     request:
       parameters:
         format:
@@ -157,6 +181,9 @@ chapters:
     overall:
       result: PASSED
     path: GET /_cat/health
+    operation:
+      method: GET
+      path: /_cat/health
     request:
       parameters:
         format:
@@ -180,6 +207,9 @@ chapters:
     overall:
       result: PASSED
     path: GET /_cat/health
+    operation:
+      method: GET
+      path: /_cat/health
     request:
       parameters:
         format:

--- a/tools/tests/tester/integ/StoryEvaluator.test.ts
+++ b/tools/tests/tester/integ/StoryEvaluator.test.ts
@@ -70,6 +70,10 @@ test('with an unexpected error deserializing data', async () => {
   expect(actual.chapters && actual.chapters[0]).toEqual({
     title: "This PUT /{index} chapter should pass.",
     path: 'PUT /{index}',
+    operation: {
+      method: 'PUT',
+      path: '/{index}'
+    },
     overall: {
       result: Result.ERROR
     },


### PR DESCRIPTION
### Description

Added a new `--coverage-report` option that displays a hierarchy of paths that are not tested. This is helpful to see if an entire API is tested vs. what's missing.

For example, the `/_alias` API is missing 4 tests and `/_plugins` are missing 46, including 11 in `/_plugins/_knn`.

```
  /_alias (4)
    GET /_alias
   /{name} (3)
     GET /_alias/{name}
     POST /_alias/{name}
     HEAD /_alias/{name}
```

```
/_plugins (46)
   /_knn (11)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
