### PR TITLE
Allow shortcut specifying InlineScript as just a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added the `context` query param to the `put_script` APIs ([#586](https://github.com/opensearch-project/opensearch-api-specification/pull/586))
 - Added `persian_stem` filter ([#592](https://github.com/opensearch-project/opensearch-api-specification/pull/592))
 - Added `404` response for `DELETE /{index}`, `GET /{index}/_doc/{id}`, `DELETE /{index}/_doc/{id}` ([#589](https://github.com/opensearch-project/opensearch-api-specification/pull/589))
+- Added ability to pass `InlineScript` as a simple string ([#605](https://github.com/opensearch-project/opensearch-api-specification/pull/605))
 
 ### Changed
 

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -470,6 +470,12 @@ components:
               required:
                 - source
     ScriptLanguage:
+      anyOf:
+        - title: builtin
+          $ref: '#/components/schemas/BuiltinScriptLanguage'
+        - title: custom
+          type: string
+    BuiltinScriptLanguage:
       type: string
       enum:
         - expression

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -455,20 +455,20 @@ components:
         - title: source
           type: string
         - allOf:
-          - $ref: '#/components/schemas/ScriptBase'
-          - type: object
-            properties:
-              lang:
-                $ref: '#/components/schemas/ScriptLanguage'
-              options:
-                type: object
-                additionalProperties:
+            - $ref: '#/components/schemas/ScriptBase'
+            - type: object
+              properties:
+                lang:
+                  $ref: '#/components/schemas/ScriptLanguage'
+                options:
+                  type: object
+                  additionalProperties:
+                    type: string
+                source:
+                  description: The script source.
                   type: string
-              source:
-                description: The script source.
-                type: string
-            required:
-              - source
+              required:
+                - source
     ScriptLanguage:
       type: string
       enum:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -451,21 +451,24 @@ components:
         - title: stored
           $ref: '#/components/schemas/StoredScriptId'
     InlineScript:
-      allOf:
-        - $ref: '#/components/schemas/ScriptBase'
-        - type: object
-          properties:
-            lang:
-              $ref: '#/components/schemas/ScriptLanguage'
-            options:
-              type: object
-              additionalProperties:
+      oneOf:
+        - title: source
+          type: string
+        - allOf:
+          - $ref: '#/components/schemas/ScriptBase'
+          - type: object
+            properties:
+              lang:
+                $ref: '#/components/schemas/ScriptLanguage'
+              options:
+                type: object
+                additionalProperties:
+                  type: string
+              source:
+                description: The script source.
                 type: string
-            source:
-              description: The script source.
-              type: string
-          required:
-            - source
+            required:
+              - source
     ScriptLanguage:
       type: string
       enum:

--- a/tests/default/_core/search/query/script.yaml
+++ b/tests/default/_core/search/query/script.yaml
@@ -1,0 +1,78 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test ScriptQuery functionality.
+
+prologues:
+  - path: /movies
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            title:
+              type: keyword
+            year:
+              type: integer
+
+  - path: /movies/_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - index:
+            _id: 1
+        - title: The Lion King
+          year: 1994
+        - index:
+            _id: 2
+        - title: Beauty and the Beast
+          year: 1991
+        - index:
+            _id: 3
+        - title: Aladdin
+          year: 1992
+        - index:
+            _id: 4
+        - title: The Little Mermaid
+          year: 1989
+    status: [200]
+
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+
+chapters:
+  - synopsis: Search using ScriptQuery with filtering to movies with odd years.
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request:
+      payload:
+        query:
+          bool:
+            filter:
+              script:
+                script: "doc['year'].value % 2 == 1"
+        sort:
+          - year:
+              order: desc
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 2
+          hits:
+            - _id: '2'
+              _source:
+                title: Beauty and the Beast
+                year: 1991
+            - _id: '4'
+              _source:
+                title: The Little Mermaid
+                year: 1989


### PR DESCRIPTION
### Description
Allow shortcut specifying InlineScript as just a string

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
