### PR TITLE
fix matchAllQuery

### DIFF
--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -984,9 +984,7 @@ components:
         - all
         - none
     MatchAllQuery:
-      allOf:
-        - $ref: '#/components/schemas/QueryBase'
-        - type: object
+      $ref: '#/components/schemas/QueryBase'
     MatchBoolPrefixQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'


### PR DESCRIPTION
### Description

curr def: 
```
MatchAllQuery:
      allOf:
        - $ref: '#/components/schemas/QueryBase'
        - type: object
```
        
extra free-format object in match all query

![image](https://github.com/user-attachments/assets/7338bdd9-8e11-4b18-97b3-cba39a5e0d46)

![image](https://github.com/user-attachments/assets/472ce08d-32ae-4e04-a5b3-11fa4e159d7b)

we can fix with 

```
MatchAllQuery:
      allOf:
        - $ref: '#/components/schemas/QueryBase'
```

or 

```
MatchAllQuery:
        - $ref: '#/components/schemas/QueryBase'
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-api-specification/issues/571

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
