### PR TITLE
update with more accurate numeric type in _core.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed create/delete/index operation in `_bulk` ([#582](https://github.com/opensearch-project/opensearch-api-specification/pull/582))
 - Add `mode` and `compression` to k-NN index creation and search, and add `rescore` and `oversample_factor` to k-NN search ([#588](https://github.com/opensearch-project/opensearch-api-specification/pull/588))
 - Fixed `/{index}/_search` with aggregations ([#576](https://github.com/opensearch-project/opensearch-api-specification/pull/576))
-- Fixed inaccurate numeric type in DSL ([#597](https://github.com/opensearch-project/opensearch-api-specification/pull/597))
+- Fixed inaccurate numeric type ([#597](https://github.com/opensearch-project/opensearch-api-specification/pull/597))([#598](https://github.com/opensearch-project/opensearch-api-specification/pull/598))
 
 ### Security
 

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2306,6 +2306,7 @@ components:
               max_docs:
                 description: The maximum number of documents to delete.
                 type: number
+                format: int32
               query:
                 $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
               slice:
@@ -2446,10 +2447,12 @@ components:
               max_docs:
                 description: The maximum number of documents to reindex.
                 type: number
+                format: int32
               script:
                 $ref: '../schemas/_common.yaml#/components/schemas/Script'
               size:
                 type: number
+                format: int32
               source:
                 $ref: '../schemas/_core.reindex.yaml#/components/schemas/Source'
             required:
@@ -2536,6 +2539,7 @@ components:
                   By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.
                   To page through more hits, use the `search_after` parameter.
                 type: number
+                format: int32
               highlight:
                 $ref: '../schemas/_core.search.yaml#/components/schemas/Highlight'
               track_total_hits:
@@ -2547,6 +2551,7 @@ components:
                   type: object
                   additionalProperties:
                     type: number
+                    format: float
               docvalue_fields:
                 description: |-
                   Array of wildcard (`*`) patterns.
@@ -2561,6 +2566,7 @@ components:
                   Minimum `_score` for matching documents.
                   Documents with a lower `_score` are not included in the search results.
                 type: number
+                format: float
               post_filter:
                 $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
               profile:
@@ -2590,6 +2596,7 @@ components:
                   By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.
                   To page through more hits, use the `search_after` parameter.
                 type: number
+                format: int32
               slice:
                 $ref: '../schemas/_common.yaml#/components/schemas/SlicedScroll'
               sort:
@@ -2616,6 +2623,7 @@ components:
                   Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
                   If set to `0` (default), the query does not terminate early.
                 type: number
+                format: int32
               timeout:
                 description: |-
                   Specifies the period of time to wait for a response from each shard.
@@ -2733,6 +2741,7 @@ components:
               max_docs:
                 description: The maximum number of documents to update.
                 type: number
+                format: int32
               query:
                 $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
               script:
@@ -2761,8 +2770,10 @@ components:
                   maxProperties: 1
               took:
                 type: number
+                format: int64
               ingest_took:
                 type: number
+                format: int64
             required:
               - errors
               - items
@@ -2785,8 +2796,10 @@ components:
                   maxProperties: 1
               took:
                 type: number
+                format: int64
               ingest_took:
                 type: number
+                format: int64
             required:
               - errors
               - items
@@ -2801,6 +2814,7 @@ components:
                 type: boolean
               num_freed:
                 type: number
+                format: int32
             required:
               - num_freed
               - succeeded
@@ -2814,6 +2828,7 @@ components:
                 type: boolean
               count:
                 type: number
+                format: int64
               _shards:
                 $ref: '../schemas/_common.yaml#/components/schemas/ShardStatistics'
             required:
@@ -3072,6 +3087,7 @@ components:
               metric_score:
                 description: The overall evaluation quality calculated by the defined metric
                 type: number
+                format: double
               details:
                 description: The details section contains one entry for every query in the original requests section, keyed by the search request id
                 type: object
@@ -3181,6 +3197,7 @@ components:
             properties:
               took:
                 type: number
+                format: int64
               timed_out:
                 type: boolean
               _shards:
@@ -3199,8 +3216,10 @@ components:
                   type: object
               max_score:
                 type: number
+                format: float
               num_reduce_phases:
                 type: number
+                format: int32
               profile:
                 $ref: '../schemas/_core.search.yaml#/components/schemas/Profile'
               pit_id:
@@ -3238,6 +3257,7 @@ components:
                   $ref: '../schemas/_core.termvectors.yaml#/components/schemas/TermVector'
               took:
                 type: number
+                format: int64
               _version:
                 $ref: '../schemas/_common.yaml#/components/schemas/VersionNumber'
             required:
@@ -3570,6 +3590,7 @@ components:
       description: Sets the minimum `_score` value that documents must have to be included in the result.
       schema:
         type: number
+        format: float
       style: form
     count::query.preference:
       in: query
@@ -3604,6 +3625,7 @@ components:
         OpenSearch collects documents before sorting.
       schema:
         type: number
+        format: int32
       style: form
     create::path.id:
       in: path
@@ -3750,6 +3772,7 @@ components:
       description: Only perform the operation if the document has this primary term.
       schema:
         type: number
+        format: int64
       style: form
     delete::query.if_seq_no:
       in: query
@@ -3913,6 +3936,7 @@ components:
       description: Starting offset.
       schema:
         type: number
+        format: int32
         default: 0
       style: form
     delete_by_query::query.ignore_unavailable:
@@ -3937,6 +3961,7 @@ components:
         Defaults to all documents.
       schema:
         type: number
+        format: int32
       style: form
     delete_by_query::query.preference:
       in: query
@@ -3977,6 +4002,7 @@ components:
       description: The throttle for this request in sub-requests per second.
       schema:
         type: number
+        format: float
         default: 0
       style: form
     delete_by_query::query.routing:
@@ -3999,6 +4025,7 @@ components:
       description: Size of the scroll request that powers the operation.
       schema:
         type: number
+        format: int32
         default: 100
       style: form
     delete_by_query::query.search_timeout:
@@ -4066,6 +4093,7 @@ components:
         Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
       schema:
         type: number
+        format: int32
       style: form
     delete_by_query::query.timeout:
       in: query
@@ -4114,6 +4142,7 @@ components:
       description: The throttle for this request in sub-requests per second.
       schema:
         type: number
+        format: float
       style: form
     delete_script::path.id:
       in: path
@@ -4706,6 +4735,7 @@ components:
       description: Only perform the operation if the document has this primary term.
       schema:
         type: number
+        format: int64
       style: form
     index::query.if_seq_no:
       in: query
@@ -4886,6 +4916,7 @@ components:
       description: Maximum number of concurrent searches the multi search API can execute.
       schema:
         type: number
+        format: int32
       style: form
     msearch::query.max_concurrent_shard_requests:
       in: query
@@ -4893,6 +4924,7 @@ components:
       description: Maximum number of concurrent shard requests that each sub-search request executes per node.
       schema:
         type: number
+        format: int32
         default: 5
       style: form
     msearch::query.pre_filter_shard_size:
@@ -4901,6 +4933,7 @@ components:
       description: Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method i.e., if date filters are mandatory to match but the shard bounds and the query are disjoint.
       schema:
         type: number
+        format: int32
       style: form
     msearch::query.rest_total_hits_as_int:
       in: query
@@ -4949,6 +4982,7 @@ components:
       description: Maximum number of concurrent searches the API can run.
       schema:
         type: number
+        format: int32
       style: form
     msearch_template::query.rest_total_hits_as_int:
       in: query
@@ -5198,6 +5232,7 @@ components:
         Defaults to no throttle.
       schema:
         type: number
+        format: float
         default: 0
       style: form
     reindex::query.scroll:
@@ -5257,6 +5292,7 @@ components:
       description: The throttle for this request in sub-requests per second.
       schema:
         type: number
+        format: float
       style: form
     render_search_template::path.id:
       in: path
@@ -5390,6 +5426,7 @@ components:
         This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
       schema:
         type: number
+        format: int32
         default: 512
       style: form
     search::query.ccs_minimize_roundtrips:
@@ -5452,6 +5489,7 @@ components:
         To page through more hits, use the `search_after` parameter.
       schema:
         type: number
+        format: int32
         default: 0
       style: form
     search::query.ignore_throttled:
@@ -5493,6 +5531,7 @@ components:
         This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.
       schema:
         type: number
+        format: int32
         default: 5
       style: form
     search::query.pre_filter_shard_size:
@@ -5507,6 +5546,7 @@ components:
         the primary sort of the query targets an indexed field.
       schema:
         type: number
+        format: int32
       style: form
     search::query.preference:
       in: query
@@ -5606,6 +5646,7 @@ components:
         To page through more hits, use the `search_after` parameter.
       schema:
         type: number
+        format: int32
         default: 10
       style: form
     search::query.sort:
@@ -5663,6 +5704,7 @@ components:
         This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
       schema:
         type: number
+        format: int32
       style: form
     search::query.suggest_text:
       in: query
@@ -5687,6 +5729,7 @@ components:
         If set to `0` (default), the query does not terminate early.
       schema:
         type: number
+        format: int32
       style: form
     search::query.timeout:
       in: query
@@ -6061,6 +6104,7 @@ components:
       description: Only perform the operation if the document has this primary term.
       schema:
         type: number
+        format: int64
       style: form
     update::query.if_seq_no:
       in: query
@@ -6101,6 +6145,7 @@ components:
       description: Specify how many times should the operation be retried when a conflict occurs.
       schema:
         type: number
+        format: int32
         default: 0
       style: form
     update::query.routing:
@@ -6238,6 +6283,7 @@ components:
       description: Starting offset.
       schema:
         type: number
+        format: int32
         default: 0
       style: form
     update_by_query::query.ignore_unavailable:
@@ -6262,6 +6308,7 @@ components:
         Defaults to all documents.
       schema:
         type: number
+        format: int32
       style: form
     update_by_query::query.pipeline:
       in: query
@@ -6310,6 +6357,7 @@ components:
       description: The throttle for this request in sub-requests per second.
       schema:
         type: number
+        format: float
         default: 0
       style: form
     update_by_query::query.routing:
@@ -6332,6 +6380,7 @@ components:
       description: Size of the scroll request that powers the operation.
       schema:
         type: number
+        format: int32
         default: 100
       style: form
     update_by_query::query.search_timeout:
@@ -6395,6 +6444,7 @@ components:
         Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
       schema:
         type: number
+        format: int32
       style: form
     update_by_query::query.timeout:
       in: query
@@ -6443,4 +6493,5 @@ components:
       description: The throttle for this request in sub-requests per second.
       schema:
         type: number
+        format: float
       style: form


### PR DESCRIPTION
### Description
for _core.yaml

max_docs (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/modules/reindex/src/main/java/org/opensearch/index/reindex/AbstractBaseReindexRestHandler.java#L117

from (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/search/internal/SearchContext.java#L368

indices_boost (float) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java#L1340C20-L1340C99

min_score (float) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java#L1281

size (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java#L170

terminate_after (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/search/builder/SearchSourceBuilder.java#L193

took / ingest_tool (int64) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/action/bulk/BulkResponse.java#L201

num_freed (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/action/search/ClearScrollResponse.java#L77 

count (long) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/client/rest-high-level/src/main/java/org/opensearch/client/core/CountResponse.java#L60

metric_score (double) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/EvalQueryQuality.java#L61

num_reduce_phases (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/action/search/SearchResponse.java#L412

requestsPerSecondString (float) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/modules/reindex/src/main/java/org/opensearch/index/reindex/AbstractBaseReindexRestHandler.java#L160

requests_per_second (float) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/modules/reindex/src/main/java/org/opensearch/index/reindex/RethrottleRequest.java#L53

if_primary_term (int64) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/action/bulk/BulkRequestParser.java#L236

max_concurrent_searches (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/modules/rank-eval/src/main/java/org/opensearch/index/rankeval/RankEvalSpec.java#L119

max_concurrent_shard_requests (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/rest/action/search/RestMultiSearchAction.java#L138

pre_filter_shard_size (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/action/search/SearchRequest.java#L82

batched_reduce_size (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/action/search/SearchRequest.java#L108

suggest_size (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java#L334

retry_on_conflict (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/action/bulk/BulkRequestParser.java#L238 

scroll_size (int32) -> https://github.com/opensearch-project/OpenSearch/blob/4e3a6d038dfc37660c7b9e47f570a32b0f2be4d4/server/src/main/java/org/opensearch/index/reindex/AbstractBulkByScrollRequest.java#L70



### Issues Resolved
#596

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
