### PR TITLE
Add spec for new rename_alias_pattern and rename_alias_replacement parameters to snapshot restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `PhoneAnalyzer` from `analysis-phonenumber` plugin ([#609](https://github.com/opensearch-project/opensearch-api-specification/pull/609))
 - Added `/_list/indices` & `/_list/shards` api specs ([#613](https://github.com/opensearch-project/opensearch-api-specification/pull/613))
 - Added `GET` and `HEAD /{index}/_source/{id}` returning `404` ([#673](https://github.com/opensearch-project/opensearch-api-specification/pull/673))
+- Added `rename_alias_pattern` and `rename_alias_replacment` to `/_snapshot/{repository}/{snapshot}/_restore` body parameters ([#615](https://github.com/opensearch-project/opensearch-api-specification/pull/615))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))
@@ -148,7 +149,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added API spec for `adjust_pure_negative` for bool queries ([#641](https://github.com/opensearch-project/opensearch-api-specification/pull/641))
 - Added a spec style checker [#620](https://github.com/opensearch-project/opensearch-api-specification/pull/620).
 - Added `remote_store` to node `Stats` ([#643](https://github.com/opensearch-project/opensearch-api-specification/pull/643))
-- Added `rename_alias_pattern` and `rename_alias_replacment` to `/_snapshot/{repository}/{snapshot}/_restore` body parameters ([#615](https://github.com/opensearch-project/opensearch-api-specification/pull/615))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added API spec for `adjust_pure_negative` for bool queries ([#641](https://github.com/opensearch-project/opensearch-api-specification/pull/641))
 - Added a spec style checker [#620](https://github.com/opensearch-project/opensearch-api-specification/pull/620).
 - Added `remote_store` to node `Stats` ([#643](https://github.com/opensearch-project/opensearch-api-specification/pull/643))
+- Added `rename_alias_pattern` and `rename_alias_replacment` to `/_snapshot/{repository}/{snapshot}/_restore` body parameters ([#615](https://github.com/opensearch-project/opensearch-api-specification/pull/615))
 
 ### Changed
 

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -360,8 +360,10 @@ components:
               rename_replacement:
                 type: string
               rename_alias_pattern:
+                x-version-added: '2.18'
                 type: string
               rename_alias_replacement:
+                x-version-added: '2.18'
                 type: string
             description: Details of what to restore
   responses:

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -294,7 +294,7 @@ components:
             type: object
             properties:
               ignore_unavailable:
-                description: If `true`, the request ignores data streams and indexes in `indices` that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed.
+                description: If `true`, the request ignores data streams and indexes in `indexes` that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed.
                 type: boolean
               include_global_state:
                 description: If `true`, the current cluster state is included in the snapshot. The cluster state includes persistent cluster settings, composable index templates, legacy index templates, ingest pipelines, and ILM policies. It also includes data stored in system indexes, such as Watches and task records (configurable with `feature_states`).
@@ -342,32 +342,34 @@ components:
                   type: string
               ignore_unavailable:
                 type: boolean
-                description: How to handle data streams or indices that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed. If `true`, the request ignores data streams and indices in indices that are missing or closed. Defaults to `false`.
+                description: How to handle data streams or indexes that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed. If `true`, the request ignores data streams and indexes in indexes that are missing or closed. Defaults to `false`.
               include_aliases:
                 type: boolean
-                description: How to handle index aliases from the original snapshot. If `true`, index aliases from the original snapshot are restored. If `false`, aliases along with associated indices are not restored. Defaults to `true`.
+                description: How to handle index aliases from the original snapshot. If `true`, index aliases from the original snapshot are restored. If `false`, aliases along with associated indexes are not restored. Defaults to `true`.
               include_global_state:
                 type: boolean
                 description: Whether to restore the current cluster state. If `false`, the cluster state is not restored. If true, the current cluster state is restored. Defaults to `false`.
               index_settings:
-                description: A comma-delimited list of settings to add or change in all restored indices. Use this parameter to override index settings during snapshot restoration. For data streams, these index settings are applied to the restored backing indices.
+                description: A comma-delimited list of settings to add or change in all restored indexes. Use this parameter to override index settings during snapshot restoration. For data streams, these index settings are applied to the restored backing indexes.
                 $ref: '../schemas/indices._common.yaml#/components/schemas/IndexSettings'
               indices:
-                description: A comma-delimited list of data streams and indices to restore from the snapshot. Multi-index syntax is supported. By default, a restore operation includes all data streams and indices in the snapshot. If this argument is provided, the restore operation only includes the data streams and indices that you specify.
+                description: A comma-delimited list of data streams and indexes to restore from the snapshot. Multi-index syntax is supported. By default, a restore operation includes all data streams and indexes in the snapshot. If this argument is provided, the restore operation only includes the data streams and indexes that you specify.
                 $ref: '../schemas/_common.yaml#/components/schemas/Indices'
               partial:
                 type: boolean
                 description: |-
-                  How the restore operation will behave if indices in the snapshot do not have all primary shards available. If `false`, the entire restore operation fails if any indices in the snapshot do not have all primary shards available.
-                  If `true`, allows the restoration of a partial snapshot of indices with unavailable shards. Only shards that were successfully included in the snapshot are restored. All missing shards are recreated as empty. By default, the entire restore operation fails if one or more indices included in the snapshot do not have all primary shards available. To change this behavior, set `partial` to `true`. Defaults to `false`.
+                  How the restore operation will behave if indexes in the snapshot do not have all primary shards available.
+                  If `false`, the entire restore operation fails if any indexes in the snapshot do not have all primary shards available.
+                  If `true`, allows the restoration of a partial snapshot of indexes with unavailable shards. Only shards that were successfully included in the snapshot are restored. All missing shards are recreated as empty. By default, the entire restore operation fails if one or more indexes included in the snapshot do not have all primary shards available. To change this behavior, set `partial` to `true`.
+                  Defaults to `false`.
               rename_pattern:
                 type: string
                 description: |-
-                  The pattern to apply to the restored data streams and indices. Data streams and indices matching the rename pattern will be renamed according to the `rename_replacement` setting.
+                  The pattern to apply to the restored data streams and indexes. Data streams and indexes matching the rename pattern will be renamed according to the `rename_replacement` setting.
                   The rename pattern is applied as defined by the regular expression that supports referencing the original text.
-                  The request fails if two or more data streams or indices are renamed into the same name.
-                  If you rename a restored data stream, its backing indices are also renamed. For example, if you rename the logs data stream to `recovered-logs`, the backing index `.ds-logs-1` is renamed to `.ds-recovered-logs-1`.
-                  If you rename a restored stream, ensure an index template matches the new stream name. If there are no matching index template names, the stream cannot roll over and new backing indices are not created.
+                  The request fails if two or more data streams or indexes are renamed into the same name.
+                  If you rename a restored data stream, its backing indexes are also renamed. For example, if you rename the logs data stream to `recovered-logs`, the backing index `.ds-logs-1` is renamed to `.ds-recovered-logs-1`.
+                  If you rename a restored stream, ensure an index template matches the new stream name. If there are no matching index template names, the stream cannot roll over and new backing indexes are not created.
               rename_replacement:
                 type: string
                 description: The rename replacement string.

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -359,6 +359,10 @@ components:
                 type: string
               rename_replacement:
                 type: string
+              rename_alias_pattern:
+                type: string
+              rename_alias_replacement:
+                type: string
             description: Details of what to restore
   responses:
     snapshot.cleanup_repository@200:

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -357,17 +357,27 @@ components:
                 $ref: '../schemas/_common.yaml#/components/schemas/Indices'
               partial:
                 type: boolean
-                description: How the restore operation will behave if indices in the snapshot do not have all primary shards available. If `false`, the entire restore operation fails if any indices in the snapshot do not have all primary shards available.  If `true`, allows the restoration of a partial snapshot of indices with unavailable shards. Only shards that were successfully included in the snapshot are restored. All missing shards are recreated as empty. By default, the entire restore operation fails if one or more indices included in the snapshot do not have all primary shards available. To change this behavior, set `partial` to `true`. Defaults to `false`.
+                description: |-
+                  How the restore operation will behave if indices in the snapshot do not have all primary shards available. If `false`, the entire restore operation fails if any indices in the snapshot do not have all primary shards available.
+                  If `true`, allows the restoration of a partial snapshot of indices with unavailable shards. Only shards that were successfully included in the snapshot are restored. All missing shards are recreated as empty. By default, the entire restore operation fails if one or more indices included in the snapshot do not have all primary shards available. To change this behavior, set `partial` to `true`. Defaults to `false`.
               rename_pattern:
                 type: string
-                description: The pattern to apply to the restored data streams and indices. Data streams and indices matching the rename pattern will be renamed according to the `rename_replacement` setting.  The rename pattern is applied as defined by the regular expression that supports referencing the original text.   The request fails if two or more data streams or indices are renamed into the same name. If you rename a restored data stream, its backing indices are also renamed. For example, if you rename the logs data stream to `recovered-logs`, the backing index `.ds-logs-1` is renamed to `.ds-recovered-logs-1`.  If you rename a restored stream, ensure an index template matches the new stream name. If there are no matching index template names, the stream cannot roll over and new backing indices are not created.
+                description: |-
+                  The pattern to apply to the restored data streams and indices. Data streams and indices matching the rename pattern will be renamed according to the `rename_replacement` setting.
+                  The rename pattern is applied as defined by the regular expression that supports referencing the original text.
+                  The request fails if two or more data streams or indices are renamed into the same name.
+                  If you rename a restored data stream, its backing indices are also renamed. For example, if you rename the logs data stream to `recovered-logs`, the backing index `.ds-logs-1` is renamed to `.ds-recovered-logs-1`.
+                  If you rename a restored stream, ensure an index template matches the new stream name. If there are no matching index template names, the stream cannot roll over and new backing indices are not created.
               rename_replacement:
                 type: string
                 description: The rename replacement string.
               rename_alias_pattern:
                 x-version-added: '2.18'
                 type: string
-                description: The pattern to apply to the restored aliases. Aliases matching the rename pattern will be renamed according to the `rename_alias_replacement` setting. The rename pattern is applied as defined by the regular expression that supports referencing the original text.  If two or more aliases are renamed into the same name, these aliases will be merged into one.
+                description: |-
+                  The pattern to apply to the restored aliases. Aliases matching the rename pattern will be renamed according to the `rename_alias_replacement` setting.
+                  The rename pattern is applied as defined by the regular expression that supports referencing the original text.
+                  If two or more aliases are renamed into the same name, these aliases will be merged into one.
               rename_alias_replacement:
                 x-version-added: '2.18'
                 type: string
@@ -379,7 +389,11 @@ components:
               storage_type:
                 x-version-added: '2.7'
                 type: string
-                description: '`local` indicates that all snapshot metadata and index data will be downloaded to local storage.  `remote_snapshot` indicates that snapshot metadata will be downloaded to the cluster, but the remote repository will remain the authoritative store of the index data. Data will be downloaded and cached as necessary to service queries. At least one node in the cluster must be configured with the search role in order to restore a snapshot using the type `remote_snapshot`.  Defaults to `local`.'
+                description: |-
+                  Where will be the authoritative store of the restored indexes' data.
+                  A value of `local` indicates that all snapshot metadata and index data will be downloaded to local storage.
+                  A value of `remote_snapshot` indicates that snapshot metadata will be downloaded to the cluster, but the remote repository will remain the authoritative store of the index data. Data will be downloaded and cached as necessary to service queries. At least one node in the cluster must be configured with the search role in order to restore a snapshot using the type `remote_snapshot`.
+                  Defaults to `local`.
             description: Details of what to restore
   responses:
     snapshot.cleanup_repository@200:

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -335,36 +335,51 @@ components:
           schema:
             type: object
             properties:
-              feature_states:
-                type: array
-                items:
-                  type: string
               ignore_index_settings:
+                description: A comma-delimited list of index settings that you don't want to restore from a snapshot.
                 type: array
                 items:
                   type: string
               ignore_unavailable:
                 type: boolean
+                description: How to handle data streams or indices that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed. If `true`, the request ignores data streams and indices in indices that are missing or closed. Defaults to `false`.
               include_aliases:
                 type: boolean
+                description: How to handle index aliases from the original snapshot. If `true`, index aliases from the original snapshot are restored. If `false`, aliases along with associated indices are not restored. Defaults to `true`.
               include_global_state:
                 type: boolean
+                description: Whether to restore the current cluster state. If `false`, the cluster state is not restored. If true, the current cluster state is restored. Defaults to `false`.
               index_settings:
+                description: A comma-delimited list of settings to add or change in all restored indices. Use this parameter to override index settings during snapshot restoration. For data streams, these index settings are applied to the restored backing indices.
                 $ref: '../schemas/indices._common.yaml#/components/schemas/IndexSettings'
               indices:
+                description: A comma-delimited list of data streams and indices to restore from the snapshot. Multi-index syntax is supported. By default, a restore operation includes all data streams and indices in the snapshot. If this argument is provided, the restore operation only includes the data streams and indices that you specify.
                 $ref: '../schemas/_common.yaml#/components/schemas/Indices'
               partial:
                 type: boolean
+                description: How the restore operation will behave if indices in the snapshot do not have all primary shards available. If `false`, the entire restore operation fails if any indices in the snapshot do not have all primary shards available.  If `true`, allows the restoration of a partial snapshot of indices with unavailable shards. Only shards that were successfully included in the snapshot are restored. All missing shards are recreated as empty. By default, the entire restore operation fails if one or more indices included in the snapshot do not have all primary shards available. To change this behavior, set `partial` to `true`. Defaults to `false`.
               rename_pattern:
                 type: string
+                description: The pattern to apply to the restored data streams and indices. Data streams and indices matching the rename pattern will be renamed according to the `rename_replacement` setting.  The rename pattern is applied as defined by the regular expression that supports referencing the original text.   The request fails if two or more data streams or indices are renamed into the same name. If you rename a restored data stream, its backing indices are also renamed. For example, if you rename the logs data stream to `recovered-logs`, the backing index `.ds-logs-1` is renamed to `.ds-recovered-logs-1`.  If you rename a restored stream, ensure an index template matches the new stream name. If there are no matching index template names, the stream cannot roll over and new backing indices are not created.
               rename_replacement:
                 type: string
+                description: The rename replacement string.
               rename_alias_pattern:
                 x-version-added: '2.18'
                 type: string
+                description: The pattern to apply to the restored aliases. Aliases matching the rename pattern will be renamed according to the `rename_alias_replacement` setting. The rename pattern is applied as defined by the regular expression that supports referencing the original text.  If two or more aliases are renamed into the same name, these aliases will be merged into one.
               rename_alias_replacement:
                 x-version-added: '2.18'
                 type: string
+                description: The rename replacement string for aliases.
+              source_remote_store_repository:
+                x-version-added: '2.10'
+                type: string
+                description: The name of the remote store repository of the source index being restored. If not provided, the Snapshot Restore API will use the repository that was registered when the snapshot was created.
+              storage_type:
+                x-version-added: '2.7'
+                type: string
+                description: '`local` indicates that all snapshot metadata and index data will be downloaded to local storage.  `remote_snapshot` indicates that snapshot metadata will be downloaded to the cluster, but the remote repository will remain the authoritative store of the index data. Data will be downloaded and cached as necessary to service queries. At least one node in the cluster must be configured with the search role in order to restore a snapshot using the type `remote_snapshot`.  Defaults to `local`.'
             description: Details of what to restore
   responses:
     snapshot.cleanup_repository@200:

--- a/tests/snapshot/snapshot/restore.yaml
+++ b/tests/snapshot/snapshot/restore.yaml
@@ -137,6 +137,7 @@ chapters:
         snapshot:
           snapshot: my-test-snapshot
   - synopsis: Restore snapshot with rename_alias_pattern and rename_alias_replacement.
+    version: '>= 2.18'
     path: /_snapshot/{repository}/{snapshot}/_restore
     method: POST
     parameters:

--- a/tests/snapshot/snapshot/restore.yaml
+++ b/tests/snapshot/snapshot/restore.yaml
@@ -130,7 +130,7 @@ chapters:
       payload:
         indices: stories
         rename_pattern: '^(.*)$'
-        rename_replacement: '$1_restored'
+        rename_replacement: $1_restored
     response:
       status: 200
       payload:
@@ -149,7 +149,7 @@ chapters:
         indices: stories
         include_aliases: true
         rename_alias_pattern: '^(.*)$'
-        rename_alias_replacement: '$1_restored'
+        rename_alias_replacement: $1_restored
     response:
       status: 200
       payload:

--- a/tests/snapshot/snapshot/restore.yaml
+++ b/tests/snapshot/snapshot/restore.yaml
@@ -22,7 +22,7 @@ epilogues:
   - path: /stories
     method: DELETE
     status: [200, 404]
-  - path: /renamed_stories
+  - path: /stories_restored
     method: DELETE
     status: [200, 404]
 prologues:
@@ -129,8 +129,8 @@ chapters:
     request:
       payload:
         indices: stories
-        rename_pattern: stories
-        rename_replacement: renamed_stories
+        rename_pattern: '^(.*)$'
+        rename_replacement: '$1_restored'
     response:
       status: 200
       payload:
@@ -148,8 +148,8 @@ chapters:
       payload:
         indices: stories
         include_aliases: true
-        rename_alias_pattern: stories
-        rename_alias_replacement: renamed_stories
+        rename_alias_pattern: '^(.*)$'
+        rename_alias_replacement: '$1_restored'
     response:
       status: 200
       payload:

--- a/tests/snapshot/snapshot/restore.yaml
+++ b/tests/snapshot/snapshot/restore.yaml
@@ -19,6 +19,12 @@ epilogues:
   - path: /books
     method: DELETE
     status: [200, 404]
+  - path: /stories
+    method: DELETE
+    status: [200, 404]
+  - path: /new_stories
+    method: DELETE
+    status: [200, 404]
 prologues:
   - path: /_snapshot/{repository}
     method: PUT
@@ -33,6 +39,16 @@ prologues:
     method: PUT
   - path: /books
     method: PUT
+  - path: /stories
+    method: PUT
+  - path: /_aliases
+    method: POST
+    request:
+      payload:
+        actions:
+        - add:
+            index: "stories"
+            alias: "stories_alias"
   - path: /_snapshot/{repository}/{snapshot}
     method: PUT
     parameters:
@@ -44,6 +60,7 @@ prologues:
         indices:
           - books
           - movies
+          - stories
         ignore_unavailable: true
         include_global_state: false
         partial: true
@@ -51,6 +68,9 @@ prologues:
     method: DELETE
     status: [200, 404]
   - path: /books
+    method: DELETE
+    status: [200, 404]
+  - path: /stories
     method: DELETE
     status: [200, 404]
 chapters:
@@ -99,3 +119,38 @@ chapters:
               type: SNAPSHOT
     retry:
       count: 3
+  - synopsis: Restore snapshot with rename_pattern and rename_replacement.
+    path: /_snapshot/{repository}/{snapshot}/_restore
+    method: POST
+    parameters:
+      repository: my-fs-repository
+      snapshot: my-test-snapshot
+      wait_for_completion: true
+    request:
+      payload:
+        indices: stories
+        rename_pattern: stories
+        rename_replacement: new_stories
+    response:
+      status: 200
+      payload:
+        snapshot:
+          snapshot: my-test-snapshot
+  - synopsis: Restore snapshot with rename_alias_pattern and rename_alias_replacement.
+    path: /_snapshot/{repository}/{snapshot}/_restore
+    method: POST
+    parameters:
+      repository: my-fs-repository
+      snapshot: my-test-snapshot
+      wait_for_completion: true
+    request:
+      payload:
+        indices: stories
+        include_aliases: true
+        rename_alias_pattern: stories
+        rename_alias_replacement: new_stories
+    response:
+      status: 200
+      payload:
+        snapshot:
+          snapshot: my-test-snapshot

--- a/tests/snapshot/snapshot/restore.yaml
+++ b/tests/snapshot/snapshot/restore.yaml
@@ -22,7 +22,7 @@ epilogues:
   - path: /stories
     method: DELETE
     status: [200, 404]
-  - path: /new_stories
+  - path: /renamed_stories
     method: DELETE
     status: [200, 404]
 prologues:
@@ -46,9 +46,9 @@ prologues:
     request:
       payload:
         actions:
-        - add:
-            index: "stories"
-            alias: "stories_alias"
+          - add:
+              index: stories
+              alias: stories_alias
   - path: /_snapshot/{repository}/{snapshot}
     method: PUT
     parameters:
@@ -130,7 +130,7 @@ chapters:
       payload:
         indices: stories
         rename_pattern: stories
-        rename_replacement: new_stories
+        rename_replacement: renamed_stories
     response:
       status: 200
       payload:
@@ -148,7 +148,7 @@ chapters:
         indices: stories
         include_aliases: true
         rename_alias_pattern: stories
-        rename_alias_replacement: new_stories
+        rename_alias_replacement: renamed_stories
     response:
       status: 200
       payload:


### PR DESCRIPTION
### Description
Add spec for new rename_alias_pattern and rename_alias_replacement parameters to snapshot restore implemented in [Opensearch PR 16292](https://github.com/opensearch-project/OpenSearch/pull/16292)

### Issues Resolved
No related issues 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
