### PR TITLE
Fix CleanupRepositoryResults properties to be longs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Changed `rank_eval`'s `search_type` query param to use the `SearchType` enum rather than a plain string ([#586](https://github.com/opensearch-project/opensearch-api-specification/pull/586))
 - Changed `cluster.reroute`'s `metric` path param to use an enum of metrics ([#586](https://github.com/opensearch-project/opensearch-api-specification/pull/586))
 - Changed `indices.stats`'s `metric` path param to use an enum of metrics ([#586](https://github.com/opensearch-project/opensearch-api-specification/pull/586))
+- Changed `CleanupRepositoryResults`' properties to be `int64`s ([#587](https://github.com/opensearch-project/opensearch-api-specification/pull/587))
 
 ### Deprecated
 

--- a/spec/schemas/snapshot.cleanup_repository.yaml
+++ b/spec/schemas/snapshot.cleanup_repository.yaml
@@ -11,10 +11,12 @@ components:
       properties:
         deleted_blobs:
           description: Number of binary large objects (blobs) removed during cleanup.
-          type: number
+          type: integer
+          format: int64
         deleted_bytes:
           description: Number of bytes freed by cleanup operations.
-          type: number
+          type: integer
+          format: int64
       required:
         - deleted_blobs
         - deleted_bytes


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
