### PR TITLE
Fix cat API tests and add missing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `AwarenessAttributeStats` to `/_cluster/health` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
 - Added `cache_reserved_in_bytes` to `ClusterFileSystem` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
 - Added `cluster_manager` to `ClusterNodeCount` ([#534](https://github.com/opensearch-project/opensearch-api-specification/pull/534))
-- Added support for `query` with `terms` in `_search` ([#546](https://github.com/opensearch-project/opensearch-api-specification/pull/546)).
+- Added support for `query` with `terms` in `_search` ([#546](https://github.com/opensearch-project/opensearch-api-specification/pull/546))
+- Added `h`, `bytes`, `time` parameters to cat API tests ([#551](https://github.com/opensearch-project/opensearch-api-specification/pull/551))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `knn` query specification ([#538](https://github.com/opensearch-project/opensearch-api-specification/pull/538))
 - Fixed content-type for `/hot_threads` ([#543](https://github.com/opensearch-project/opensearch-api-specification/pull/543))
 - Fixed `/_cluster/settings` returning flat results ([#545](https://github.com/opensearch-project/opensearch-api-specification/pull/545))
+- Fixed missing fields in cat API ([#551](https://github.com/opensearch-project/opensearch-api-specification/pull/551))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Replace nullable with null type ([#436](https://github.com/opensearch-project/opensearch-api-specification/pull/436))
 - Split test suite ([#472])(https://github.com/opensearch-project/opensearch-api-specification/pull/472)
 - Changed `WriteResponseBase`'s `_primary_term`, `_seq_no` & `_version` to have `int64` format ([#530](https://github.com/opensearch-project/opensearch-api-specification/pull/530))
+- Adjust indices, shards cat API to test against unassigned indices ([#551](https://github.com/opensearch-project/opensearch-api-specification/pull/551))
 
 ### Deprecated
 

--- a/spec/schemas/cat.indices.yaml
+++ b/spec/schemas/cat.indices.yaml
@@ -47,352 +47,380 @@ components:
           type: ['null', string]
         completion.size:
           description: size of completion
-          type: string
+          type: ['null', string]
         pri.completion.size:
           description: size of completion
-          type: string
+          type: ['null', string]
         fielddata.memory_size:
           description: used fielddata cache
-          type: string
+          type: ['null', string]
         pri.fielddata.memory_size:
           description: used fielddata cache
-          type: string
+          type: ['null', string]
         fielddata.evictions:
           description: fielddata evictions
-          type: string
+          type: ['null', string]
         pri.fielddata.evictions:
           description: fielddata evictions
-          type: string
+          type: ['null', string]
         query_cache.memory_size:
           description: used query cache
-          type: string
+          type: ['null', string]
         pri.query_cache.memory_size:
           description: used query cache
-          type: string
+          type: ['null', string]
         query_cache.evictions:
           description: query cache evictions
-          type: string
+          type: ['null', string]
         pri.query_cache.evictions:
           description: query cache evictions
-          type: string
+          type: ['null', string]
         request_cache.memory_size:
           description: used request cache
-          type: string
+          type: ['null', string]
         pri.request_cache.memory_size:
           description: used request cache
-          type: string
+          type: ['null', string]
         request_cache.evictions:
           description: request cache evictions
-          type: string
+          type: ['null', string]
         pri.request_cache.evictions:
           description: request cache evictions
-          type: string
+          type: ['null', string]
         request_cache.hit_count:
           description: request cache hit count
-          type: string
+          type: ['null', string]
         pri.request_cache.hit_count:
           description: request cache hit count
-          type: string
+          type: ['null', string]
         request_cache.miss_count:
           description: request cache miss count
-          type: string
+          type: ['null', string]
         pri.request_cache.miss_count:
           description: request cache miss count
-          type: string
+          type: ['null', string]
         flush.total:
           description: number of flushes
-          type: string
+          type: ['null', string]
         pri.flush.total:
           description: number of flushes
-          type: string
+          type: ['null', string]
         flush.total_time:
           description: time spent in flush
-          type: string
+          type: ['null', string]
         pri.flush.total_time:
           description: time spent in flush
-          type: string
+          type: ['null', string]
         get.current:
           description: number of current get ops
-          type: string
+          type: ['null', string]
         pri.get.current:
           description: number of current get ops
-          type: string
+          type: ['null', string]
         get.time:
           description: time spent in get
-          type: string
+          type: ['null', string]
         pri.get.time:
           description: time spent in get
-          type: string
+          type: ['null', string]
         get.total:
           description: number of get ops
-          type: string
+          type: ['null', string]
         pri.get.total:
           description: number of get ops
-          type: string
+          type: ['null', string]
         get.exists_time:
           description: time spent in successful gets
-          type: string
+          type: ['null', string]
         pri.get.exists_time:
           description: time spent in successful gets
-          type: string
+          type: ['null', string]
         get.exists_total:
           description: number of successful gets
-          type: string
+          type: ['null', string]
         pri.get.exists_total:
           description: number of successful gets
-          type: string
+          type: ['null', string]
         get.missing_time:
           description: time spent in failed gets
-          type: string
+          type: ['null', string]
         pri.get.missing_time:
           description: time spent in failed gets
-          type: string
+          type: ['null', string]
         get.missing_total:
           description: number of failed gets
-          type: string
+          type: ['null', string]
         pri.get.missing_total:
           description: number of failed gets
-          type: string
+          type: ['null', string]
         indexing.delete_current:
           description: number of current deletions
-          type: string
+          type: ['null', string]
         pri.indexing.delete_current:
           description: number of current deletions
-          type: string
+          type: ['null', string]
         indexing.delete_time:
           description: time spent in deletions
-          type: string
+          type: ['null', string]
         pri.indexing.delete_time:
           description: time spent in deletions
-          type: string
+          type: ['null', string]
         indexing.delete_total:
           description: number of delete ops
-          type: string
+          type: ['null', string]
         pri.indexing.delete_total:
           description: number of delete ops
-          type: string
+          type: ['null', string]
         indexing.index_current:
           description: number of current indexing ops
-          type: string
+          type: ['null', string]
         pri.indexing.index_current:
           description: number of current indexing ops
-          type: string
+          type: ['null', string]
         indexing.index_time:
           description: time spent in indexing
-          type: string
+          type: ['null', string]
         pri.indexing.index_time:
           description: time spent in indexing
-          type: string
+          type: ['null', string]
         indexing.index_total:
           description: number of indexing ops
-          type: string
+          type: ['null', string]
         pri.indexing.index_total:
           description: number of indexing ops
-          type: string
+          type: ['null', string]
         indexing.index_failed:
           description: number of failed indexing ops
-          type: string
+          type: ['null', string]
         pri.indexing.index_failed:
           description: number of failed indexing ops
-          type: string
+          type: ['null', string]
         merges.current:
           description: number of current merges
-          type: string
+          type: ['null', string]
         pri.merges.current:
           description: number of current merges
-          type: string
+          type: ['null', string]
         merges.current_docs:
           description: number of current merging docs
-          type: string
+          type: ['null', string]
         pri.merges.current_docs:
           description: number of current merging docs
-          type: string
+          type: ['null', string]
         merges.current_size:
           description: size of current merges
-          type: string
+          type: ['null', string]
         pri.merges.current_size:
           description: size of current merges
-          type: string
+          type: ['null', string]
         merges.total:
           description: number of completed merge ops
-          type: string
+          type: ['null', string]
         pri.merges.total:
           description: number of completed merge ops
-          type: string
+          type: ['null', string]
         merges.total_docs:
           description: docs merged
-          type: string
+          type: ['null', string]
         pri.merges.total_docs:
           description: docs merged
-          type: string
+          type: ['null', string]
         merges.total_size:
           description: size merged
-          type: string
+          type: ['null', string]
         pri.merges.total_size:
           description: size merged
-          type: string
+          type: ['null', string]
         merges.total_time:
           description: time spent in merges
-          type: string
+          type: ['null', string]
         pri.merges.total_time:
           description: time spent in merges
-          type: string
+          type: ['null', string]
         refresh.total:
           description: total refreshes
-          type: string
+          type: ['null', string]
         pri.refresh.total:
           description: total refreshes
-          type: string
+          type: ['null', string]
         refresh.time:
           description: time spent in refreshes
-          type: string
+          type: ['null', string]
         pri.refresh.time:
           description: time spent in refreshes
-          type: string
+          type: ['null', string]
         refresh.external_total:
           description: total external refreshes
-          type: string
+          type: ['null', string]
         pri.refresh.external_total:
           description: total external refreshes
-          type: string
+          type: ['null', string]
         refresh.external_time:
           description: time spent in external refreshes
-          type: string
+          type: ['null', string]
         pri.refresh.external_time:
           description: time spent in external refreshes
-          type: string
+          type: ['null', string]
         refresh.listeners:
           description: number of pending refresh listeners
-          type: string
+          type: ['null', string]
         pri.refresh.listeners:
           description: number of pending refresh listeners
-          type: string
+          type: ['null', string]
         search.fetch_current:
           description: current fetch phase ops
-          type: string
+          type: ['null', string]
         pri.search.fetch_current:
           description: current fetch phase ops
-          type: string
+          type: ['null', string]
         search.fetch_time:
           description: time spent in fetch phase
-          type: string
+          type: ['null', string]
         pri.search.fetch_time:
           description: time spent in fetch phase
-          type: string
+          type: ['null', string]
         search.fetch_total:
           description: total fetch ops
-          type: string
+          type: ['null', string]
         pri.search.fetch_total:
           description: total fetch ops
-          type: string
+          type: ['null', string]
         search.open_contexts:
           description: open search contexts
-          type: string
+          type: ['null', string]
         pri.search.open_contexts:
           description: open search contexts
-          type: string
+          type: ['null', string]
         search.query_current:
           description: current query phase ops
-          type: string
+          type: ['null', string]
         pri.search.query_current:
           description: current query phase ops
-          type: string
+          type: ['null', string]
         search.query_time:
           description: time spent in query phase
-          type: string
+          type: ['null', string]
         pri.search.query_time:
           description: time spent in query phase
-          type: string
+          type: ['null', string]
         search.query_total:
           description: total query phase ops
-          type: string
+          type: ['null', string]
         pri.search.query_total:
           description: total query phase ops
-          type: string
+          type: ['null', string]
+        search.concurrent_query_current:
+          type: ['null', string]
+        pri.search.concurrent_query_current:
+          type: ['null', string]
+        search.concurrent_query_time:
+          type: ['null', string]
+        pri.search.concurrent_query_time:
+          type: ['null', string]
+        search.concurrent_query_total:
+          type: ['null', string]
+        pri.search.concurrent_query_total:
+          type: ['null', string]
+        search.concurrent_avg_slice_count:
+          type: ['null', string]
+        pri.search.concurrent_avg_slice_count:
+          type: ['null', string]
         search.scroll_current:
           description: open scroll contexts
-          type: string
+          type: ['null', string]
         pri.search.scroll_current:
           description: open scroll contexts
-          type: string
+          type: ['null', string]
         search.scroll_time:
           description: time scroll contexts held open
-          type: string
+          type: ['null', string]
         pri.search.scroll_time:
           description: time scroll contexts held open
-          type: string
+          type: ['null', string]
         search.scroll_total:
           description: completed scroll contexts
-          type: string
+          type: ['null', string]
         pri.search.scroll_total:
           description: completed scroll contexts
-          type: string
+          type: ['null', string]
+        search.point_in_time_current:
+          type: ['null', string]
+        pri.search.point_in_time_current:
+          type: ['null', string]
+        search.point_in_time_time:
+          type: ['null', string]
+        pri.search.point_in_time_time:
+          type: ['null', string]
+        search.point_in_time_total:
+          type: ['null', string]
+        pri.search.point_in_time_total:
+          type: ['null', string]
         segments.count:
           description: number of segments
-          type: string
+          type: ['null', string]
         pri.segments.count:
           description: number of segments
-          type: string
+          type: ['null', string]
         segments.memory:
           description: memory used by segments
-          type: string
+          type: ['null', string]
         pri.segments.memory:
           description: memory used by segments
-          type: string
+          type: ['null', string]
         segments.index_writer_memory:
           description: memory used by index writer
-          type: string
+          type: ['null', string]
         pri.segments.index_writer_memory:
           description: memory used by index writer
-          type: string
+          type: ['null', string]
         segments.version_map_memory:
           description: memory used by version map
-          type: string
+          type: ['null', string]
         pri.segments.version_map_memory:
           description: memory used by version map
-          type: string
+          type: ['null', string]
         segments.fixed_bitset_memory:
           description: memory used by fixed bit sets for nested object field types and export type filters for types referred in _parent fields
-          type: string
+          type: ['null', string]
         pri.segments.fixed_bitset_memory:
           description: memory used by fixed bit sets for nested object field types and export type filters for types referred in _parent fields
-          type: string
+          type: ['null', string]
         warmer.current:
           description: current warmer ops
-          type: string
+          type: ['null', string]
         pri.warmer.current:
           description: current warmer ops
-          type: string
+          type: ['null', string]
         warmer.total:
           description: total warmer ops
-          type: string
+          type: ['null', string]
         pri.warmer.total:
           description: total warmer ops
-          type: string
+          type: ['null', string]
         warmer.total_time:
           description: time spent in warmers
-          type: string
+          type: ['null', string]
         pri.warmer.total_time:
           description: time spent in warmers
-          type: string
+          type: ['null', string]
         suggest.current:
           description: number of current suggest ops
-          type: string
+          type: ['null', string]
         pri.suggest.current:
           description: number of current suggest ops
-          type: string
+          type: ['null', string]
         suggest.time:
           description: time spend in suggest
-          type: string
+          type: ['null', string]
         pri.suggest.time:
           description: time spend in suggest
-          type: string
+          type: ['null', string]
         suggest.total:
           description: number of suggest ops
-          type: string
+          type: ['null', string]
         pri.suggest.total:
           description: number of suggest ops
-          type: string
+          type: ['null', string]
         memory.total:
           description: total used memory
           type: string
@@ -401,34 +429,4 @@ components:
           type: string
         search.throttled:
           description: indicates if the index is search throttled
-          type: string
-        bulk.total_operations:
-          description: number of bulk shard ops
-          type: string
-        pri.bulk.total_operations:
-          description: number of bulk shard ops
-          type: string
-        bulk.total_time:
-          description: time spend in shard bulk
-          type: string
-        pri.bulk.total_time:
-          description: time spend in shard bulk
-          type: string
-        bulk.total_size_in_bytes:
-          description: total size in bytes of shard bulk
-          type: string
-        pri.bulk.total_size_in_bytes:
-          description: total size in bytes of shard bulk
-          type: string
-        bulk.avg_time:
-          description: average time spend in shard bulk
-          type: string
-        pri.bulk.avg_time:
-          description: average time spend in shard bulk
-          type: string
-        bulk.avg_size_in_bytes:
-          description: average size in bytes of shard bulk
-          type: string
-        pri.bulk.avg_size_in_bytes:
-          description: average size in bytes of shard bulk
           type: string

--- a/spec/schemas/cat.nodes.yaml
+++ b/spec/schemas/cat.nodes.yaml
@@ -255,6 +255,14 @@ components:
         search.query_total:
           description: The total query phase operations.
           type: string
+        search.concurrent_query_current:
+          type: string
+        search.concurrent_query_time:
+          type: string
+        search.concurrent_query_total:
+          type: string
+        search.concurrent_avg_slice_count:
+          type: string
         search.scroll_current:
           description: The open scroll contexts.
           type: string
@@ -263,6 +271,12 @@ components:
           type: string
         search.scroll_total:
           description: The completed scroll contexts.
+          type: string
+        search.point_in_time_current:
+          type: string
+        search.point_in_time_time:
+          type: string
+        search.point_in_time_total:
           type: string
         segments.count:
           description: The number of segments.

--- a/spec/schemas/cat.recovery.yaml
+++ b/spec/schemas/cat.recovery.yaml
@@ -17,11 +17,11 @@ components:
         start_time:
           $ref: '_common.yaml#/components/schemas/DateTime'
         start_time_millis:
-          $ref: '_common.yaml#/components/schemas/EpochTimeUnitMillis'
+          $ref: '_common.yaml#/components/schemas/StringifiedEpochTimeUnitMillis'
         stop_time:
           $ref: '_common.yaml#/components/schemas/DateTime'
         stop_time_millis:
-          $ref: '_common.yaml#/components/schemas/EpochTimeUnitMillis'
+          $ref: '_common.yaml#/components/schemas/StringifiedEpochTimeUnitMillis'
         time:
           $ref: '_common.yaml#/components/schemas/Duration'
         type:

--- a/spec/schemas/cat.shards.yaml
+++ b/spec/schemas/cat.shards.yaml
@@ -38,13 +38,13 @@ components:
           type: ['null', string]
         id:
           description: The unique identifier for the node.
-          type: string
+          type: ['null', string]
         node:
           description: The name of node.
           type: ['null', string]
         sync_id:
           description: The sync identifier.
-          type: string
+          type: ['null', string]
         unassigned.reason:
           description: |-
             The reason for the last change to the state of an unassigned shard.
@@ -67,201 +67,219 @@ components:
             `REINITIALIZED`: When a shard moves from started back to initializing.
             `REPLICA_ADDED`: Unassigned as a result of explicit addition of a replica.
             `REROUTE_CANCELLED`: Unassigned as a result of explicit cancel reroute command.
-          type: string
+          type: ['null', string]
         unassigned.at:
           description: The time at which the shard became unassigned in Coordinated Universal Time (UTC).
-          type: string
+          type: ['null', string]
         unassigned.for:
           description: The time at which the shard was requested to be unassigned in Coordinated Universal Time (UTC).
-          type: string
+          type: ['null', string]
         unassigned.details:
           description: |-
             Additional details as to why the shard became unassigned.
             It does not explain why the shard is not assigned; use the cluster allocation explain API for that information.
-          type: string
+          type: ['null', string]
         recoverysource.type:
           description: The type of recovery source.
-          type: string
+          type: ['null', string]
         completion.size:
           description: The size of completion.
-          type: string
+          type: ['null', string]
         fielddata.memory_size:
           description: The used fielddata cache memory.
-          type: string
+          type: ['null', string]
         fielddata.evictions:
           description: The fielddata cache evictions.
-          type: string
+          type: ['null', string]
         query_cache.memory_size:
           description: The used query cache memory.
-          type: string
+          type: ['null', string]
         query_cache.evictions:
           description: The query cache evictions.
-          type: string
+          type: ['null', string]
         flush.total:
           description: The number of flushes.
-          type: string
+          type: ['null', string]
         flush.total_time:
           description: The time spent in flush.
-          type: string
+          type: ['null', string]
         get.current:
           description: The number of current get operations.
-          type: string
+          type: ['null', string]
         get.time:
           description: The time spent in get operations.
-          type: string
+          type: ['null', string]
         get.total:
           description: The number of get operations.
-          type: string
+          type: ['null', string]
         get.exists_time:
           description: The time spent in successful get operations.
-          type: string
+          type: ['null', string]
         get.exists_total:
           description: The number of successful get operations.
-          type: string
+          type: ['null', string]
         get.missing_time:
           description: The time spent in failed get operations.
-          type: string
+          type: ['null', string]
         get.missing_total:
           description: The number of failed get operations.
-          type: string
+          type: ['null', string]
         indexing.delete_current:
           description: The number of current deletion operations.
-          type: string
+          type: ['null', string]
         indexing.delete_time:
           description: The time spent in deletion operations.
-          type: string
+          type: ['null', string]
         indexing.delete_total:
           description: The number of delete operations.
-          type: string
+          type: ['null', string]
         indexing.index_current:
           description: The number of current indexing operations.
-          type: string
+          type: ['null', string]
         indexing.index_time:
           description: The time spent in indexing operations.
-          type: string
+          type: ['null', string]
         indexing.index_total:
           description: The number of indexing operations.
-          type: string
+          type: ['null', string]
         indexing.index_failed:
           description: The number of failed indexing operations.
-          type: string
+          type: ['null', string]
         merges.current:
           description: The number of current merge operations.
-          type: string
+          type: ['null', string]
         merges.current_docs:
           description: The number of current merging documents.
-          type: string
+          type: ['null', string]
         merges.current_size:
           description: The size of current merge operations.
-          type: string
+          type: ['null', string]
         merges.total:
           description: The number of completed merge operations.
-          type: string
+          type: ['null', string]
         merges.total_docs:
           description: The number of merged documents.
-          type: string
+          type: ['null', string]
         merges.total_size:
           description: The size of current merges.
-          type: string
+          type: ['null', string]
         merges.total_time:
           description: The time spent merging documents.
-          type: string
+          type: ['null', string]
         refresh.total:
           description: The total number of refreshes.
-          type: string
+          type: ['null', string]
         refresh.time:
           description: The time spent in refreshes.
-          type: string
+          type: ['null', string]
         refresh.external_total:
           description: The total number of external refreshes.
-          type: string
+          type: ['null', string]
         refresh.external_time:
           description: The time spent in external refreshes.
-          type: string
+          type: ['null', string]
         refresh.listeners:
           description: The number of pending refresh listeners.
-          type: string
+          type: ['null', string]
         search.fetch_current:
           description: The current fetch phase operations.
-          type: string
+          type: ['null', string]
         search.fetch_time:
           description: The time spent in fetch phase.
-          type: string
+          type: ['null', string]
         search.fetch_total:
           description: The total number of fetch operations.
-          type: string
+          type: ['null', string]
         search.open_contexts:
           description: The number of open search contexts.
-          type: string
+          type: ['null', string]
         search.query_current:
           description: The current query phase operations.
-          type: string
+          type: ['null', string]
         search.query_time:
           description: The time spent in query phase.
-          type: string
+          type: ['null', string]
         search.query_total:
           description: The total number of query phase operations.
-          type: string
+          type: ['null', string]
+        search.concurrent_query_current:
+          type: ['null', string]
+        search.concurrent_query_time:
+          type: ['null', string]
+        search.concurrent_query_total:
+          type: ['null', string]
+        search.concurrent_avg_slice_count:
+          type: ['null', string]
         search.scroll_current:
           description: The open scroll contexts.
-          type: string
+          type: ['null', string]
         search.scroll_time:
           description: The time scroll contexts were held open.
-          type: string
+          type: ['null', string]
         search.scroll_total:
           description: The number of completed scroll contexts.
-          type: string
+          type: ['null', string]
+        search.point_in_time_current:
+          type: ['null', string]
+        search.point_in_time_time:
+          type: ['null', string]
+        search.point_in_time_total:
+          type: ['null', string]
+        search.search_idle_reactivate_count_total:
+          type: ['null', string]
         segments.count:
           description: The number of segments.
-          type: string
+          type: ['null', string]
         segments.memory:
           description: The memory used by segments.
-          type: string
+          type: ['null', string]
         segments.index_writer_memory:
           description: The memory used by the index writer.
-          type: string
+          type: ['null', string]
         segments.version_map_memory:
           description: The memory used by the version map.
-          type: string
+          type: ['null', string]
         segments.fixed_bitset_memory:
           description: The memory used by fixed bit sets for nested object field types and export type filters for types referred in `_parent` fields.
-          type: string
+          type: ['null', string]
         seq_no.max:
           description: The maximum sequence number.
-          type: string
+          type: ['null', string]
         seq_no.local_checkpoint:
           description: The local checkpoint.
-          type: string
+          type: ['null', string]
         seq_no.global_checkpoint:
           description: The global checkpoint.
-          type: string
+          type: ['null', string]
         warmer.current:
           description: The number of current warmer operations.
-          type: string
+          type: ['null', string]
         warmer.total:
           description: The total number of warmer operations.
-          type: string
+          type: ['null', string]
         warmer.total_time:
           description: The time spent in warmer operations.
-          type: string
+          type: ['null', string]
         path.data:
           description: The shard data path.
-          type: string
+          type: ['null', string]
         path.state:
           description: The shard state path.
-          type: string
+          type: ['null', string]
         bulk.total_operations:
           description: The number of bulk shard operations.
-          type: string
+          type: ['null', string]
         bulk.total_time:
           description: The time spent in shard bulk operations.
-          type: string
+          type: ['null', string]
         bulk.total_size_in_bytes:
           description: The total size in bytes of shard bulk operations.
-          type: string
+          type: ['null', string]
         bulk.avg_time:
           description: The average time spent in shard bulk operations.
-          type: string
+          type: ['null', string]
         bulk.avg_size_in_bytes:
           description: The average size in bytes of shard bulk operations.
-          type: string
+          type: ['null', string]
+        docs.deleted:
+          type: ['null', string]

--- a/spec/schemas/cat.thread_pool.yaml
+++ b/spec/schemas/cat.thread_pool.yaml
@@ -58,6 +58,8 @@ components:
         completed:
           description: The number of completed tasks.
           type: string
+        total_wait_time:
+          type: string
         core:
           description: The core number of active threads allowed in a scaling thread pool.
           type: ['null', string]

--- a/tests/default/cat/fielddata.yaml
+++ b/tests/default/cat/fielddata.yaml
@@ -15,6 +15,7 @@ chapters:
     method: GET
     parameters:
       format: json
+      bytes: b
     response:
       status: 200
       payload:

--- a/tests/default/cat/indices.yaml
+++ b/tests/default/cat/indices.yaml
@@ -8,8 +8,23 @@ prologues:
       index: books
     request:
       payload: {}
+  - path: /{index}
+    method: PUT
+    parameters:
+      index: unassigned
+      wait_for_active_shards: 0
+    request:
+      payload:
+        settings:
+          routing:
+            allocation:
+              require:
+                test: test
 epilogues:
   - path: /books
+    method: DELETE
+    status: [200, 404]
+  - path: /unassigned
     method: DELETE
     status: [200, 404]
 chapters:

--- a/tests/default/cat/indices.yaml
+++ b/tests/default/cat/indices.yaml
@@ -62,6 +62,26 @@ chapters:
     response:
       status: 200
       content_type: text/plain
+  - synopsis: List information related to indexes with bytes, time and all fields.
+    method: GET
+    path: /_cat/indices
+    parameters:
+      format: json
+      bytes: b
+      time: s
+      h:
+        - '*'
+    response:
+      status: 200
+      content_type: application/json
+  - synopsis: List information related to indexes with all fields.
+    method: GET
+    path: /_cat/indices
+    parameters:
+      format: json
+    response:
+      status: 200
+      content_type: application/json
   - synopsis: List information related to indexes in different formats (format=json).
     method: GET
     path: /_cat/indices

--- a/tests/default/cat/nodes.yaml
+++ b/tests/default/cat/nodes.yaml
@@ -22,3 +22,29 @@ chapters:
       status: 200
       payload:
         - cluster_manager: '*'
+  - synopsis: List node-level information with all fields.
+    path: /_cat/nodes
+    version: '>= 2.0'
+    method: GET
+    parameters:
+      format: json
+      h:
+        - '*'
+    response:
+      status: 200
+      payload:
+        - cluster_manager: '*'
+  - synopsis: List node-level information with bytes, time and all fields.
+    path: /_cat/nodes
+    version: '>= 2.0'
+    method: GET
+    parameters:
+      format: json
+      bytes: b
+      time: s
+      h:
+        - '*'
+    response:
+      status: 200
+      payload:
+        - cluster_manager: '*'

--- a/tests/default/cat/plugins.yaml
+++ b/tests/default/cat/plugins.yaml
@@ -7,5 +7,7 @@ chapters:
     method: GET
     parameters:
       format: json
+      h:
+        - '*'
     response:
       status: 200

--- a/tests/default/cat/recovery.yaml
+++ b/tests/default/cat/recovery.yaml
@@ -16,6 +16,8 @@ chapters:
     method: GET
     parameters:
       format: json
+      h:
+        - '*'
     response:
       status: 200
   - synopsis: List all completed and ongoing index and shard recoveries for a given index.
@@ -29,5 +31,7 @@ chapters:
       bytes: kb
       detailed: true
       time: m
+      h:
+        - '*'
     response:
       status: 200

--- a/tests/default/cat/segments.yaml
+++ b/tests/default/cat/segments.yaml
@@ -16,6 +16,8 @@ chapters:
     method: GET
     parameters:
       format: json
+      h:
+        - '*'
     response:
       status: 200
   - synopsis: List Lucene segment-level information for an index.
@@ -24,6 +26,8 @@ chapters:
     parameters:
       format: json
       bytes: kb
+      h:
+        - '*'
       index:
         - books
     response:

--- a/tests/default/cat/shards.yaml
+++ b/tests/default/cat/shards.yaml
@@ -5,11 +5,26 @@ epilogues:
   - path: /games
     method: DELETE
     status: [200, 404]
+  - path: /{index}
+    method: PUT
+    parameters:
+      index: unassigned
+      wait_for_active_shards: 0
+    request:
+      payload:
+        settings:
+          routing:
+            allocation:
+              require:
+                test: test
 prologues:
   - path: /{index}
     method: PUT
     parameters:
       index: games
+  - path: /unassigned
+    method: DELETE
+    status: [200, 404]
 chapters:
   - synopsis: List the state of all primary and replica shards and how they are distributed.
     path: /_cat/shards

--- a/tests/default/cat/shards.yaml
+++ b/tests/default/cat/shards.yaml
@@ -16,6 +16,8 @@ chapters:
     method: GET
     parameters:
       format: json
+      h:
+        - '*'
   - synopsis: List the state of all primary and replica shards and how they are distributed for an index.
     path: /_cat/shards/{index}
     method: GET
@@ -26,6 +28,8 @@ chapters:
       bytes: kb
       local: true
       time: s
+      h:
+        - '*'
     response:
       status: 200
       payload:

--- a/tests/default/cat/tasks.yaml
+++ b/tests/default/cat/tasks.yaml
@@ -12,5 +12,19 @@ chapters:
       detailed: true
       parent_task_id: node_id:-1
       time: s
+      h:
+        - '*'
+    response:
+      status: 200
+  - synopsis: List the progress of all tasks currently running on your cluster.
+    path: /_cat/tasks
+    method: GET
+    parameters:
+      format: json
+      h:
+        - '*'
+      nodes:
+        - local
+      detailed: true
     response:
       status: 200

--- a/tests/default/cat/thread_pool.yaml
+++ b/tests/default/cat/thread_pool.yaml
@@ -7,6 +7,8 @@ chapters:
     method: GET
     parameters:
       format: json
+      h:
+        - '*'
     response:
       status: 200
   - synopsis: List the active, queued, and rejected threads of different thread pools on each node.
@@ -16,6 +18,8 @@ chapters:
       format: json
       thread_pool_patterns: generic
       local: true
+      h:
+        - '*'
     response:
       status: 200
       payload:


### PR DESCRIPTION
### Description
- Add `h`, `bytes` and `time` parameters to some cat API tests
- Add tests against unassigned indices/shards for indices and shards cat endpoint
- Add missing fields and adjust there types due to the test cases.
- Remove some old? none existing? fields from the cat indices endpoint

### Issues Resolved
Closes #550

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
