### PR TITLE
Adds tests for _mget.

### DIFF
--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -791,7 +791,7 @@ components:
         - title: includes
           type: array
           items:
-            $ref: '_common.yaml#/components/schemas/Field' 
+            $ref: '_common.yaml#/components/schemas/Field'
         - title: filter
           $ref: '#/components/schemas/SourceFilter'
     SourceFilter:

--- a/tests/default/_core/mget.yaml
+++ b/tests/default/_core/mget.yaml
@@ -1,0 +1,47 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test document multi-get.
+epilogues:
+  - path: /books
+    method: DELETE
+    status: [200, 404]
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: books, _id: book1}}
+        - {author: Harper Lee, title: To Kill a Mockingbird, year: 60}
+        - {create: {_index: movies, _id: movie1}}
+        - {director: Bennett Miller, title: The Cruise, year: 1998}
+        - {create: {_index: movies, _id: movie2}}
+        - {director: Nicolas Winding Refn, title: Drive, year: 1960}
+chapters:
+  - synopsis: Retrieve documents from multiple indexes.
+    path: /_mget
+    method: GET
+    request:
+      payload:
+        docs:
+          - _index: movies
+            _id: movie1
+            _source: true
+          - _index: books
+            _id: book1
+            _source:
+              includes:
+                - title
+    response:
+      status: 200
+      payload:
+        docs:
+          - _index: movies
+            _id: movie1
+          - _index: books
+            _id: book1

--- a/tests/default/indices/mget.yaml
+++ b/tests/default/indices/mget.yaml
@@ -1,0 +1,48 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test document multi-get.
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: movies, _id: movie1}}
+        - {director: Bennett Miller, title: The Cruise, year: 1998}
+        - {create: {_index: movies, _id: movie2}}
+        - {director: Nicolas Winding Refn, title: Drive, year: 1960}
+chapters:
+  - synopsis: Retrieve documents from multiple indexes.
+    path: /{index}/_mget
+    method: GET
+    parameters:
+      index: movies
+    request:
+      payload:
+        docs:
+          - _id: movie1
+            _source:
+              excludes:
+                - title
+          - _id: movie1
+            _source: false
+          - _id: movie2
+            _source:
+              includes:
+                - title
+    response:
+      status: 200
+      payload:
+        docs:
+          - _index: movies
+            _id: movie1
+          - _index: movies
+            _id: movie1
+          - _index: movies
+            _id: movie2


### PR DESCRIPTION
### Description

Adds tests for `_mget`.

Note that `excludes` and `includes` are the correct terms to use, not `exclude` and `include` which [are deprecated](https://github.com/opensearch-project/OpenSearch/blob/ba0ccfa50828688ea5793fc1f1fd08c6a21d5f92/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourceContext.java#L65).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
