### PR TITLE
Rename index and field in geo_bounding_box query test

### DIFF
--- a/tests/default/_core/search/query/geo_bounding_box.yaml
+++ b/tests/default/_core/search/query/geo_bounding_box.yaml
@@ -2,39 +2,39 @@ $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test search endpoint with geo_bounding_box query.
 prologues:
-  - path: /point_index
+  - path: /cinemas
     method: PUT
     request:
       payload:
         mappings:
           properties:
-            field:
+            location:
               type: geo_point
-  - path: /point_index/_doc/1
+  - path: /cinemas/_doc/1
     method: POST
     parameters:
       refresh: true
     request:
       payload:
-        field:
+        location:
           lat: 74
           lon: 40
     status: [201]
 epilogues:
-  - path: /point_index
+  - path: /cinemas
     method: DELETE
     status: [200, 404]
 chapters:
-  - synopsis: Search point_index for documents whose point objects are within the specified bounding box.
+  - synopsis: Search cinemas for documents whose point objects are within the specified bounding box.
     path: /{index}/_search
     parameters:
-      index: point_index
+      index: cinemas
     method: GET
     request:
       payload:
         query:
           geo_bounding_box:
-            field:
+            location:
               top: 75
               left: 28
               bottom: 73
@@ -52,9 +52,9 @@ chapters:
             relation: eq
           max_score: 1
           hits:
-            - _index: point_index
+            - _index: cinemas
               _score: 1
               _source:
-                field:
+                location:
                   lat: 74
                   lon: 40


### PR DESCRIPTION
Renames the index to `cinemas` and field to `location` to fit with the movie theme.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
