### PR TITLE
Extracted ML tests into a separate workflow execution.

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -31,6 +31,8 @@ jobs:
           - version: 2.16.0
             tests: plugins/index_state_management
           - version: 2.16.0
+            tests: plugins/ml
+          - version: 2.16.0
             tests: snapshot
           - version: 2.17.0
             hub: opensearchstaging

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -168,7 +168,7 @@ chapters:
 
 ### Using Output from Previous Chapters
 
-Consider the following chapters in [ml/model_groups](tests/default/ml/model_groups.yaml) test story:
+Consider the following chapters in [ml/model_groups](tests/plugins/ml/ml/model_groups.yaml) test story:
 ```yaml
   - synopsis: Create model group.
     id: create_model_group # Only needed if you want to refer to this chapter in another chapter.

--- a/tests/default/_core/reindex/pipeline.yaml
+++ b/tests/default/_core/reindex/pipeline.yaml
@@ -1,6 +1,8 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test reindex with a Search pipeline.
+warnings:
+  multiple-paths-detected: false
 epilogues:
   - path: /movies
     method: DELETE
@@ -54,15 +56,11 @@ chapters:
     response:
       status: 200
   - synopsis: Refresh the index.
-    warnings:
-      multiple-paths-detected: false
     path: /{index}/_refresh
     method: POST
     parameters:
       index: videos
   - synopsis: Get all videos.
-    warnings:
-      multiple-paths-detected: false
     path: /{index}/_search
     method: POST
     parameters:

--- a/tests/default/asynchronous_search/search.yaml
+++ b/tests/default/asynchronous_search/search.yaml
@@ -57,9 +57,3 @@ chapters:
       id: ${async_search.id}
     response:
       status: 200
-  - synopsis: Get stats.
-    path: /_plugins/_asynchronous_search/stats
-    method: GET
-    version: < 3.0
-    response:
-      status: 200

--- a/tests/default/asynchronous_search/stats.yaml
+++ b/tests/default/asynchronous_search/stats.yaml
@@ -1,0 +1,11 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test asynchronous_search.
+
+chapters:
+  - synopsis: Get stats.
+    path: /_plugins/_asynchronous_search/stats
+    method: GET
+    version: < 3.0
+    response:
+      status: 200

--- a/tests/default/indices/component_template.yaml
+++ b/tests/default/indices/component_template.yaml
@@ -1,6 +1,8 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test component templates.
+warnings:
+  multiple-paths-detected: false
 epilogues:
   - path: /logs-2020-01-01
     method: DELETE
@@ -51,8 +53,6 @@ chapters:
     response:
       status: 200
   - synopsis: Create an index template composed of 2 component templates.
-    warnings:
-      multiple-paths-detected: false
     path: /_index_template/{name}
     method: POST
     parameters:
@@ -84,8 +84,6 @@ chapters:
     response:
       status: 200
   - synopsis: Create an index using the composite template.
-    warnings:
-      multiple-paths-detected: false
     path: /{index}
     method: PUT
     parameters:
@@ -93,8 +91,6 @@ chapters:
     response:
       status: 200
   - synopsis: Get an index using the composite template.
-    warnings:
-      multiple-paths-detected: false
     path: /{index}
     method: GET
     parameters:
@@ -102,8 +98,6 @@ chapters:
     response:
       status: 200
   - synopsis: Delete index template.
-    warnings:
-      multiple-paths-detected: false
     path: /_index_template/{name}
     method: DELETE
     parameters:

--- a/tests/plugins/ml/docker-compose.yml
+++ b/tests/plugins/ml/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  opensearch-cluster:
+    image: ${OPENSEARCH_DOCKER_HUB_PROJECT:-opensearchproject}/opensearch:${OPENSEARCH_VERSION:-latest}${OPENSEARCH_DOCKER_REF}
+    ports:
+      - 9200:9200
+      - 9600:9600
+    environment:
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_PASSWORD:-myStrongPassword123!}
+      - OPENSEARCH_JAVA_OPTS=${OPENSEARCH_JAVA_OPTS}
+      - discovery.type=single-node
+      - plugins.ml_commons.only_run_on_ml_node=false

--- a/tests/plugins/ml/ingest/pipeline/neural_search.yaml
+++ b/tests/plugins/ml/ingest/pipeline/neural_search.yaml
@@ -1,4 +1,4 @@
-$schema: ../../../../json_schemas/test_story.schema.yaml
+$schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test the creation a neural search ingest pipeline.
 distributions:
@@ -8,15 +8,6 @@ distributions:
     - amazon-serverless
 warnings:
   multiple-paths-detected: false
-prologues:
-  - path: /_cluster/settings
-    method: PUT
-    request:
-      payload:
-        persistent:
-          plugins:
-            ml_commons:
-              only_run_on_ml_node: false
 epilogues:
   - path: /_ingest/pipeline/movies_pipeline
     method: DELETE

--- a/tests/plugins/ml/ml/model_groups.yaml
+++ b/tests/plugins/ml/ml/model_groups.yaml
@@ -1,4 +1,4 @@
-$schema: ../../../json_schemas/test_story.schema.yaml
+$schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test the creation of model groups.
 distributions:
@@ -6,15 +6,6 @@ distributions:
     - amazon-managed
     - amazon-serverless
 version: '>= 2.11'
-prologues:
-  - path: /_cluster/settings
-    method: PUT
-    request:
-      payload:
-        persistent:
-          plugins:
-            ml_commons:
-              only_run_on_ml_node: false
 epilogues:
   - path: /_plugins/_ml/model_groups/{model_group_id}
     method: DELETE

--- a/tests/plugins/ml/ml/models.yaml
+++ b/tests/plugins/ml/ml/models.yaml
@@ -1,4 +1,4 @@
-$schema: ../../../json_schemas/test_story.schema.yaml
+$schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test the creation of models.
 distributions:
@@ -6,15 +6,8 @@ distributions:
     - amazon-managed
     - amazon-serverless
 version: '>= 2.11'
-prologues:
-  - path: /_cluster/settings
-    method: PUT
-    request:
-      payload:
-        persistent:
-          plugins:
-            ml_commons:
-              only_run_on_ml_node: false
+warnings:
+  multiple-paths-detected: false
 chapters:
   - synopsis: Register model.
     id: register_model
@@ -33,8 +26,6 @@ chapters:
     id: get_completed_task
     path: /_plugins/_ml/tasks/{task_id}
     method: GET
-    warnings:
-      multiple-paths-detected: false
     parameters:
       task_id: ${register_model.task_id}
     response:

--- a/tools/tests/tester/fixtures/stories/passed.yaml
+++ b/tools/tests/tester/fixtures/stories/passed.yaml
@@ -1,6 +1,8 @@
 $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: This story should pass.
+warnings:
+  multiple-paths-detected: false
 epilogues:
   - path: /books
     method: DELETE
@@ -9,23 +11,17 @@ chapters:
   - synopsis: This PUT /{index} chapter should pass.
     path: /{index}
     method: PUT
-    warnings:
-      multiple-paths-detected: false
     parameters:
       index: books
   - synopsis: This GET /_cat chapter returns text/plain and should pass.
     path: /_cat
     method: GET
-    warnings:
-      multiple-paths-detected: false
     response:
       status: 200
       content_type: text/plain
   - synopsis: This GET /_cat chapter with a header should pass.
     path: /_cat
     method: GET
-    warnings:
-      multiple-paths-detected: false
     request:
       headers:
         User-Agent: OpenSearch API Spec/1.0


### PR DESCRIPTION
### Description

- ML tests set `plugins.ml_commons.only_run_on_ml_node=false`, take quite a bit of time, and trigger memory circuit breakers causing flakes. Extracted into a separate run.
- Organized some warnings.
- Moved asynchronous_search/stats into its own file to match recommended layout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
