### PR TITLE
Fix some integer/long typings

### DIFF
--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -138,7 +138,7 @@ components:
         - $ref: '#/components/schemas/UnitMillis'
     UnitMillis:
       description: Time unit for milliseconds.
-      type: number
+      type: integer
       format: int64
     DurationLarge:
       description: |-
@@ -173,10 +173,10 @@ components:
       description: Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
       type: string
     SequenceNumber:
-      type: number
+      type: integer
       format: int64
     VersionNumber:
-      type: number
+      type: integer
       format: int64
     SortResults:
       type: array
@@ -276,7 +276,7 @@ components:
         - successful
         - total
     uint:
-      type: number
+      type: integer
     ShardFailure:
       type: object
       properties:
@@ -287,7 +287,7 @@ components:
         reason:
           $ref: '#/components/schemas/ErrorCause'
         shard:
-          type: number
+          type: integer
         status:
           type: string
       required:
@@ -325,7 +325,8 @@ components:
         - $ref: '#/components/schemas/UnitNanos'
     UnitNanos:
       description: Time unit for nanoseconds.
-      type: number
+      type: integer
+      format: int64
     ScrollId:
       type: string
     Routing:
@@ -1318,13 +1319,13 @@ components:
             $ref: '#/components/schemas/ErrorCause'
         total:
           description: Total number of nodes selected by the request.
-          type: number
+          type: integer
         successful:
           description: Number of nodes that responded successfully to the request.
-          type: number
+          type: integer
         failed:
           description: Number of nodes that rejected the request or failed to respond. If this value is not 0, a reason for the rejection or failure is included in the response.
-          type: number
+          type: integer
       required:
         - failed
         - successful
@@ -1339,7 +1340,7 @@ components:
         _index:
           $ref: '#/components/schemas/IndexName'
         _primary_term:
-          type: number
+          type: integer
           format: int64
         result:
           $ref: '#/components/schemas/Result'
@@ -1404,9 +1405,11 @@ components:
       type: object
       properties:
         bulk:
-          type: number
+          type: integer
+          format: int64
         search:
-          type: number
+          type: integer
+          format: int64
       required:
         - bulk
         - search
@@ -1418,7 +1421,7 @@ components:
       type: object
       properties:
         task_id:
-          type: number
+          type: integer
         node_id:
           $ref: '#/components/schemas/NodeId'
         status:

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -84,7 +84,7 @@ components:
           type: string
           description: The model group name.
         latest_version:
-          type: number
+          type: integer
           description: The latest version.
         description:
           type: string

--- a/spec/schemas/tasks._common.yaml
+++ b/spec/schemas/tasks._common.yaml
@@ -65,7 +65,8 @@ components:
           additionalProperties:
             type: string
         id:
-          type: number
+          type: integer
+          format: int64
         node:
           $ref: '_common.yaml#/components/schemas/NodeId'
         running_time:


### PR DESCRIPTION
### Description
Fixes a handful of integer/long typings, especially a few that erroneously had `type: number` rather than `type: integer`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
