### PR TITLE
Show relative path instead of a full one.

### DIFF
--- a/tools/src/tester/ResultLogger.ts
+++ b/tools/src/tester/ResultLogger.ts
@@ -12,6 +12,7 @@ import { overall_result } from './helpers'
 import * as ansi from './Ansi'
 import TestResults from './TestResults'
 import _ from 'lodash'
+import * as path from 'path'
 
 export interface ResultLogger {
   log: (evaluation: StoryEvaluation) => void
@@ -71,7 +72,7 @@ export class ConsoleResultLogger implements ResultLogger {
   }
 
   #log_story ({ result, full_path, display_path, message, warnings }: StoryEvaluation): void {
-    this.#log_evaluation({ result, message: message ?? full_path }, ansi.cyan(ansi.b(display_path)))
+    this.#log_evaluation({ result, message: message ?? path.relative('.', full_path) }, ansi.cyan(ansi.b(display_path)))
     this.#log_warnings(warnings)
   }
 

--- a/tools/tests/tester/test.test.ts
+++ b/tools/tests/tester/test.test.ts
@@ -9,7 +9,6 @@
 
 import { spawnSync } from 'child_process'
 import * as ansi from 'tester/Ansi'
-import * as path from 'path'
 import { type Chapter, type ChapterRequest, type Output, type Request, Story } from 'tester/types/story.types'
 import { ChapterEvaluation, Result, StoryEvaluation } from 'tester/types/eval.types'
 import StoryEvaluator from 'tester/StoryEvaluator'
@@ -158,11 +157,10 @@ test.todo('--tab-width')
 test('--dry-run', () => {
   const test_yaml = 'tools/tests/tester/fixtures/empty_with_all_the_parts.yaml'
   const s = spec(['--dry-run', '--tests', test_yaml]).stdout
-  const full_path = path.join(__dirname, '../../../' + test_yaml)
   expect(s).not.toContain(`${ansi.yellow('SKIPPED')} CHAPTERS`)
   expect(s).not.toContain(`${ansi.yellow('SKIPPED')} EPILOGUES`)
   expect(s).not.toContain(`${ansi.yellow('SKIPPED')} PROLOGUES`)
-  expect(s).toContain(`${ansi.yellow('SKIPPED')} ${ansi.cyan(ansi.b('empty_with_all_the_parts.yaml'))} ${ansi.gray('(' + full_path + ')')}`)
+  expect(s).toContain(`${ansi.yellow('SKIPPED')} ${ansi.cyan(ansi.b('empty_with_all_the_parts.yaml'))} ${ansi.gray('(' + test_yaml + ')')}`)
 })
 
 test('--dry-run --verbose', () => {


### PR DESCRIPTION
### Description

Before:

![Screenshot 2024-09-10 at 2 03 46 PM](https://github.com/user-attachments/assets/63a7f744-577b-48d9-bf2a-c02880d9c169)

After:

![Screenshot 2024-09-10 at 2 03 57 PM](https://github.com/user-attachments/assets/c834905d-be09-4c0d-8a5c-a92cbf1ad19a)

I think it's much easier to grok.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
