### PR TITLE
Add info_win.yaml (cloned from info.yaml). Can be used in Windows env

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -29,6 +29,16 @@ We have devised our own test framework to test the spec against an OpenSearch cl
 
 ### Running Spec Tests Locally
 
+Downloading and installing latest version of Node.js and npm
+
+https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+
+```bash
+Note: to download the latest version of npm, on the command line, run the following command:
+
+npm install -g npm
+```
+
 Set up an OpenSearch cluster with Docker:
 
 (Replace `<<your_password>>` with your desired password. If not provided, the default password inside the `docker-compose.yml` file will be used.)
@@ -36,6 +46,10 @@ Set up an OpenSearch cluster with Docker:
 export OPENSEARCH_PASSWORD=<<your_password>>
 cd tests/default
 docker compose up -d
+```
+In Windows env:
+``` 
+$Env:OPENSEARCH_PASSWORD="MyPassword!"
 ```
 
 Run the tests (use `--opensearch-insecure` for a local cluster running in Docker that does not have a valid SSL certificate):

--- a/package-lock.json
+++ b/package-lock.json
@@ -3927,9 +3927,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -12493,9 +12494,9 @@
       }
     },
     "axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/tests/default/_core/info_win.yaml
+++ b/tests/default/_core/info_win.yaml
@@ -1,0 +1,24 @@
+
+$schema: ..\..\..\json_schemas\test_story.schema.yaml
+
+description: Test root endpoint.
+distributions:
+  excluded:
+    - amazon-serverless
+chapters:
+  - synopsis: Get server info.
+    path: \
+    method: GET
+    response:
+      status: 200
+  - synopsis: Get server info (pretty=false).
+    path: \
+    method: GET
+    parameters:
+      pretty: false
+    response:
+      status: 200
+      payload:
+        version:
+          distribution: opensearch
+        tagline: 'The OpenSearch Project: https://opensearch.org/'


### PR DESCRIPTION
### Description
Added the initial step for setting up an env. for running test.
Added a new info_win.yaml (identical into.yaml) test file for Windows

### Issues Resolved
lets run tests in windows:
'''
npm run test:spec -- --opensearch-insecure --tests tests/default/_core/info_win.yaml

> opensearch_api_tools@1.0.0 test:spec
> ts-node tools/src/tester/test.ts --opensearch-insecure --tests tests/default/_core/info_win.yaml

OpenSearch 2.16.0


FAILED  info_win.yaml (C:\Users\marka\Projects\OpenSearch\runTests\opensearch-api-specification\tests\default\_core\info_win.yaml)
    FAILED  CHAPTERS
        FAILED  Get server info. (Operation "GET \" not found in the spec.)
        FAILED  Get server info (pretty=false). (Operation "GET \" not found in the spec.)


Tested 0/550 paths.
'''

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
