### PR TITLE
add accurate numeric type in DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed create/delete/index operation in `_bulk` ([#582](https://github.com/opensearch-project/opensearch-api-specification/pull/582))
 - Add `mode` and `compression` to k-NN index creation and search, and add `rescore` and `oversample_factor` to k-NN search ([#588](https://github.com/opensearch-project/opensearch-api-specification/pull/588))
 - Fixed `/{index}/_search` with aggregations ([#576](https://github.com/opensearch-project/opensearch-api-specification/pull/576))
+- Fixed inaccurate numeric type in DSL ([#597](https://github.com/opensearch-project/opensearch-api-specification/pull/597))
 
 ### Security
 

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -280,6 +280,7 @@ components:
             A boost value between 0 and 1.0 decreases the relevance score.
             A value greater than 1.0 increases the relevance score.
           type: number
+          format: float
         _name:
           type: string
     BoostingQuery:
@@ -290,6 +291,7 @@ components:
             negative_boost:
               description: Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.
               type: number
+              format: float
             negative:
               $ref: '#/components/schemas/QueryContainer'
             positive:
@@ -307,6 +309,7 @@ components:
               type: string
             cutoff_frequency:
               type: number
+              format: float
             high_freq_operator:
               $ref: '#/components/schemas/Operator'
             low_freq_operator:
@@ -379,6 +382,7 @@ components:
             tie_breaker:
               description: Floating point number between 0 and 1.0 used to increase the relevance scores of documents matching multiple query clauses.
               type: number
+              format: float
           required:
             - queries
     DistanceFeatureQuery:
@@ -447,9 +451,11 @@ components:
             max_boost:
               description: Restricts the new score to not exceed the provided limit.
               type: number
+              format: float
             min_score:
               description: Excludes documents that do not meet the provided score threshold.
               type: number
+              format: float
             query:
               $ref: '#/components/schemas/QueryContainer'
             score_mode:
@@ -471,6 +477,7 @@ components:
               $ref: '#/components/schemas/QueryContainer'
             weight:
               type: number
+              format: float
         - type: object
           properties:
             exp:
@@ -524,11 +531,13 @@ components:
         factor:
           description: Optional factor to multiply the field value with.
           type: number
+          format: float
         missing:
           description: |-
             Value used if the document doesn't have that field.
             The modifier and factor are still applied to it as though it were read from the document.
           type: number
+          format: double
         modifier:
           $ref: '#/components/schemas/FieldValueFactorModifier'
       required:
@@ -554,6 +563,7 @@ components:
         seed:
           oneOf:
             - type: number
+              format: int32
             - type: string
     ScriptScoreFunction:
       type: object
@@ -579,9 +589,11 @@ components:
             max_expansions:
               description: Maximum number of variations created.
               type: number
+              format: int32
             prefix_length:
               description: Number of beginning characters left unchanged when creating expansions.
               type: number
+              format: int32
             rewrite:
               $ref: '_common.yaml#/components/schemas/MultiTermQueryRewrite'
             transpositions:
@@ -696,11 +708,13 @@ components:
                 Maximum number of child documents that match the query allowed for a returned parent document.
                 If the parent document exceeds this limit, it is excluded from the search results.
               type: number
+              format: int32
             min_children:
               description: |-
                 Minimum number of child documents that match the query required to match the query for a returned parent document.
                 If the parent document does not meet this limit, it is excluded from the search results.
               type: number
+              format: int32
             query:
               $ref: '#/components/schemas/QueryContainer'
             score_mode:
@@ -791,6 +805,7 @@ components:
             Maximum number of positions between the matching terms.
             Intervals produced by the rules further apart than this are not considered matches.
           type: number
+          format: int32
         ordered:
           description: If `true`, intervals produced by the rules should appear in the order in which they are specified.
           type: boolean
@@ -861,6 +876,7 @@ components:
         prefix_length:
           description: Number of beginning characters left unchanged when creating expansions.
           type: number
+          format: int32
         term:
           description: The term to match.
           type: string
@@ -882,6 +898,7 @@ components:
             Maximum number of positions between the matching terms.
             Terms further apart than this are not considered matches.
           type: number
+          format: int32
         ordered:
           description: If `true`, matching terms must appear in their specified order.
           type: boolean
@@ -942,6 +959,7 @@ components:
             cutoff_frequency:
               deprecated: true
               type: number
+              format: float
             fuzziness:
               $ref: '_common.yaml#/components/schemas/Fuzziness'
             fuzzy_rewrite:
@@ -955,6 +973,7 @@ components:
             max_expansions:
               description: Maximum number of terms to which the query will expand.
               type: number
+              format: int32
             minimum_should_match:
               $ref: '_common.yaml#/components/schemas/MinimumShouldMatch'
             operator:
@@ -962,6 +981,7 @@ components:
             prefix_length:
               description: Number of beginning characters left unchanged for fuzzy matching.
               type: number
+              format: int32
             query:
               description: Text, number, boolean value or date you wish to find in the provided field.
               oneOf:
@@ -1001,6 +1021,7 @@ components:
                 Maximum number of terms to which the query will expand.
                 Can be applied to the term subqueries constructed for all terms but the final term.
               type: number
+              format: int32
             minimum_should_match:
               $ref: '_common.yaml#/components/schemas/MinimumShouldMatch'
             operator:
@@ -1010,6 +1031,7 @@ components:
                 Number of beginning characters left unchanged for fuzzy matching.
                 Can be applied to the term subqueries constructed for all terms but the final term.
               type: number
+              format: int32
             query:
               description: |-
                 Terms you wish to find in the provided field.
@@ -1035,6 +1057,7 @@ components:
             slop:
               description: Maximum number of positions allowed between matching tokens.
               type: number
+              format: int32
             zero_terms_query:
               $ref: '#/components/schemas/ZeroTermsQuery'
           required:
@@ -1050,12 +1073,14 @@ components:
             max_expansions:
               description: Maximum number of terms to which the last provided term of the query value will expand.
               type: number
+              format: int32
             query:
               description: Text you wish to find in the provided field.
               type: string
             slop:
               description: Maximum number of positions allowed between matching tokens.
               type: number
+              format: int32
             zero_terms_query:
               $ref: '#/components/schemas/ZeroTermsQuery'
           required:
@@ -1076,6 +1101,7 @@ components:
                 This sets the boost factor to use when using this feature.
                 Defaults to deactivated (0).
               type: number
+              format: float
             fail_on_unsupported_field:
               description: Controls whether the query should fail (throw an exception) if any of the specified fields are not of the supported types (`text` or `keyword`).
               type: boolean
@@ -1099,25 +1125,31 @@ components:
             max_doc_freq:
               description: The maximum document frequency above which the terms are ignored from the input document.
               type: number
+              format: int32
             max_query_terms:
               description: The maximum number of query terms that can be selected.
               type: number
+              format: int32
             max_word_length:
               description: |-
                 The maximum word length above which the terms are ignored.
                 Defaults to unbounded (`0`).
               type: number
+              format: int32
             min_doc_freq:
               description: The minimum document frequency below which the terms are ignored from the input document.
               type: number
+              format: int32
             minimum_should_match:
               $ref: '_common.yaml#/components/schemas/MinimumShouldMatch'
             min_term_freq:
               description: The minimum term frequency below which the terms are ignored from the input document.
               type: number
+              format: int32
             min_word_length:
               description: The minimum word length below which the terms are ignored.
               type: number
+              format: int32
             per_field_analyzer:
               description: Overrides the default analyzer.
               type: object
@@ -1183,6 +1215,7 @@ components:
             cutoff_frequency:
               deprecated: true
               type: number
+              format: float
             fields:
               $ref: '_common.yaml#/components/schemas/Fields'
             fuzziness:
@@ -1200,6 +1233,7 @@ components:
             max_expansions:
               description: Maximum number of terms to which the query will expand.
               type: number
+              format: int32
             minimum_should_match:
               $ref: '_common.yaml#/components/schemas/MinimumShouldMatch'
             operator:
@@ -1207,15 +1241,18 @@ components:
             prefix_length:
               description: Number of beginning characters left unchanged for fuzzy matching.
               type: number
+              format: int32
             query:
               description: Text, number, boolean value or date you wish to find in the provided field.
               type: string
             slop:
               description: Maximum number of positions allowed between matching tokens.
               type: number
+              format: int32
             tie_breaker:
               description: Determines how scores for each per-term blended query and scores across groups are combined.
               type: number
+              format: float
             type:
               $ref: '#/components/schemas/TextQueryType'
             zero_terms_query:
@@ -1270,8 +1307,10 @@ components:
           type: integer
         min_score:
           type: number
+          format: float
         max_distance:
           type: number
+          format: float
         filter:
           $ref: '#/components/schemas/QueryContainer'
     ParentIdQuery:
@@ -1408,9 +1447,11 @@ components:
             fuzzy_max_expansions:
               description: Maximum number of terms to which the query expands for fuzzy matching.
               type: number
+              format: int32
             fuzzy_prefix_length:
               description: Number of beginning characters left unchanged for fuzzy matching.
               type: number
+              format: int32
             fuzzy_rewrite:
               $ref: '_common.yaml#/components/schemas/MultiTermQueryRewrite'
             fuzzy_transpositions:
@@ -1422,11 +1463,13 @@ components:
             max_determinized_states:
               description: Maximum number of automaton states required for the query.
               type: number
+              format: int32
             minimum_should_match:
               $ref: '_common.yaml#/components/schemas/MinimumShouldMatch'
             phrase_slop:
               description: Maximum number of positions allowed between matching tokens for phrases.
               type: number
+              format: int32
             query:
               description: Query string you wish to parse and use for search.
               type: string
@@ -1445,6 +1488,7 @@ components:
             tie_breaker:
               description: How to combine the queries generated from the individual search terms in the resulting `dis_max` query.
               type: number
+              format: float
             time_zone:
               $ref: '_common.yaml#/components/schemas/TimeZone'
             type:
@@ -1539,6 +1583,7 @@ components:
             pivot:
               description: Configurable pivot value so that the result will be less than 0.5.
               type: number
+              format: float
     RankFeatureFunction:
       type: object
     RankFeatureFunctionLogarithm:
@@ -1549,6 +1594,7 @@ components:
             scaling_factor:
               description: Configurable scaling factor.
               type: number
+              format: float
           required:
             - scaling_factor
     RankFeatureFunctionLinear:
@@ -1563,9 +1609,11 @@ components:
             pivot:
               description: Configurable pivot value so that the result will be less than 0.5.
               type: number
+              format: float
             exponent:
               description: Configurable Exponent.
               type: number
+              format: float
           required:
             - exponent
             - pivot
@@ -1585,6 +1633,7 @@ components:
             max_determinized_states:
               description: Maximum number of automaton states required for the query.
               type: number
+              format: int32
             rewrite:
               $ref: '_common.yaml#/components/schemas/MultiTermQueryRewrite'
             value:
@@ -1624,6 +1673,7 @@ components:
             min_score:
               description: Documents with a score lower than this floating point number are excluded from the search results.
               type: number
+              format: float
             query:
               $ref: '#/components/schemas/QueryContainer'
             script:
@@ -1661,9 +1711,11 @@ components:
             fuzzy_max_expansions:
               description: Maximum number of terms to which the query expands for fuzzy matching.
               type: number
+              format: int32
             fuzzy_prefix_length:
               description: Number of beginning characters left unchanged for fuzzy matching.
               type: number
+              format: int32
             fuzzy_transpositions:
               description: If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).
               type: boolean
@@ -1762,6 +1814,7 @@ components:
             end:
               description: Controls the maximum end position permitted in a match.
               type: number
+              format: int32
             match:
               $ref: '#/components/schemas/SpanQuery'
           required:
@@ -1799,6 +1852,7 @@ components:
             slop:
               description: Controls the maximum number of intervening unmatched positions permitted.
               type: number
+              format: int32
           required:
             - clauses
     SpanNotQuery:
@@ -1811,6 +1865,7 @@ components:
                 The number of tokens from within the include span that can't have overlap with the exclude span.
                 Equivalent to setting both `pre` and `post`.
               type: number
+              format: int32
             exclude:
               $ref: '#/components/schemas/SpanQuery'
             include:
@@ -1818,9 +1873,11 @@ components:
             post:
               description: The number of tokens after the include span that can't have overlap with the exclude span.
               type: number
+              format: int32
             pre:
               description: The number of tokens before the include span that can't have overlap with the exclude span.
               type: number
+              format: int32
           required:
             - exclude
             - include


### PR DESCRIPTION
### Description

spec field  -->  OpenSearch Core reference link

boost ->  https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/QueryBuilder.java#L85

cutoff_frequency -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/CommonTermsQueryBuilder.java#L352C54-L352C64

tie_breaker -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/DisMaxQueryBuilder.java#L64C31-L64C50


max_boost -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/functionscore/FunctionScoreQueryBuilder.java#L559


min_score -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreQueryBuilder.java#L100


weight -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/common/lucene/search/function/WeightFactorFunction.java#L52


factor -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/common/lucene/search/function/FieldValueFactorFunction.java#L71

missing -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/common/lucene/search/function/FieldValueFactorFunction.java#L73

seed -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/functionscore/RandomScoreFunctionBuilder.java#L101

max_expansions -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/FuzzyQueryBuilder.java#L68C29-L68C51

prefix_length -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/FuzzyQueryBuilder.java#L65


max_children -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/search/sort/NestedSortBuilder.java#L159


max_gaps -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/IntervalsSourceProvider.java#L243

prefix_length -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/FuzzyQueryBuilder.java#L65

slop -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/MatchPhraseQueryBuilder.java#L137


https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java#L107

max_doc_freq -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java#L103

max_query_terms -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java#L100

MAX_WORD_LENGTH -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java#L105


MIN_DOC_FREQ -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/MoreLikeThisQueryBuilder.java#L102

min_score -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/functionscore/ScriptScoreQueryBuilder.java#L100C19-L100C27


max_distance -> https://github.com/opensearch-project/neural-search/blob/10ad4737e4a356f54068bd074881a46db0741610/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java#L274

fuzzy_max_expansions -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java#L80

fuzzy_prefix_length -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java#L79

max_determinized_states -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java#L711

PHRASE_SLOP_FIELD -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/QueryStringQueryBuilder.java#L723

pivot -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/modules/mapper-extras/src/main/java/org/opensearch/index/query/RankFeatureQueryBuilder.java#L222

exponent -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/modules/mapper-extras/src/main/java/org/opensearch/index/query/RankFeatureQueryBuilder.java#L225

scaling_factor -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/modules/mapper-extras/src/main/java/org/opensearch/index/query/RankFeatureQueryBuilder.java#L85


max_determinized_states -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/search/suggest/completion/RegexOptions.java#L124

fuzzy_max_expansions -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/SimpleQueryStringBuilder.java#L104

fuzzy_prefix_length -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/SimpleQueryStringBuilder.java#L102

end -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/IntervalBuilder.java#L275

dist -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/SpanNotQueryBuilder.java#L132

post -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/SpanNotQueryBuilder.java#L158

pre -> https://github.com/opensearch-project/OpenSearch/blob/1ee858fc8cc631d35c4a48b2a53d4ab6009e2c2b/server/src/main/java/org/opensearch/index/query/SpanNotQueryBuilder.java#L142

### Issues Resolved
#596 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
