### PR TITLE
Fix: correctly combine test coverage.

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -108,13 +108,14 @@ jobs:
         shell: bash -eo pipefail {0}
         run: |
           jq -sc '
-            map(to_entries) |
-            flatten |
-            group_by(.key) |
-            map({key: .[0].key, value: map(.value) | max}) |
-            from_entries |
-            .' $(find ./coverage -name "test-spec-coverage-*.json") > ./coverage/coverage.json
-
+            (map(.operations) | add | unique | length) as $total_operations_count |
+            (map(.evaluated_operations) | add | unique | length) as $evaluated_operations_count |
+            { 
+              total_operations_count: $total_operations_count,
+              evaluated_operations_count: $evaluated_operations_count,
+              evaluated_paths_pct: $evaluated_operations_count | (10000 * . / $total_operations_count | round / 100)
+            }
+          ' $(find ./coverage -name "test-spec-coverage-*.json") > ./coverage/coverage.json
           cat ./coverage/coverage.json
 
       - name: Construct Comment Data Payload

--- a/tools/src/tester/TestResults.ts
+++ b/tools/src/tester/TestResults.ts
@@ -7,7 +7,7 @@
 * compatible open source license.
 */
 
-import _ from "lodash";
+import _, { isEqual } from "lodash";
 import MergedOpenApiSpec from "./MergedOpenApiSpec";
 import { Operation, StoryEvaluations } from "./types/eval.types";
 import { SpecTestCoverage } from "./types/test.types";
@@ -27,9 +27,9 @@ export default class TestResults {
 
   evaluated_operations(): Operation[] {
     if (this._evaluated_operations !== undefined) return this._evaluated_operations
-    this._evaluated_operations = _.uniq(_.compact(_.flatMap(this._evaluations.evaluations, (evaluation) =>
+    this._evaluated_operations = _.uniqWith(_.compact(_.flatMap(this._evaluations.evaluations, (evaluation) =>
       _.map(evaluation.chapters, (chapter) => chapter.operation)
-    )))
+    )), isEqual)
     return this._evaluated_operations
   }
 
@@ -47,22 +47,26 @@ export default class TestResults {
 
   operations(): Operation[] {
     if (this._operations !== undefined) return this._operations
-    this._operations = _.uniq(Object.entries(this._spec.paths()).flatMap(([path, path_item]) => {
+    this._operations = _.uniqWith(Object.entries(this._spec.paths()).flatMap(([path, path_item]) => {
       return Object.values(path_item).map((method) => {
         return { method: method.toUpperCase(), path }
       })
-    }))
+    }), isEqual)
 
     return this._operations
   }
 
   test_coverage(): SpecTestCoverage {
     return {
-      evaluated_operations_count: this.evaluated_operations().length,
-      total_operations_count: this.operations().length,
-      evaluated_paths_pct: this.operations().length > 0 ? Math.round(
-        this.evaluated_operations().length / this.operations().length * 100 * 100
-      ) / 100 : 0,
+      summary: {
+        evaluated_operations_count: this.evaluated_operations().length,
+        total_operations_count: this.operations().length,
+        evaluated_paths_pct: this.operations().length > 0 ? Math.round(
+          this.evaluated_operations().length / this.operations().length * 100 * 100
+        ) / 100 : 0
+      },
+      operations: this.operations(),
+      evaluated_operations: this.evaluated_operations()
     }
   }
 

--- a/tools/src/tester/types/test.types.ts
+++ b/tools/src/tester/types/test.types.ts
@@ -7,8 +7,14 @@
 * compatible open source license.
 */
 
+import { Operation } from "./eval.types"
+
 export interface SpecTestCoverage {
-  total_operations_count: number
-  evaluated_operations_count: number,
-  evaluated_paths_pct: number
+  summary: {
+    total_operations_count: number
+    evaluated_operations_count: number,
+    evaluated_paths_pct: number
+  },
+  operations: Operation[],
+  evaluated_operations: Operation[]
 }

--- a/tools/tests/tester/TestResults.test.ts
+++ b/tools/tests/tester/TestResults.test.ts
@@ -70,9 +70,22 @@ describe('TestResults', () => {
     const filename = 'coverage.json'
     test_results.write_coverage(filename)
     expect(JSON.parse(fs.readFileSync(filename, 'utf8'))).toEqual({
-      evaluated_operations_count: 1,
-      evaluated_paths_pct: 16.67,
-      total_operations_count: 6
+      summary: {
+        evaluated_operations_count: 1,
+        evaluated_paths_pct: 16.67,
+        total_operations_count: 6
+      },
+      evaluated_operations: [
+        { method: 'PUT', path: '/{index}' },
+      ],
+      operations: [
+        { method: 'GET', path: '/_nodes/{id}' },
+        { method: 'POST', path: '/_nodes/{id}' },
+        { method: 'GET', path: '/cluster_manager' },
+        { method: 'POST', path: '/cluster_manager' },
+        { method: 'GET', path: '/index' },
+        { method: 'GET', path: '/nodes' }
+      ]
     })
     fs.unlinkSync(filename)
   })


### PR DESCRIPTION
### Description

Test coverage was being combined naively and incorrectly.

I had sneaked in a minimal implementation in https://github.com/opensearch-project/opensearch-api-specification/pull/513 where a bunch of tests would run in parallel, then the `jq` code that combined results would just pick the max number of tests run, which would account for the default test suite, but not for the other test suites.

This is now replaced with producing a JSON that contains an actually unique set of all operations and a unique set of evaluated operations, then merge all these results, then sum up the numbers and calculate the overall percentage.

The bad news is that we were including dups in the counts, so we're not at 66% but 43.29%.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
