### PR TITLE
fix snapshot restore and recovery endpoint

### DIFF
--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -427,10 +427,11 @@ components:
           schema:
             type: object
             properties:
+              accepted:
+                description: Equals `true` if the restore was accepted. Present when the request had `wait_for_completion` set to `false`
+                type: boolean
               snapshot:
                 $ref: '../schemas/snapshot.restore.yaml#/components/schemas/SnapshotRestore'
-            required:
-              - snapshot
     snapshot.status@200:
       content:
         application/json:

--- a/spec/schemas/indices.recovery.yaml
+++ b/spec/schemas/indices.recovery.yaml
@@ -175,6 +175,14 @@ components:
           $ref: '_common.yaml#/components/schemas/Uuid'
         index:
           $ref: '_common.yaml#/components/schemas/IndexName'
+        isSearchableSnapshot:
+          type: boolean
+        remoteStoreIndexShallowCopy:
+          type: boolean
+        sourceRemoteStoreRepository:
+          type: ['null', string]
+        sourceRemoteTranslogRepository:
+          type: ['null', string]
     RecoveryStartStatus:
       type: object
       properties:

--- a/tests/snapshot/snapshot/restore.yaml
+++ b/tests/snapshot/snapshot/restore.yaml
@@ -1,0 +1,101 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test _snapshot/{repository}/{snapshot}/_restore endpoints.
+epilogues:
+  - path: /_snapshot/{repository}/{snapshot}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      repository: my-fs-repository
+      snapshot: my-test-snapshot
+  - path: /_snapshot/{repository}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      repository: my-fs-repository
+  - path: /restore-index-wait-true
+    method: DELETE
+    status: [200, 404]
+  - path: /restore-index-wait-false
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /_snapshot/{repository}
+    method: PUT
+    parameters:
+      repository: my-fs-repository
+    request:
+      payload:
+        type: fs
+        settings:
+          location: /tmp/opensearch/repo
+  - path: /restore-index-wait-true
+    method: PUT
+  - path: /restore-index-wait-false
+    method: PUT
+  - path: /_snapshot/{repository}/{snapshot}
+    method: PUT
+    parameters:
+      repository: my-fs-repository
+      snapshot: my-test-snapshot
+      wait_for_completion: true
+    request:
+      payload:
+        indices:
+          - restore-index-wait-false
+          - restore-index-wait-true
+        ignore_unavailable: true
+        include_global_state: false
+        partial: true
+  - path: /restore-index-wait-true
+    method: DELETE
+    status: [200, 404]
+  - path: /restore-index-wait-false
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Restore snapshot with wait_for_completion true.
+    path: /_snapshot/{repository}/{snapshot}/_restore
+    method: POST
+    parameters:
+      repository: my-fs-repository
+      snapshot: my-test-snapshot
+      wait_for_completion: true
+    request:
+      payload:
+        indices: restore-index-wait-true
+    response:
+      status: 200
+      payload:
+        snapshot:
+          snapshot: my-test-snapshot
+  - synopsis: Restore snapshot with wait_for_completion false.
+    path: /_snapshot/{repository}/{snapshot}/_restore
+    method: POST
+    parameters:
+      repository: my-fs-repository
+      snapshot: my-test-snapshot
+      wait_for_completion: false
+    request:
+      payload:
+        indices: restore-index-wait-false
+    response:
+      status: 200
+      payload:
+        accepted: true
+  - synopsis: Wait finish async restore.
+    path: /{index}/_recovery
+    warnings:
+      multiple-paths-detected: false
+    method: GET
+    parameters:
+      index: restore-index-wait-false
+    response:
+      status: 200
+      payload:
+        restore-index-wait-false:
+          shards:
+            - stage: DONE
+              type: SNAPSHOT
+    retry:
+      count: 3


### PR DESCRIPTION
### Description
Fixed snapshot restore endpoint when wait_for_completion is false.
Also fixed _recovery endpoint needed for testing when wait_for_completion is false.

### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
