### PR TITLE
adding async search tests for OS 3.0 version 

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -42,7 +42,7 @@ jobs:
             ref: '@sha256:4445e195c53992038891519dc3be0d273cdaad1b047943d68921168ed243e7e9'
           - version: 3.0.0
             hub: opensearchstaging
-            ref: '@sha256:cf07c0ffa7d9e8a3e7fdb58041caae3bb81f1123260431b99d0ebf4a52c3d9a3'
+            ref: '@sha256:727643acdfebed77bfdb26362dbcff536b7ea02a0cc4ae2da2521729171333de'
 
     name: test-opensearch-spec (version=${{ matrix.entry.version }}, hub=${{ matrix.entry.hub || 'opensearchproject' }}, tests=${{ matrix.entry.tests || 'default' }})
     runs-on: ubuntu-latest

--- a/tests/default/asynchronous_search/search.yaml
+++ b/tests/default/asynchronous_search/search.yaml
@@ -27,7 +27,6 @@ chapters:
     synopsis: Asynchronous Search.
     path: /_plugins/_asynchronous_search
     method: POST
-    version: < 3.0
     parameters:
       index: books
       keep_on_completion: true
@@ -44,7 +43,6 @@ chapters:
   - synopsis: Get partial response from asynchronous search.
     path: /_plugins/_asynchronous_search/{id}
     method: GET
-    version: < 3.0
     parameters:
       id: ${async_search.id}
     response:
@@ -52,7 +50,6 @@ chapters:
   - synopsis: Delete partial response from asynchronous search.
     path: /_plugins/_asynchronous_search/{id}
     method: DELETE
-    version: < 3.0
     parameters:
       id: ${async_search.id}
     response:

--- a/tests/default/asynchronous_search/stats.yaml
+++ b/tests/default/asynchronous_search/stats.yaml
@@ -6,6 +6,5 @@ chapters:
   - synopsis: Get stats.
     path: /_plugins/_asynchronous_search/stats
     method: GET
-    version: < 3.0
     response:
       status: 200


### PR DESCRIPTION
### Description
Hello everyone! During the previous PR, we noticed that async search was not working in the OS 3.0 build. They have already fixed it, so we can use async search in version 3.0 as well.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
