### PR TITLE
Fix fuzzy query rewrite parameter and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed content-type for `/hot_threads` ([#543](https://github.com/opensearch-project/opensearch-api-specification/pull/543))
 - Fixed `/_cluster/settings` returning flat results ([#545](https://github.com/opensearch-project/opensearch-api-specification/pull/545))
 - Fixed missing fields in `_cat` API ([#551](https://github.com/opensearch-project/opensearch-api-specification/pull/551))
+- Fixed `geo_distance` query spec ([#561](https://github.com/opensearch-project/opensearch-api-specification/pull/561))
 
 ### Security
 

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -436,10 +436,10 @@ components:
       type: string
       enum:
         - constant_score
-        - scoring_boolean
         - constant_score_boolean
-        - top_terms_N
+        - scoring_boolean
         - top_terms_boost_N
+        - top_terms_N
         - top_terms_blended_freqs_N
     Fuzziness:
       oneOf:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -438,9 +438,9 @@ components:
         - constant_score
         - constant_score_boolean
         - scoring_boolean
-        - top_terms_boost_N
         - top_terms_N
         - top_terms_blended_freqs_N
+        - top_terms_boost_N
     Fuzziness:
       oneOf:
         - type: string

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -434,6 +434,13 @@ components:
             - id
     MultiTermQueryRewrite:
       type: string
+      enum:
+        - constant_score
+        - scoring_boolean
+        - constant_score_boolean
+        - top_terms_N
+        - top_terms_boost_N
+        - top_terms_blended_freqs_N
     Fuzziness:
       oneOf:
         - type: string

--- a/tests/default/_core/search/query/fuzzy.yaml
+++ b/tests/default/_core/search/query/fuzzy.yaml
@@ -1,0 +1,56 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test search endpoint with fuzzy query.
+prologues:
+  - path: /movies
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            title:
+              type: text
+  - path: /movies/_doc/1
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      payload:
+        title: Braveheart
+    status: [201]
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Search for documents using a fuzzy query.
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: GET
+    request:
+      payload:
+        query:
+          fuzzy:
+            title: 
+              value: bravehaer
+              fuzziness: 2
+              max_expansions: 40
+              prefix_length: 0
+              transpositions: true
+              rewrite: constant_score
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 1
+            relation: eq
+          max_score: 1
+          hits:
+            - _index: movies
+              _score: 1
+              _source:
+                title: Braveheart
+                

--- a/tests/default/_core/search/query/fuzzy.yaml
+++ b/tests/default/_core/search/query/fuzzy.yaml
@@ -16,7 +16,7 @@ prologues:
       refresh: true
     request:
       payload:
-        title: Braveheart
+        title: Brave
     status: [201]
 epilogues:
   - path: /movies
@@ -33,7 +33,7 @@ chapters:
         query:
           fuzzy:
             title: 
-              value: bravehaer
+              value: bake
               fuzziness: 2
               max_expansions: 40
               prefix_length: 0
@@ -52,5 +52,5 @@ chapters:
             - _index: movies
               _score: 1
               _source:
-                title: Braveheart
+                title: Brave
                 


### PR DESCRIPTION
This PR adds an enum of possible values for the `rewrite` parameter of the `fuzzy` query. It also adds a corresponding test for the `fuzzy` query.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
