### PR TITLE
add phone number analysis plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added a spec style checker [#620](https://github.com/opensearch-project/opensearch-api-specification/pull/620).
 - Added `remote_store` to node `Stats` ([#643](https://github.com/opensearch-project/opensearch-api-specification/pull/643))
 - Added `/_cluster/stats/{metric}/nodes/{node_id}` and `/_cluster/stats/{metric}/{index_metric}/nodes/{node_id}` ([#639](https://github.com/opensearch-project/opensearch-api-specification/pull/639))
+- Added `PhoneAnalyzer` from `analysis-phonenumber` plugin ([#609](https://github.com/opensearch-project/opensearch-api-specification/pull/609))
 
 ### Changed
 

--- a/spec/schemas/_common.analysis.yaml
+++ b/spec/schemas/_common.analysis.yaml
@@ -27,6 +27,7 @@ components:
         - $ref: '#/components/schemas/DutchAnalyzer'
         - $ref: '#/components/schemas/SmartcnAnalyzer'
         - $ref: '#/components/schemas/CjkAnalyzer'
+        - $ref: '#/components/schemas/PhoneAnalyzer'
     CustomAnalyzer:
       type: object
       properties:
@@ -367,6 +368,17 @@ components:
           $ref: '#/components/schemas/StopWords'
         stopwords_path:
           type: string
+    PhoneAnalyzer:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - phone
+            - phone-search
+        phone-region:
+          type: string
+          description: Optional ISO 3166 country code, defaults to "ZZ" (unknown region).
     CharFilter:
       oneOf:
         - title: name

--- a/tests/plugins/analysis/Dockerfile
+++ b/tests/plugins/analysis/Dockerfile
@@ -4,3 +4,4 @@ ARG OPENSEARCH_DOCKER_REF
 
 FROM ${OPENSEARCH_DOCKER_HUB_PROJECT}/opensearch:${OPENSEARCH_VERSION}${OPENSEARCH_DOCKER_REF}
 RUN ./bin/opensearch-plugin install -b analysis-icu
+RUN ./bin/opensearch-plugin install -b analysis-phonenumber

--- a/tests/plugins/analysis/indices/analyze/analyzer/phone.yaml
+++ b/tests/plugins/analysis/indices/analyze/analyzer/phone.yaml
@@ -1,0 +1,38 @@
+$schema: ../../../../../../json_schemas/test_story.schema.yaml
+
+description: Test /{index}/_analyze for the phone and phone-search analyzers.
+prologues:
+  - path: /example-phone
+    method: PUT
+    request:
+      payload:
+        settings:
+          index:
+            analysis:
+              analyzer:
+                phone-ch:
+                  type: phone
+                  phone-region: CH
+                phone-search-ch:
+                  type: phone-search
+                  phone-region: CH
+epilogues:
+  - path: /example-phone
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Analyze phone number.
+    path: /{index}/_analyze
+    method: POST
+    parameters:
+      index: example-phone
+    request:
+      payload:
+        analyzer: phone-ch
+        text: '+41 60 555 12 34'
+    response:
+      status: 200
+      payload:
+        tokens:
+          - token: '+41 60 555 12 34'
+          - token: '6055512'


### PR DESCRIPTION
### Description
this is part of opensearch-project/OpenSearch#11326. the actual implementation was done opensearch-project/OpenSearch#15915. see the commit message on the PR for further details.

the new test group `analysis` has been added so that it can later be extended with all other optional language analyzers (which are currently also not covered).

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
