### PR TITLE
Made NestedAggregate inherit from AggregateBase

### DIFF
--- a/spec/schemas/_common.aggregations.yaml
+++ b/spec/schemas/_common.aggregations.yaml
@@ -784,7 +784,7 @@ components:
             - doc_count
     NestedAggregate:
       allOf:
-        - $ref: '#/components/schemas/SingleBucketAggregateBase'
+        - $ref: '#/components/schemas/AggregateBase'
         - type: object
           properties:
             doc_count:


### PR DESCRIPTION
### Description
Made NestedAggregate inherit from AggregateBase instead of SingleBucketAggregateBase to resolve `doc_count`  conflict where the schema is a union of 2 different objects with conflicting requirement for properties `doc_type` (one says it's optional while the other says it's required)

This conflict is causing an [error](https://github.com/opensearch-project/opensearch-js/actions/runs/11443079444/job/31834939793?pr=886#step:10:25) on the Node.js client generator.

- [x] Tests have already been provided in a previous [commit](https://github.com/opensearch-project/opensearch-api-specification/commit/a92c4923142bb3b53e41a10a374ef46d8d0efdba#diff-6c53c1dfb24e95a082ce8882937e37ed8ea26fed502c43b6245346c10a0cd868R789-R791) that updated this schema.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
