### PR TITLE
Split `Percentage` into `PercentageNumber`, `PercentageString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Corrected Sort schema for `/_search`'s request body ([#529](https://github.com/opensearch-project/opensearch-api-specification/issues/529))
 - Rename `Bytes` component to `StorageType` ([#552](https://github.com/opensearch-project/opensearch-api-specification/pull/552))
 - Rename `ByteSize` to `StorageSize` ([#552](https://github.com/opensearch-project/opensearch-api-specification/pull/552))
+- Split `Percentage` into `PercentageNumber`, `PercentageString` ([#573](https://github.com/opensearch-project/opensearch-api-specification/pull/573))
 
 ### Deprecated
 

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -745,10 +745,11 @@ components:
     ByteCount:
       type: integer
       format: int64
-    Percentage:
-      oneOf:
-        - type: string
-        - type: number
+    PercentageNumber:
+      type: number
+    PercentageString:
+      type: string
+      pattern: '\d+(\.\d+)?'
     Host:
       type: string
     Ip:

--- a/spec/schemas/cat._common.yaml
+++ b/spec/schemas/cat._common.yaml
@@ -63,11 +63,11 @@ components:
         files_fetched:
           type: string
         files_percent:
-          type: string
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         bytes_fetched:
           type: string
         bytes_percent:
-          type: string
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         start_time:
           type: string
         stop_time:

--- a/spec/schemas/cat.allocation.yaml
+++ b/spec/schemas/cat.allocation.yaml
@@ -36,7 +36,7 @@ components:
         disk.percent:
           description: Total percentage of disk space in use. Calculated as `disk.used / disk.total`.
           oneOf:
-            - $ref: '_common.yaml#/components/schemas/Percentage'
+            - $ref: '_common.yaml#/components/schemas/PercentageString'
             - type: 'null'
         host:
           description: Network host for the node. Set using the `network.host` setting.

--- a/spec/schemas/cat.health.yaml
+++ b/spec/schemas/cat.health.yaml
@@ -48,7 +48,7 @@ components:
           type: string
         active_shards_percent:
           description: active number of shards in percent
-          type: string
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         discovered_cluster_manager:
           description: cluster manager is discovered or not
           type: string

--- a/spec/schemas/cat.nodes.yaml
+++ b/spec/schemas/cat.nodes.yaml
@@ -44,12 +44,12 @@ components:
         disk.avail:
           type: string
         disk.used_percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         heap.current:
           description: The used heap.
           type: string
         heap.percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         heap.max:
           description: The maximum configured heap.
           type: string
@@ -57,7 +57,7 @@ components:
           description: The used machine memory.
           type: string
         ram.percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         ram.max:
           description: The total machine memory.
           type: string
@@ -65,7 +65,7 @@ components:
           description: The used file descriptors.
           type: string
         file_desc.percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         file_desc.max:
           description: The maximum number of file descriptors.
           type: string

--- a/spec/schemas/cat.recovery.yaml
+++ b/spec/schemas/cat.recovery.yaml
@@ -55,7 +55,7 @@ components:
           description: The files recovered.
           type: string
         files_percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         files_total:
           description: The total number of files.
           type: string
@@ -66,7 +66,7 @@ components:
           description: The bytes recovered.
           type: string
         bytes_percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         bytes_total:
           description: The total number of bytes.
           type: string
@@ -77,4 +77,4 @@ components:
           description: The translog operations recovered.
           type: string
         translog_ops_percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'

--- a/spec/schemas/cluster.allocation_explain.yaml
+++ b/spec/schemas/cluster.allocation_explain.yaml
@@ -98,9 +98,9 @@ components:
         free_bytes:
           $ref: '_common.yaml#/components/schemas/ByteCount'
         free_disk_percent:
-          type: number
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
         used_disk_percent:
-          type: number
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
       required:
         - free_bytes
         - free_disk_percent

--- a/spec/schemas/cluster.health.yaml
+++ b/spec/schemas/cluster.health.yaml
@@ -15,8 +15,10 @@ components:
         active_shards:
           description: The total number of active primary and replica shards.
           type: number
+        active_shards_percent:
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         active_shards_percent_as_number:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
         awareness_attributes:
           description: Cluster health information for each awareness attribute.
           type: object

--- a/spec/schemas/cluster.stats.yaml
+++ b/spec/schemas/cluster.stats.yaml
@@ -654,7 +654,7 @@ components:
           $ref: '_common.yaml#/components/schemas/ByteCount'
         free_percent:
           description: Percentage of free physical memory across all selected nodes.
-          type: number
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
         total:
           description: Total amount of physical memory across all selected nodes.
           $ref: '_common.yaml#/components/schemas/HumanReadableByteCount'
@@ -669,7 +669,7 @@ components:
           $ref: '_common.yaml#/components/schemas/ByteCount'
         used_percent:
           description: Percentage of physical memory in use across all selected nodes.
-          type: number
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
       required:
         - free_in_bytes
         - free_percent
@@ -730,7 +730,7 @@ components:
           description: |-
             Percentage of CPU used across all selected nodes.
             Returns `-1` if not supported.
-          type: number
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
       required:
         - percent
     ClusterProcessOpenFileDescriptors:

--- a/spec/schemas/indices.recovery.yaml
+++ b/spec/schemas/indices.recovery.yaml
@@ -93,7 +93,7 @@ components:
       type: object
       properties:
         percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         recovered:
           $ref: '_common.yaml#/components/schemas/HumanReadableByteCount'
         recovered_in_bytes:
@@ -123,7 +123,7 @@ components:
           items:
             $ref: '#/components/schemas/FileDetails'
         percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         recovered:
           type: number
         reused:
@@ -193,7 +193,7 @@ components:
       type: object
       properties:
         percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         recovered:
           type: number
         total:

--- a/spec/schemas/nodes._common.yaml
+++ b/spec/schemas/nodes._common.yaml
@@ -114,6 +114,8 @@ components:
         failed:
           description: Number of failed operations for the processor.
           type: number
+        time:
+          $ref: '_common.yaml#/components/schemas/Duration'
         time_in_millis:
           $ref: '_common.yaml#/components/schemas/DurationValueUnitMillis'
     ThreadCount:
@@ -346,16 +348,16 @@ components:
         timestamp:
           type: number
         cpu_utilization_percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         memory_utilization_percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         io_usage_stats:
           $ref: '#/components/schemas/ShardResourceUsageStatsIoUsageStats'
     ShardResourceUsageStatsIoUsageStats:
       type: object
       properties:
         max_io_utilization_percent:
-          $ref: '_common.yaml#/components/schemas/Percentage'
+          $ref: '_common.yaml#/components/schemas/PercentageString'
     ShardSegmentReplicationBackpressureStats:
       type: object
       properties:
@@ -677,7 +679,7 @@ components:
           $ref: '_common.yaml#/components/schemas/ByteCount'
         heap_used_percent:
           description: Percentage of memory currently in use by the heap.
-          type: number
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
         heap_committed:
           description: Amount of memory available for use by the heap.
           $ref: '_common.yaml#/components/schemas/HumanReadableByteCount'
@@ -749,7 +751,7 @@ components:
         max_in_bytes:
           $ref: '_common.yaml#/components/schemas/ByteCount'
         usage_percent:
-          type: number
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
     JvmThreads:
       type: object
       properties:
@@ -776,7 +778,7 @@ components:
       type: object
       properties:
         percent:
-          type: number
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
         sys:
           $ref: '_common.yaml#/components/schemas/Duration'
         sys_in_millis:
@@ -800,10 +802,10 @@ components:
           properties:
             free_percent:
               description: Percentage of free memory.
-              type: number
+              $ref: '_common.yaml#/components/schemas/PercentageNumber'
             used_percent:
               description: Percentage of used memory.
-              type: number
+              $ref: '_common.yaml#/components/schemas/PercentageNumber'
     MemoryStats:
       type: object
       properties:
@@ -1224,7 +1226,7 @@ components:
         cancellation_limit_reached_count:
           type: number
         cancelled_task_percentage:
-          type: number
+          $ref: '_common.yaml#/components/schemas/PercentageNumber'
         current_cancellation_eligible_tasks_count:
           type: number
     TotalRejectionsBreakup:

--- a/tests/default/cluster/health.yaml
+++ b/tests/default/cluster/health.yaml
@@ -9,6 +9,7 @@ chapters:
       expand_wildcards: all
       level: cluster
       local: false
+      human: true
       timeout: 10s
       wait_for_active_shards: 0
       wait_for_nodes: <2


### PR DESCRIPTION
### Description
- Split `Percentage` into `PercentageNumber`, `PercentageString`
- Add missing fields
- Use reference instead of type for percentage fields 

### Issues Resolved
Related to #423 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
