### PR TITLE
remove extra free-format object in create/index/delete operation from…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `geo_bounding_box` and `geo_shape` queries ([#531](https://github.com/opensearch-project/opensearch-api-specification/pull/531))
 - Fixed tasks namespace schemas ([#520](https://github.com/opensearch-project/opensearch-api-specification/pull/520))
 - Fixed `/_plugins/_transform/_preview` ([#568](https://github.com/opensearch-project/opensearch-api-specification/pull/568))
+- Fixed create/delete/index operation in `_bulk` ([#582](https://github.com/opensearch-project/opensearch-api-specification/pull/582))
 
 ### Security
 

--- a/spec/schemas/_core.bulk.yaml
+++ b/spec/schemas/_core.bulk.yaml
@@ -20,9 +20,7 @@ components:
       minProperties: 1
       maxProperties: 1
     IndexOperation:
-      allOf:
-        - $ref: '#/components/schemas/WriteOperation'
-        - type: object
+      $ref: '#/components/schemas/WriteOperation'
     WriteOperation:
       allOf:
         - $ref: '#/components/schemas/OperationBase'
@@ -64,9 +62,7 @@ components:
         version_type:
           $ref: '_common.yaml#/components/schemas/VersionType'
     CreateOperation:
-      allOf:
-        - $ref: '#/components/schemas/WriteOperation'
-        - type: object
+      $ref: '#/components/schemas/WriteOperation'
     UpdateOperation:
       allOf:
         - $ref: '#/components/schemas/OperationBase'
@@ -78,9 +74,7 @@ components:
             retry_on_conflict:
               type: number
     DeleteOperation:
-      allOf:
-        - $ref: '#/components/schemas/OperationBase'
-        - type: object
+      $ref: '#/components/schemas/OperationBase'
     UpdateAction:
       type: object
       properties:


### PR DESCRIPTION
… bulk api

### Description
remove extra free-format object in create/index/delete operation in bulk

### Issues Resolved

Closes #581

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
