### PR TITLE
Add spec for cluster stats metric and index_metric filter paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added API spec for `adjust_pure_negative` for bool queries ([#641](https://github.com/opensearch-project/opensearch-api-specification/pull/641))
 - Added a spec style checker [#620](https://github.com/opensearch-project/opensearch-api-specification/pull/620).
 - Added `remote_store` to node `Stats` ([#643](https://github.com/opensearch-project/opensearch-api-specification/pull/643))
+- Added `/_cluster/stats/{metric}/nodes/{node_id}` and `/_cluster/stats/{metric}/{index_metric}/nodes/{node_id}` ([#639](https://github.com/opensearch-project/opensearch-api-specification/pull/639))
 
 ### Changed
 

--- a/spec/namespaces/cluster.yaml
+++ b/spec/namespaces/cluster.yaml
@@ -331,6 +331,39 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/cluster.stats@200'
+  /_cluster/stats/{metric}/nodes/{node_id}:
+    get:
+      operationId: cluster.stats.2
+      x-operation-group: cluster.stats
+      x-version-added: '2.18'
+      description: Returns high-level overview of cluster statistics.
+      externalDocs:
+        url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/
+      parameters:
+        - $ref: '#/components/parameters/cluster.stats::path.metric'
+        - $ref: '#/components/parameters/cluster.stats::path.node_id'
+        - $ref: '#/components/parameters/cluster.stats::query.flat_settings'
+        - $ref: '#/components/parameters/cluster.stats::query.timeout'
+      responses:
+        '200':
+          $ref: '#/components/responses/cluster.stats@200'
+  /_cluster/stats/{metric}/{index_metric}/nodes/{node_id}:
+    get:
+      operationId: cluster.stats.3
+      x-operation-group: cluster.stats
+      x-version-added: '2.18'
+      description: Returns high-level overview of cluster statistics.
+      externalDocs:
+        url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/
+      parameters:
+        - $ref: '#/components/parameters/cluster.stats::path.index_metric'
+        - $ref: '#/components/parameters/cluster.stats::path.metric'
+        - $ref: '#/components/parameters/cluster.stats::path.node_id'
+        - $ref: '#/components/parameters/cluster.stats::query.flat_settings'
+        - $ref: '#/components/parameters/cluster.stats::query.timeout'
+      responses:
+        '200':
+          $ref: '#/components/responses/cluster.stats@200'
   /_cluster/voting_config_exclusions:
     post:
       operationId: cluster.post_voting_config_exclusions.0
@@ -1380,6 +1413,27 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
+    cluster.stats::path.index_metric:
+      in: path
+      name: index_metric
+      description: Limit the information returned for indexes metric to the specific index metrics. It can be used only if indexes (or all) metric is specified.
+      required: true
+      schema:
+        type: array
+        items:
+          $ref: '../schemas/cluster.stats.yaml#/components/schemas/IndexMetric'
+      style: simple
+    cluster.stats::path.metric:
+      in: path
+      name: metric
+      description: Limit the information returned to the specified metrics
+      required: true
+      schema:
+        type: array
+        items:
+          $ref: '../schemas/cluster.stats.yaml#/components/schemas/Metric'
+      style:
+        simple
     cluster.stats::path.node_id:
       in: path
       name: node_id

--- a/spec/schemas/cluster.stats.yaml
+++ b/spec/schemas/cluster.stats.yaml
@@ -27,8 +27,6 @@ components:
           required:
             - cluster_name
             - cluster_uuid
-            - indices
-            - nodes
             - status
             - timestamp
     ClusterIndices:
@@ -60,17 +58,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/IndicesVersions'
-      required:
-        - analysis
-        - completion
-        - count
-        - docs
-        - fielddata
-        - mappings
-        - query_cache
-        - segments
-        - shards
-        - store
     CharFilterTypes:
       type: object
       properties:
@@ -271,18 +258,6 @@ components:
           type: array
           items:
             $ref: '_common.yaml#/components/schemas/VersionString'
-      required:
-        - count
-        - discovery_types
-        - fs
-        - ingest
-        - jvm
-        - network_types
-        - os
-        - packaging_types
-        - plugins
-        - process
-        - versions
     ClusterNodeCount:
       type: object
       properties:
@@ -689,3 +664,30 @@ components:
         - avg
         - max
         - min
+    Metric:
+      type: string
+      enum:
+        - _all
+        - discovery_type
+        - fs
+        - indices
+        - ingest
+        - jvm
+        - network_types
+        - os
+        - packaging_types
+        - plugins
+        - process
+    IndexMetric:
+      type: string
+      enum:
+        - _all
+        - analysis
+        - completion
+        - docs
+        - fielddata
+        - mappings
+        - query_cache
+        - segments
+        - shards
+        - store

--- a/tests/default/cluster/stats/index_metric.yaml
+++ b/tests/default/cluster/stats/index_metric.yaml
@@ -1,0 +1,18 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test cluster manager stats.
+# TODO: Re-enable in 3.0, see https://github.com/opensearch-project/opensearch-api-specification/pull/613
+version: '>= 2.18 < 3'
+chapters:
+  - synopsis: Get mapping and analysis indices stats.
+    path: /_cluster/stats/{metric}/{index_metric}/nodes/{node_id}
+    method: GET
+    parameters:
+      node_id: _all
+      metric:
+        - indices
+      index_metric:
+        - analysis
+        - mappings
+    response:
+      status: 200

--- a/tests/default/cluster/stats/metric.yaml
+++ b/tests/default/cluster/stats/metric.yaml
@@ -1,0 +1,17 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test cluster manager stats.
+# TODO: Re-enable in 3.0, see https://github.com/opensearch-project/opensearch-api-specification/pull/613
+version: '>= 2.18 < 3'
+chapters:
+  - synopsis: Get nodes fs and jvm stats.
+    path: /_cluster/stats/{metric}/nodes/{node_id}
+    method: GET
+    parameters:
+      node_id: _all
+      metric:
+        - fs
+        - jvm
+    response:
+      status: 200
+


### PR DESCRIPTION
### Description
Adding specs for path` /_cluster/stats/{metric}/nodes/{nodeId}` and `/_cluster/stats/{metric}/{index_metric}/nodes/{nodeId}` in cluster/stats API. With https://github.com/opensearch-project/OpenSearch/pull/15938, the cluster/stats API will have filtering support that will allow the clients to fetch only specific metrics from cluster/stats instead of all metrics.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
