### PR TITLE
Fix: cluster settings can be flat.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed query DSL `neural` field `query_image` set `contentEncoding` and `model_id` as optional ([#512](https://github.com/opensearch-project/opensearch-api-specification/pull/512))
 - Fixed `knn` query specification ([#538](https://github.com/opensearch-project/opensearch-api-specification/pull/538))
 - Fixed content-type for `/hot_threads` ([#543](https://github.com/opensearch-project/opensearch-api-specification/pull/543))
+- Fixed `/_cluster/settings` returning flat results ([#545](https://github.com/opensearch-project/opensearch-api-specification/pull/545))
 
 ### Security
 

--- a/spec/namespaces/cluster.yaml
+++ b/spec/namespaces/cluster.yaml
@@ -634,16 +634,13 @@ components:
             properties:
               persistent:
                 type: object
-                additionalProperties:
-                  type: object
+                additionalProperties: true
               transient:
                 type: object
-                additionalProperties:
-                  type: object
+                additionalProperties: true
               defaults:
                 type: object
-                additionalProperties:
-                  type: object
+                additionalProperties: true
             required:
               - persistent
               - transient

--- a/tests/default/cluster/settings.yaml
+++ b/tests/default/cluster/settings.yaml
@@ -1,0 +1,44 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test cluster settings.
+chapters:
+  - synopsis: Returns cluster settings.
+    path: /_cluster/settings
+    method: GET
+    parameters:
+      flat_settings: false
+    response:
+      status: 200
+  - synopsis: Returns cluster settings with defaults.
+    path: /_cluster/settings
+    method: GET
+    parameters:
+      include_defaults: true
+    response:
+      status: 200
+  - synopsis: Returns cluster flat settings.
+    path: /_cluster/settings
+    method: GET
+    parameters:
+      flat_settings: true
+    response:
+      status: 200
+  - synopsis: Sets cluster settings.
+    path: /_cluster/settings
+    method: PUT
+    request:
+      payload:
+        transient:
+          cluster:
+            max_shards_per_node: 500
+    response:
+      status: 200
+  - synopsis: Sets cluster flat settings.
+    path: /_cluster/settings
+    method: PUT
+    request:
+      payload:
+        transient:
+          cluster.max_shards_per_node: 500
+    response:
+      status: 200


### PR DESCRIPTION
### Description

Cluster settings don't always return nested objects, they can be flat key/value pairs.

Here's the default output with `include_defaults` on the test cluster, note `processors`.

```json
    "logger": {
      "level": "INFO"
    },
    "processors": "10",
    "ingest": {
      "geoip": {
        "cache_size": "1000"
      },
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
