### PR TITLE
Ignore superseded operations in coverage reports.

### DIFF
--- a/tools/src/tester/TestResults.ts
+++ b/tools/src/tester/TestResults.ts
@@ -47,11 +47,14 @@ export default class TestResults {
 
   operations(): Operation[] {
     if (this._operations !== undefined) return this._operations
-    this._operations = _.uniqWith(Object.entries(this._spec.paths()).flatMap(([path, path_item]) => {
-      return Object.values(path_item).map((method) => {
-        return { method: method.toUpperCase(), path }
+
+    this._operations = _.uniqWith(_.compact(Object.entries(this._spec.spec().paths).flatMap(([path, ops]) => {
+      return Object.entries(ops as Record<string, any>).map(([method, spec]) => {
+        if (spec['x-ignorable'] !== true) {
+          return { method: method.toUpperCase(), path }
+        }
       })
-    }), isEqual)
+    })), isEqual)
 
     return this._operations
   }

--- a/tools/src/tester/types/test.types.ts
+++ b/tools/src/tester/types/test.types.ts
@@ -12,9 +12,9 @@ import { Operation } from "./eval.types"
 export interface SpecTestCoverage {
   summary: {
     total_operations_count: number
-    evaluated_operations_count: number,
+    evaluated_operations_count: number
     evaluated_paths_pct: number
   },
-  operations: Operation[],
+  operations: Operation[]
   evaluated_operations: Operation[]
 }

--- a/tools/tests/tester/MergedOpenApiSpec.test.ts
+++ b/tools/tests/tester/MergedOpenApiSpec.test.ts
@@ -22,6 +22,7 @@ describe('merged API spec', () => {
     test('paths', () => {
       expect(spec.paths()).toEqual({
         '/_nodes/{id}': ['get', 'post'],
+        '/_superseded/nodes/{id}': ['get'],
         '/cluster_manager': ['get', 'post'],
         '/index': ['get'],
         '/nodes': ['get']

--- a/tools/tests/tester/fixtures/specs/complete/_superseded_operations.yaml
+++ b/tools/tests/tester/fixtures/specs/complete/_superseded_operations.yaml
@@ -1,1 +1,6 @@
 $schema: should-be-ignored
+
+/_superseded/nodes/{id}:
+  superseded_by: /_nodes/{id}
+  operations:
+    - GET


### PR DESCRIPTION
### Description

IMO we don't need to test superseded operations, exclude those from test coverage numbers and reports.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
