### PR TITLE
Refactor the common query DSL spec to extract IgnoreUnmapped

### DIFF
--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -591,6 +591,12 @@ components:
                 - type: boolean
           required:
             - value
+    IgnoreUnmapped:
+      type: boolean
+      default: false
+      description: |-
+        Set to `true` to ignore an unmapped field and not match any documents for this query.
+        Set to `false` to throw an exception if the field is not mapped.
     GeoBoundingBoxQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
@@ -601,10 +607,7 @@ components:
             validation_method:
               $ref: '#/components/schemas/GeoValidationMethod'
             ignore_unmapped:
-              description: |-
-                Set to `true` to ignore an unmapped field and not match any documents for this query.
-                Set to `false` to throw an exception if the field is not mapped.
-              type: boolean
+              $ref: '#/components/schemas/IgnoreUnmapped'
     GeoExecution:
       type: string
       enum:
@@ -628,11 +631,7 @@ components:
             validation_method:
               $ref: '#/components/schemas/GeoValidationMethod'
             ignore_unmapped:
-              description: |-
-                Set to `true` to ignore an unmapped field and not match any documents for this query.
-                Set to `false` to throw an exception if the field is not mapped.
-              type: boolean
-              default: false
+              $ref: '#/components/schemas/IgnoreUnmapped'
             field:
               type: object
           required:
@@ -646,25 +645,22 @@ components:
             validation_method:
               $ref: '#/components/schemas/GeoValidationMethod'
             ignore_unmapped:
-              type: boolean
+              $ref: '#/components/schemas/IgnoreUnmapped'
     GeoShapeQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
         - type: object
           properties:
             ignore_unmapped:
-              description: |-
-                Set to `true` to ignore an unmapped field and not match any documents for this query.
-                Set to `false` to throw an exception if the field is not mapped.
-              type: boolean
+              $ref: '#/components/schemas/IgnoreUnmapped'
     HasChildQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
         - type: object
           properties:
             ignore_unmapped:
+              $ref: '#/components/schemas/IgnoreUnmapped'
               description: Indicates whether to ignore an unmapped `type` and not return any documents instead of an error.
-              type: boolean
             inner_hits:
               $ref: '_core.search.yaml#/components/schemas/InnerHits'
             max_children:
@@ -712,10 +708,10 @@ components:
         - type: object
           properties:
             ignore_unmapped:
+              $ref: '#/components/schemas/IgnoreUnmapped'
               description: |-
                 Indicates whether to ignore an unmapped `parent_type` and not return any documents instead of an error.
                 You can use this parameter to query multiple indices that may not contain the `parent_type`.
-              type: boolean
             inner_hits:
               $ref: '_core.search.yaml#/components/schemas/InnerHits'
             parent_type:
@@ -1209,8 +1205,8 @@ components:
         - type: object
           properties:
             ignore_unmapped:
+              $ref: '#/components/schemas/IgnoreUnmapped'
               description: Indicates whether to ignore an unmapped path and not return any documents instead of an error.
-              type: boolean
             inner_hits:
               $ref: '_core.search.yaml#/components/schemas/InnerHits'
             path:
@@ -1230,8 +1226,8 @@ components:
             id:
               $ref: '_common.yaml#/components/schemas/Id'
             ignore_unmapped:
+              $ref: '#/components/schemas/IgnoreUnmapped'
               description: Indicates whether to ignore an unmapped `type` and not return any documents instead of an error.
-              type: boolean
             type:
               $ref: '_common.yaml#/components/schemas/RelationName'
     PercolateQuery:
@@ -1585,8 +1581,7 @@ components:
         - type: object
           properties:
             ignore_unmapped:
-              description: When set to `true` the query ignores an unmapped field and will not match any documents.
-              type: boolean
+              $ref: '#/components/schemas/IgnoreUnmapped'
     SimpleQueryStringQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'


### PR DESCRIPTION
Ignore_unmapped is a parameter that is common to several query types. This PR refactors the spec to extract IgnoreUnmapped into a common parameter. I left the descriptions in some of the query types because they are more specific than the generic description. I am assuming that the description within a query type overrides the description in the common parameter but please lmk if that's not true. I have verified that for all query types, the default for this parameter is `false`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
