### PR TITLE
Corrected /_cluster/health and /_cluster/stats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added 404 responses to `/_alias/{name}` and `/{index}/_alias/{name}` ([#519](https://github.com/opensearch-project/opensearch-api-specification/pull/519))
 - Added `asynchronous_search` ([#525](https://github.com/opensearch-project/opensearch-api-specification/pull/525))
 - Added `DELETE /_plugins/_ml/tasks/{task_id}` ([#530](https://github.com/opensearch-project/opensearch-api-specification/pull/530))
+- Added `AwarenessAttributeStats` to `/_cluster/health` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `asynchronous_search` ([#525](https://github.com/opensearch-project/opensearch-api-specification/pull/525))
 - Added `DELETE /_plugins/_ml/tasks/{task_id}` ([#530](https://github.com/opensearch-project/opensearch-api-specification/pull/530))
 - Added `AwarenessAttributeStats` to `/_cluster/health` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
+- Added `cache_reserved_in_bytes` to `ClusterFileSystem` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
+- Added `cluster_manager` to `ClusterNodeCount` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
 
 ### Changed
 

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -3990,7 +3990,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     delete_script::query.timeout:
       in: query
@@ -4452,7 +4452,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     get_source::path.id:
       in: path
@@ -4968,7 +4968,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     put_script::query.timeout:
       in: query

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -1213,7 +1213,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.allocation::query.s:
@@ -1282,7 +1282,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.cluster_manager::query.s:
@@ -1574,7 +1574,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.indices::query.pri:
@@ -1658,7 +1658,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.master::query.s:
@@ -1727,7 +1727,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.nodeattrs::query.s:
@@ -1816,7 +1816,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.nodes::query.s:
@@ -1891,7 +1891,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.pending_tasks::query.s:
@@ -2017,7 +2017,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.plugins::query.s:
@@ -2181,7 +2181,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.repositories::query.s:
@@ -2406,7 +2406,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.segments::query.s:
@@ -2493,7 +2493,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.shards::query.s:
@@ -2580,7 +2580,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.snapshots::query.s:
@@ -2751,7 +2751,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.templates::query.s:
@@ -2830,7 +2830,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     cat.thread_pool::query.s:

--- a/spec/namespaces/cluster.yaml
+++ b/spec/namespaces/cluster.yaml
@@ -774,7 +774,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.delete_component_template::query.timeout:
       in: query
@@ -837,7 +837,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.get_component_template::path.name:
       in: path
@@ -876,7 +876,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.get_decommission_awareness::path.awareness_attribute_name:
       name: awareness_attribute_name
@@ -919,7 +919,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.get_settings::query.timeout:
       in: query
@@ -990,7 +990,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.health::query.timeout:
       in: query
@@ -1070,7 +1070,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.post_voting_config_exclusions::query.node_ids:
       in: query
@@ -1139,7 +1139,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.put_component_template::query.timeout:
       name: timeout
@@ -1186,7 +1186,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.put_settings::query.timeout:
       in: query
@@ -1232,7 +1232,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.reroute::query.metric:
       in: query
@@ -1325,7 +1325,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     cluster.state::query.wait_for_metadata_version:
       in: query

--- a/spec/namespaces/dangling_indices.yaml
+++ b/spec/namespaces/dangling_indices.yaml
@@ -110,7 +110,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     dangling_indices.delete_dangling_index::query.timeout:
       in: query
@@ -150,7 +150,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     dangling_indices.import_dangling_index::query.timeout:
       in: query

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -2807,7 +2807,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.add_block::query.timeout:
       in: query
@@ -2955,7 +2955,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.clone::query.task_execution_timeout:
       name: task_execution_timeout
@@ -3042,7 +3042,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.close::query.timeout:
       in: query
@@ -3087,7 +3087,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.create::query.timeout:
       in: query
@@ -3190,7 +3190,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.delete::query.timeout:
       in: query
@@ -3238,7 +3238,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.delete_alias::query.timeout:
       in: query
@@ -3280,7 +3280,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.delete_index_template::query.timeout:
       in: query
@@ -3316,7 +3316,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.delete_template::query.timeout:
       in: query
@@ -3487,7 +3487,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.exists_template::path.name:
       in: path
@@ -3528,7 +3528,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.flush::path.index:
       in: path
@@ -3735,7 +3735,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.get_alias::path.index:
       in: path
@@ -3904,7 +3904,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.get_mapping::path.index:
       in: path
@@ -3979,7 +3979,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.get_settings::path.index:
       in: path
@@ -4073,7 +4073,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.get_template::path.name:
       in: path
@@ -4119,7 +4119,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.get_upgrade::path.index:
       name: index
@@ -4208,7 +4208,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.open::query.task_execution_timeout:
       name: task_execution_timeout
@@ -4282,7 +4282,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.put_alias::query.timeout:
       in: query
@@ -4330,7 +4330,7 @@ components:
       description: Operation timeout for connection to master node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
       deprecated: true
     indices.put_mapping::path.index:
@@ -4385,7 +4385,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.put_mapping::query.timeout:
       in: query
@@ -4471,7 +4471,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.put_settings::query.preserve_existing:
       in: query
@@ -4523,7 +4523,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.put_template::query.order:
       in: query
@@ -4667,7 +4667,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.rollover::query.timeout:
       in: query
@@ -4819,7 +4819,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.shrink::query.task_execution_timeout:
       name: task_execution_timeout
@@ -4900,7 +4900,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.simulate_template::path.name:
       in: path
@@ -4943,7 +4943,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.split::path.index:
       in: path
@@ -4986,7 +4986,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.split::query.task_execution_timeout:
       name: task_execution_timeout
@@ -5127,7 +5127,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     indices.update_aliases::query.timeout:
       in: query

--- a/spec/namespaces/ingest.yaml
+++ b/spec/namespaces/ingest.yaml
@@ -249,7 +249,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     ingest.delete_pipeline::query.timeout:
       in: query
@@ -288,7 +288,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     ingest.put_pipeline::path.id:
       in: path
@@ -313,7 +313,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     ingest.put_pipeline::query.timeout:
       in: query

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -490,7 +490,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.cleanup_repository::query.timeout:
       in: query
@@ -538,7 +538,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.create::path.repository:
       in: path
@@ -571,7 +571,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.create::query.wait_for_completion:
       in: query
@@ -604,7 +604,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.create_repository::query.timeout:
       in: query
@@ -651,7 +651,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.delete_repository::path.repository:
       in: path
@@ -676,7 +676,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.delete_repository::query.timeout:
       in: query
@@ -727,7 +727,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.get::query.verbose:
       in: query
@@ -767,7 +767,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.restore::path.repository:
       in: path
@@ -800,7 +800,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.restore::query.wait_for_completion:
       in: query
@@ -849,7 +849,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.verify_repository::path.repository:
       in: path
@@ -874,7 +874,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
-      x-version-deprecated: 2.0.0
+      x-version-deprecated: '2.0'
       x-deprecation-message: To promote inclusive language, use 'cluster_manager_timeout' instead.
     snapshot.verify_repository::query.timeout:
       in: query

--- a/spec/schemas/cat.nodes.yaml
+++ b/spec/schemas/cat.nodes.yaml
@@ -104,7 +104,7 @@ components:
             Indicates whether the node is the elected master node.
             Returned values include `*`(elected master) and `-`(not elected master).
           type: string
-          x-version-deprecated: 2.0.0
+          x-version-deprecated: '2.0'
           x-deprecation-message: To promote inclusive language, use 'cluster_manager' instead.
         name:
           $ref: '_common.yaml#/components/schemas/Name'

--- a/spec/schemas/cluster.health.yaml
+++ b/spec/schemas/cluster.health.yaml
@@ -17,11 +17,25 @@ components:
           type: number
         active_shards_percent_as_number:
           $ref: '_common.yaml#/components/schemas/Percentage'
+        awareness_attributes:
+          description: Cluster health information for each awareness attribute.
+          type: object
+          x-version-added: '2.5'
+          additionalProperties:
+            $ref: '#/components/schemas/AwarenessAttributeStats'
         cluster_name:
           $ref: '_common.yaml#/components/schemas/Name'
         delayed_unassigned_shards:
           description: The number of shards whose allocation has been delayed by the timeout settings.
           type: number
+        discovered_master:
+          description: True if the master node has been discovered.
+          type: boolean
+          x-version-deprecated: 2
+        discovered_cluster_manager:
+          description: True if the cluster manager node has been discovered.
+          type: boolean
+          x-version-added: 2
         indices:
           type: object
           additionalProperties:
@@ -51,7 +65,7 @@ components:
         task_max_waiting_in_queue_millis:
           $ref: '_common.yaml#/components/schemas/DurationValueUnitMillis'
         timed_out:
-          description: If false the response returned within the period of time that is specified by the timeout parameter (30s by default)
+          description: If false the response returned within the period of time that is specified by the timeout parameter (30s by default).
           type: boolean
         unassigned_shards:
           description: The number of shards that are not allocated.
@@ -111,6 +125,22 @@ components:
         - cluster
         - indices
         - shards
+    AwarenessAttributeStats:
+      type: object
+      x-version-added: '2.5'
+      properties:
+        active_shards:
+          type: number
+        initializing_shards:
+          type: number
+        relocating_shards:
+          type: number
+        unassigned_shards:
+          type: number
+        data_nodes:
+          type: number
+        weight:
+          type: number
     ShardHealthStats:
       type: object
       properties:

--- a/spec/schemas/cluster.health.yaml
+++ b/spec/schemas/cluster.health.yaml
@@ -31,11 +31,11 @@ components:
         discovered_master:
           description: True if the master node has been discovered.
           type: boolean
-          x-version-deprecated: 2
+          x-version-deprecated: '2.0'
         discovered_cluster_manager:
           description: True if the cluster manager node has been discovered.
           type: boolean
-          x-version-added: 2
+          x-version-added: '2.0'
         indices:
           type: object
           additionalProperties:

--- a/spec/schemas/cluster.stats.yaml
+++ b/spec/schemas/cluster.stats.yaml
@@ -341,7 +341,6 @@ components:
         - count
         - discovery_types
         - fs
-        - indexing_pressure
         - ingest
         - jvm
         - network_types
@@ -371,10 +370,16 @@ components:
           type: number
         master:
           type: number
+        cluster_manager:
+          type: number
+          x-version-added: '2.0'
         ml:
           type: number
         remote_cluster_client:
           type: number
+        search:
+          type: number
+          x-version-added: '2.4'
         total:
           type: number
         transform:
@@ -384,17 +389,10 @@ components:
       required:
         - coordinating_only
         - data
-        - data_cold
-        - data_content
-        - data_hot
-        - data_warm
         - ingest
         - master
-        - ml
         - remote_cluster_client
         - total
-        - transform
-        - voting_only
     ClusterFileSystem:
       type: object
       properties:
@@ -410,6 +408,10 @@ components:
         total_in_bytes:
           description: Total size, in bytes, of all file stores across all selected nodes.
           type: number
+        cache_reserved_in_bytes:
+          description: Total size, in bytes, of all cache reserved across all selected nodes.
+          type: number
+          x-version-added: '2.7'
       required:
         - available_in_bytes
         - free_in_bytes
@@ -677,7 +679,6 @@ components:
           type: string
       required:
         - count
-        - flavor
         - type
     ClusterProcess:
       type: object

--- a/tests/default/cluster/health.yaml
+++ b/tests/default/cluster/health.yaml
@@ -1,0 +1,28 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test cluster health.
+chapters:
+  - synopsis: Returns a simple status of the health of the cluster.
+    path: /_cluster/health
+    method: GET
+    parameters:
+      expand_wildcards: all
+      level: cluster
+      local: false
+      timeout: 10s
+      wait_for_active_shards: 0
+      wait_for_nodes: <2
+      wait_for_events: normal
+      wait_for_no_relocating_shards: false
+      wait_for_no_initializing_shards: false
+    response:
+      status: 200
+  - synopsis: Returns a status of the health of the cluster with awareness.
+    version: '>= 2.5'
+    path: /_cluster/health
+    method: GET
+    parameters:
+      level: awareness_attributes
+      awareness_attribute: zone
+    response:
+      status: 200

--- a/tests/default/cluster/health/index.yaml
+++ b/tests/default/cluster/health/index.yaml
@@ -1,0 +1,29 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test cluster health for an index.
+prologues:
+  - path: /{index}
+    method: PUT
+    parameters:
+      index: books
+epilogues:
+  - path: /books
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Returns a status of the health of the cluster for a given index.
+    path: /_cluster/health/{index}
+    method: GET
+    parameters:
+      index: books
+      expand_wildcards: all
+      level: cluster
+      local: false
+      timeout: 10s
+      wait_for_active_shards: 0
+      wait_for_nodes: <2
+      wait_for_events: normal
+      wait_for_no_relocating_shards: false
+      wait_for_no_initializing_shards: false
+    response:
+      status: 200

--- a/tests/default/cluster/stats.yaml
+++ b/tests/default/cluster/stats.yaml
@@ -1,0 +1,9 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test cluster stats.
+chapters:
+  - synopsis: Returns statistics about a cluster.
+    path: /_cluster/stats
+    method: GET
+    response:
+      status: 200

--- a/tests/default/cluster/stats/nodes.yaml
+++ b/tests/default/cluster/stats/nodes.yaml
@@ -1,0 +1,12 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test cluster manager stats.
+version: '>= 2.0'
+chapters:
+  - synopsis: Returns information about the cluster manager node.
+    path: /_cluster/stats/nodes/{node_id}
+    method: GET
+    parameters:
+      node_id: _cluster_manager
+    response:
+      status: 200


### PR DESCRIPTION
### Description

- Added `AwarenessAttributeStats` to `/_cluster/health`. We don't setup cluster awareness so the test doesn't actually return any zone data, but it's a start.
- Added `cache_reserved_in_bytes` to `ClusterFileSystem` and `cluster_manager` to `ClusterNodeCount`, with cluster stats tests.
- Spelled out 2.0 consistently in `x-version-deprecated`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
