### PR TITLE
Fixed content-type for /hot_threads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed required parameters in `NodeInfo` and `NodeOperatingSystemInfo` ([#483](https://github.com/opensearch-project/opensearch-api-specification/pull/483))
 - Fixed query DSL `neural` field `query_image` set `contentEncoding` and `model_id` as optional ([#512](https://github.com/opensearch-project/opensearch-api-specification/pull/512))
 - Fixed `knn` query specification ([#538](https://github.com/opensearch-project/opensearch-api-specification/pull/538))
+- Fixed content-type for `/hot_threads` ([#543](https://github.com/opensearch-project/opensearch-api-specification/pull/543))
 
 ### Security
 

--- a/spec/_superseded_operations.yaml
+++ b/spec/_superseded_operations.yaml
@@ -594,3 +594,19 @@ $schema: ./json_schemas/_superseded_operations.schema.yaml
   operations:
     - GET
     - POST
+/_cluster/nodes/hotthreads:
+  superseded_by: /_cluster/nodes/hot_threads
+  operations:
+    - GET
+/_cluster/nodes/{node_id}/hotthreads:
+  superseded_by: /_cluster/nodes/{node_id}/hot_threads
+  operations:
+    - GET
+/_nodes/{node_id}/hotthreads:
+  superseded_by: /_nodes/{node_id}/hot_threads
+  operations:
+    - GET
+/_nodes/hotthreads:
+  superseded_by: /_nodes/hot_threads
+  operations:
+    - GET

--- a/spec/namespaces/nodes.yaml
+++ b/spec/namespaces/nodes.yaml
@@ -26,28 +26,6 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/nodes.hot_threads@200'
-  /_cluster/nodes/hotthreads:
-    get:
-      operationId: nodes.hot_threads.1
-      x-operation-group: nodes.hot_threads
-      x-ignorable: true
-      deprecated: true
-      x-deprecation-message: The hot threads API accepts `hotthreads` but only `hot_threads` is documented
-      x-version-added: '1.0'
-      x-version-deprecated: '1.0'
-      description: Returns information about hot threads on each node in the cluster.
-      externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/
-      parameters:
-        - $ref: '#/components/parameters/nodes.hot_threads::query.ignore_idle_threads'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.interval'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.snapshots'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.threads'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.timeout'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.type'
-      responses:
-        '200':
-          $ref: '#/components/responses/nodes.hot_threads@200'
   /_cluster/nodes/{node_id}/hot_threads:
     get:
       operationId: nodes.hot_threads.2
@@ -55,29 +33,6 @@ paths:
       x-ignorable: true
       deprecated: true
       x-deprecation-message: The hot accepts /_cluster/nodes as prefix for backwards compatibility reasons
-      x-version-added: '1.0'
-      x-version-deprecated: '1.0'
-      description: Returns information about hot threads on each node in the cluster.
-      externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/
-      parameters:
-        - $ref: '#/components/parameters/nodes.hot_threads::path.node_id'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.ignore_idle_threads'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.interval'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.snapshots'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.threads'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.timeout'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.type'
-      responses:
-        '200':
-          $ref: '#/components/responses/nodes.hot_threads@200'
-  /_cluster/nodes/{node_id}/hotthreads:
-    get:
-      operationId: nodes.hot_threads.3
-      x-operation-group: nodes.hot_threads
-      x-ignorable: true
-      deprecated: true
-      x-deprecation-message: The hot threads API accepts `hotthreads` but only `hot_threads` is documented
       x-version-added: '1.0'
       x-version-deprecated: '1.0'
       description: Returns information about hot threads on each node in the cluster.
@@ -113,28 +68,6 @@ paths:
       operationId: nodes.hot_threads.4
       x-operation-group: nodes.hot_threads
       x-version-added: '1.0'
-      description: Returns information about hot threads on each node in the cluster.
-      externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/
-      parameters:
-        - $ref: '#/components/parameters/nodes.hot_threads::query.ignore_idle_threads'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.interval'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.snapshots'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.threads'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.timeout'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.type'
-      responses:
-        '200':
-          $ref: '#/components/responses/nodes.hot_threads@200'
-  /_nodes/hotthreads:
-    get:
-      operationId: nodes.hot_threads.5
-      x-operation-group: nodes.hot_threads
-      x-ignorable: true
-      deprecated: true
-      x-deprecation-message: The hot threads API accepts `hotthreads` but only `hot_threads` is documented
-      x-version-added: '1.0'
-      x-version-deprecated: '1.0'
       description: Returns information about hot threads on each node in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/
@@ -273,29 +206,6 @@ paths:
       operationId: nodes.hot_threads.6
       x-operation-group: nodes.hot_threads
       x-version-added: '1.0'
-      description: Returns information about hot threads on each node in the cluster.
-      externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/
-      parameters:
-        - $ref: '#/components/parameters/nodes.hot_threads::path.node_id'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.ignore_idle_threads'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.interval'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.snapshots'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.threads'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.timeout'
-        - $ref: '#/components/parameters/nodes.hot_threads::query.type'
-      responses:
-        '200':
-          $ref: '#/components/responses/nodes.hot_threads@200'
-  /_nodes/{node_id}/hotthreads:
-    get:
-      operationId: nodes.hot_threads.7
-      x-operation-group: nodes.hot_threads
-      x-ignorable: true
-      deprecated: true
-      x-deprecation-message: The hot threads API accepts `hotthreads` but only `hot_threads` is documented
-      x-version-added: '1.0'
-      x-version-deprecated: '1.0'
       description: Returns information about hot threads on each node in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/
@@ -449,7 +359,9 @@ components:
                 $ref: '../schemas/_common.yaml#/components/schemas/Password'
             description: An object containing the password for the opensearch keystore
   responses:
-    nodes.hot_threads@200: {}
+    nodes.hot_threads@200:
+      content:
+        text/plain: {}
     nodes.info@200:
       content:
         application/json:

--- a/tests/default/cluster/nodes/hot_threads.yaml
+++ b/tests/default/cluster/nodes/hot_threads.yaml
@@ -1,0 +1,32 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Provides information about busy JVM threads for selected cluster nodes.
+chapters:
+  - synopsis: Get busy JVM threads for all nodes.
+    path: /_cluster/nodes/hot_threads
+    method: GET
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Get busy JVM threads for all nodes with parameters.
+    path: /_cluster/nodes/hot_threads
+    method: GET
+    parameters:
+      snapshots: 3
+      interval: 100ms
+      threads: 1
+      ignore_idle_threads: false
+      type: wait
+      timeout: 10s
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Get _all node busy JVM threads (node_id).
+    path: /_cluster/nodes/{node_id}/hot_threads
+    method: GET
+    parameters:
+      node_id:
+        - _all
+    response:
+      status: 200
+      content_type: text/plain

--- a/tests/default/nodes/hot_threads.yaml
+++ b/tests/default/nodes/hot_threads.yaml
@@ -1,0 +1,32 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Provides information about busy JVM threads for selected cluster nodes.
+chapters:
+  - synopsis: Get busy JVM threads for all nodes.
+    path: /_nodes/hot_threads
+    method: GET
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Get busy JVM threads for all nodes with parameters.
+    path: /_nodes/hot_threads
+    method: GET
+    parameters:
+      snapshots: 3
+      interval: 100ms
+      threads: 1
+      ignore_idle_threads: false
+      type: wait
+      timeout: 10s
+    response:
+      status: 200
+      content_type: text/plain
+  - synopsis: Get _all node busy JVM threads (node_id).
+    path: /_nodes/{node_id}/hot_threads
+    method: GET
+    parameters:
+      node_id:
+        - _all
+    response:
+      status: 200
+      content_type: text/plain


### PR DESCRIPTION
### Description

Fixed content-type for /hot_threads. Added tests.
Moved `hotthreads` to superseded operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
