### PR TITLE
Fix geo distance query and its test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed content-type for `/hot_threads` ([#543](https://github.com/opensearch-project/opensearch-api-specification/pull/543))
 - Fixed `/_cluster/settings` returning flat results ([#545](https://github.com/opensearch-project/opensearch-api-specification/pull/545))
 - Fixed missing fields in `_cat` API ([#551](https://github.com/opensearch-project/opensearch-api-specification/pull/551))
+- Fixed `geo_distance` query spec ([#560](https://github.com/opensearch-project/opensearch-api-specification/pull/560))
 
 ### Security
 

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -653,11 +653,11 @@ components:
               $ref: '#/components/schemas/GeoValidationMethod'
             ignore_unmapped:
               $ref: '#/components/schemas/IgnoreUnmapped'
-            field:
-              type: object
+          additionalProperties:
+            $ref: '_common.yaml#/components/schemas/GeoLocation'
+          minProperties: 2
           required:
             - distance
-            - field
     GeoPolygonQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'

--- a/tests/default/_core/search/query/geo_distance.yaml
+++ b/tests/default/_core/search/query/geo_distance.yaml
@@ -1,34 +1,34 @@
-$schema: ../../../../json_schemas/test_story.schema.yaml
+$schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test search endpoint with geo_distance query.
 prologues:
-  - path: /map
+  - path: /cinemas
     method: PUT
     request:
       payload:
         mappings:
           properties:
-            field:
+            location:
               type: geo_point
-  - path: /map/_doc/1
+  - path: /cinemas/_doc/1
     method: POST
     parameters:
       refresh: true
     request:
       payload:
-        field: 
+        location: 
           lat: 74
           lon: 40.71
     status: [201]
 epilogues:
-  - path: /map
+  - path: /cinemas
     method: DELETE
     status: [200, 404]
 chapters:
   - synopsis: Search for documents whose point objects are within the specified distance from the specified point.
     path: /{index}/_search
     parameters:
-      index: map
+      index: cinemas
     method: GET
     request:
       payload:
@@ -38,7 +38,7 @@ chapters:
             distance_type: arc
             validation_method: strict
             ignore_unmapped: true
-            field:
+            location:
               lat: 73.5
               lon: 40.5
     response:
@@ -51,10 +51,10 @@ chapters:
             relation: eq
           max_score: 1
           hits:
-            - _index: map
+            - _index: cinemas
               _score: 1
               _source:
-                field: 
+                location: 
                   lat: 74
                   lon: 40.71
                 


### PR DESCRIPTION
This PR addresses the following issues for the `geo_distance` query spec and test:
- Uses `additionalProperties` instead of hard-coding the field because the field name can be anything
- Specifies that the field must be of the `geo_point` type
- Moves the `geo_distance` query test into the `query` folder
- Renames the index and field within the test to go along with the movie theme

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
