### PR TITLE
Update `TermsQuery` and TermsSetQuery and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `AwarenessAttributeStats` to `/_cluster/health` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
 - Added `cache_reserved_in_bytes` to `ClusterFileSystem` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
 - Added `cluster_manager` to `ClusterNodeCount` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
+- Added support for `query` with `terms` in `_search` ([#546](https://github.com/opensearch-project/opensearch-api-specification/pull/546)).
 
 ### Changed
 

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -280,6 +280,23 @@ components:
           type: number
         _name:
           type: string
+    Terms:
+      oneOf:
+        - type: array
+          items:
+            type: string
+        - type: object
+          properties:
+            index:
+              $ref: '_common.yaml#/components/schemas/IndexName'
+            id:
+              $ref: '_common.yaml#/components/schemas/Id'
+            path:
+              $ref: '_common.yaml#/components/schemas/Field'
+            routing:
+              $ref: '_common.yaml#/components/schemas/Routing'
+          additionalProperties: true
+          description: Object for fetching terms.
     BoostingQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
@@ -1857,9 +1874,9 @@ components:
           required:
             - value
     TermsQuery:
-      allOf:
+      anyOf:
         - $ref: '#/components/schemas/QueryBase'
-        - type: object
+        - $ref: '#/components/schemas/Terms'
     TermsSetQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
@@ -1870,10 +1887,7 @@ components:
             minimum_should_match_script:
               $ref: '_common.yaml#/components/schemas/Script'
             terms:
-              description: Array of terms you wish to find in the provided field.
-              type: array
-              items:
-                type: string
+              $ref: '#/components/schemas/Terms'
           required:
             - terms
     TextExpansionQuery:

--- a/tests/default/_core/search/query/terms.yaml
+++ b/tests/default/_core/search/query/terms.yaml
@@ -1,0 +1,146 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Comprehensive test suite for TermsQuery, including array of terms and term lookup.
+version: '>= 1.2'
+
+prologues:
+  - path: /movies
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            title:
+              type: text
+            genre:
+              type: keyword
+            director_id:
+              type: keyword
+    status: [200]
+
+  - path: /movies/_doc
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      payload:
+        title: The Lion King
+        genre: animation
+    status: [201]
+
+  - path: /movies/_doc
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      payload:
+        title: Beauty and the Beast
+        genre: adventure
+    status: [201]
+
+  - path: /games
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            title:
+              type: text
+            genre:
+              type: keyword
+            developer_id:
+              type: keyword
+    status: [200]
+
+  - path: /games/_doc
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      payload:
+        title: Monopoly
+        genre: RPG
+    status: [201]
+
+  - path: /games/_doc
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      payload:
+        title: Cyberpunk 2077
+        genre: RPG
+    status: [201]
+
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+
+  - path: /games
+    method: DELETE
+    status: [200, 404]
+
+chapters:
+  - synopsis: Search using TermsQuery with an array of terms.
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: GET
+    request:
+      payload:
+        query:
+          terms:
+            genre: 
+              - adventure
+              - animation
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 2
+            relation: eq
+          hits:
+            - _index: movies
+              _score: 1
+              _source:
+                title: The Lion King
+                genre: animation
+            - _index: movies
+              _score: 1
+              _source:
+                title: Beauty and the Beast
+                genre: adventure
+
+  - synopsis: Search using TermsQuery with an array of terms in the games index.
+    path: /{index}/_search
+    parameters:
+      index: games
+    method: GET
+    request:
+      payload:
+        query:
+          terms:
+            genre: 
+              - RPG
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 2
+            relation: eq
+          hits:
+            - _index: games
+              _score: 1
+              _source:
+                title: Monopoly
+                genre: RPG
+            - _index: games
+              _score: 1
+              _source:
+                title: Cyberpunk 2077
+                genre: RPG

--- a/tests/default/_core/search/query/terms_set.yaml
+++ b/tests/default/_core/search/query/terms_set.yaml
@@ -1,0 +1,66 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test TermsSetQuery functionality with complex example using movies.
+version: '>= 1.2'
+
+prologues:
+  - path: /movies
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            title:
+              type: keyword
+            genres:
+              type: keyword
+            min_required_genres:
+              type: integer
+
+  - path: /movies/_doc/1
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      payload:
+        title: The Lion King
+        genres: [Adventure, Animation, Family]
+        min_required_genres: 2
+    status: [201]
+
+  - path: /movies/_doc/2
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      payload:
+        title: Beauty and the Beast
+        genres: [Animation, Family, Musical]
+        min_required_genres: 2
+    status: [201]
+
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+
+chapters:
+  - synopsis: Search using TermsSetQuery with terms array and minimum_should_match_field.
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request:
+      payload:
+        query:
+          terms_set:
+            genres:
+              terms: [Adventure, Animation, Family]
+              minimum_should_match_field: min_required_genres
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 2


### PR DESCRIPTION
### Description

- Created schema for `Terms`.
- Updated `TermsQuery` and `TermsSetQuery` to use the `Terms` schema.
- Add unit tests for `TermsQuery` and `TermsSetQuery`.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-api-specification/issues/540

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
