### PR TITLE
Added a release workflow triggered on a tag.

### DIFF
--- a/.cspell
+++ b/.cspell
@@ -106,6 +106,7 @@ Nanos
 nbest
 nfkc
 ngram
+nguyenvukhang
 niofs
 nmslib
 nodeattrs
@@ -158,6 +159,7 @@ Rudnick
 ruleset
 scriptless
 securityconfig
+signoff
 slowlog
 Slowlog
 slurpfile
@@ -165,6 +167,7 @@ smartcn
 Smartcn
 snapshotted
 softmax
+softprops
 Sorani
 sslinfo
 stoptags
@@ -181,6 +184,7 @@ tenantinfo
 termvectors
 tfidf
 Tfidf
+thomaseizinger
 Tika
 tlbr
 tokenfilters

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Draft a Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  draft-a-release:
+    name: Draft a Release
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Get Current Version
+        id: current
+        run: |
+          echo version=$(yq .version spec/_info.yaml) >> "$GITHUB_OUTPUT"
+
+      - name: Check Version
+        run: |
+          echo current=v${{ steps.current.outputs.version }}
+          echo tag=${{ github.ref_name }}
+          if "v${{ steps.current.outputs.version }}" != "${{ github.ref_name }}"; then
+            echo "::error::Failing, reason: version ${{ steps.current.outputs.version }} does not match tag ${{ github.ref_name }}."
+            exit 1
+          else
+            echo "::notice::Found version ${{ steps.current.outputs.version }}, all good."
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Build
+        run: npm ci && npm run merge
+
+      - name: Upload Artifacts
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: |
+            build/*
+
+      - name: Extract Changelog
+        id: changelog
+        uses: sean0x42/markdown-extract@v2
+        with:
+          file: CHANGELOG.md
+          pattern: Unreleased
+          no-print-matched-heading: true
+
+      - name: Draft a release
+        uses: softprops/action-gh-release@v2
+        id: release
+        with:
+          draft: true
+          generate_release_notes: false
+          tag_name: ${{ github.ref_name }}
+          body: |
+            ${{ steps.changelog.outputs.markdown }}
+
+            ### Links
+            - [Build Artifact](${{ steps.upload.outputs.artifact-url }})
+          files: |
+            LICENSE.txt
+            build/*
+
+      - name: Increment Version
+        uses: nguyenvukhang/semver-increment@v1
+        id: version
+        with:
+          increment: patch
+          version-file: spec/_info.yaml
+          version-regex: '^version: (.*)'
+
+      - name: Update CHANGELOG to the Next Developer Iteration
+        uses: thomaseizinger/keep-a-changelog-new-release@v3
+        with:
+          tag: ${{ github.ref_name }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'Preparing for next developer iteration ${{ steps.version.outputs.version }}.'
+          signoff: true
+          branch: prepare-v-next
+          base: main
+          delete-branch: true
+          title: 'Preparing for next developer iteration, ${{ steps.version.outputs.version }}.'
+          body: |
+            I've drafted a release, [${{ github.ref_name }}](${{ steps.release.outputs.url }}), please verify and release it.
+            Preparing for the next developer iteration, ${{ steps.version.outputs.version }}.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `404` response for `DELETE /{index}`, `GET /{index}/_doc/{id}`, `DELETE /{index}/_doc/{id}` ([#589](https://github.com/opensearch-project/opensearch-api-specification/pull/589))
 - Added ability to pass `InlineScript` as a simple string ([#605](https://github.com/opensearch-project/opensearch-api-specification/pull/605))
 - Added `config_id` and `config_id_list` to `/_plugins/_notifications/configs` query parameters ([#594](https://github.com/opensearch-project/opensearch-api-specification/pull/594))
+- Added a release workflow triggered on a tag ([#635](https://github.com/opensearch-project/opensearch-api-specification/pull/635))
 
 ### Changed
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,28 @@
+- [Overview](#overview)
+- [Branching](#branching)
+  - [Release Branching](#release-branching)
+  - [Feature Branches](#feature-branches)
+- [Release Labels](#release-labels)
+- [Releasing](#releasing)
+
+## Overview
+
+This document explains the release strategy for opensearch-api-specification.
+
+## Versioning
+
+At this time this project follows minor semantic versioning, i.e. a breaking change is an increment from 0.1.0 to 0.2.0 and a non-breaking change is an increment from 0.1.0 to 0.1.1. A version 1.0 of the API specification will be released when the spec is known to be complete against any current version of OpenSearch.
+
+## Branching
+
+Given the early release stages of this repo we only maintain a **main** branch where all merges take place and code moves fast.
+
+# Releasing
+
+A release can be done by any [maintainer](MAINTAINERS.md).
+
+1. Check out the [upstream repo](https://github.com/opensearch-project/opensearch-api-specification) and ensure the repo is up-to-date with `git pull origin main` and that you do not have any local changes.
+2. Create a tag, e.g. `git tag v0.1.0`, and push it to GitHub with `git push origin --tags`.
+3. The [release workflow](.github/workflows/release.yml) will be automatically kicked off, a draft release, and a pull request that increments the version in [spec/_info.yaml](spec/_info.yaml) will be created.
+4. Verify and release the draft.
+5. Approve, and merge the version increment pull request.

--- a/spec/_info.yaml
+++ b/spec/_info.yaml
@@ -1,5 +1,5 @@
 $schema: ./json_schemas/_info.schema.yaml
 
 title: OpenSearch API Specification
-version: 1.0.0
+version: 0.1.0
 x-api-version: 2.16.0


### PR DESCRIPTION
### Description

Added a release workflow triggered on a tag.

1. Ensures that the tag created matches the version in the spec.
2. Drafts a release ([example](https://github.com/dblock/opensearch-api-specification/releases/tag/untagged-cdbde5c0e2f11bb257cd)).
3. Increments version.
4. Updates CHANGELOG.
5. Makes a PR with the version increment changes ([example](https://github.com/dblock/opensearch-api-specification/pull/15)).


### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/issues/84.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
