### PR TITLE
Add adjust_pure_negative for bool queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `config_id` and `config_id_list` to `/_plugins/_notifications/configs` query parameters ([#594](https://github.com/opensearch-project/opensearch-api-specification/pull/594))
 - Added a release workflow triggered on a tag ([#635](https://github.com/opensearch-project/opensearch-api-specification/pull/635))
 - Added API spec for query insights plugin ([#625](https://github.com/opensearch-project/opensearch-api-specification/pull/625))
+- Added API spec for `adjust_pure_negative` for bool queries ([#641](https://github.com/opensearch-project/opensearch-api-specification/pull/641))
 
 ### Changed
 

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -270,6 +270,13 @@ components:
                 - type: array
                   items:
                     $ref: '#/components/schemas/QueryContainer'
+            adjust_pure_negative:
+              description: |-
+                Ensures correct behavior when a query contains only must_not clauses.
+                By default set to true, OpenSearch adds a match-all clause to ensure results are returned from Lucene, with the must_not conditions applied as filters.
+                If set to false, the query may return no results, as Lucene typically requires at least one positive condition.
+              type: boolean
+              default: true
     QueryBase:
       type: object
       properties:

--- a/spec/schemas/insights._common.yaml
+++ b/spec/schemas/insights._common.yaml
@@ -137,7 +137,8 @@ components:
             NOTE: This is a debugging tool and adds significant overhead to search execution.
           type: boolean
         query:
-          $ref: '_common.query_dsl.yaml#/components/schemas/QueryContainer'
+          description: The query definition using the Query DSL.
+          type: object
         script_fields:
           description: Retrieve a script evaluation (based on different fields) for each hit.
           type: object
@@ -205,6 +206,7 @@ components:
           type: array
           items:
             type: string
+      additionalProperties: true
     Measurement:
       type: object
       properties:

--- a/spec/schemas/insights._common.yaml
+++ b/spec/schemas/insights._common.yaml
@@ -137,8 +137,7 @@ components:
             NOTE: This is a debugging tool and adds significant overhead to search execution.
           type: boolean
         query:
-          description: The query definition using the Query DSL.
-          type: object
+          $ref: '_common.query_dsl.yaml#/components/schemas/QueryContainer'
         script_fields:
           description: Retrieve a script evaluation (based on different fields) for each hit.
           type: object
@@ -206,7 +205,6 @@ components:
           type: array
           items:
             type: string
-      additionalProperties: true
     Measurement:
       type: object
       properties:

--- a/tests/plugins/query_insights/insights/top_queries.yaml
+++ b/tests/plugins/query_insights/insights/top_queries.yaml
@@ -41,6 +41,19 @@ prologues:
             terms:
               field: director.raw
 
+  - path: /{index}/_search
+    parameters:
+      index: movies
+    method: GET
+    request:
+      payload:
+        query:
+          bool:
+            adjust_pure_negative: true
+            must:
+              match:
+                title: Drive
+
 chapters:
   - synopsis: Retrieve default top queries.
     path: /_insights/top_queries


### PR DESCRIPTION
### Description
The Query Insights API spec depends on the core specifications for the source fields in queries. The issues reported in https://github.com/opensearch-project/opensearch-api-specification/issues/638 stem from unexpected fields not defined in the QueryContainer spec. This PR fixes the bug by adding the `adjust_pure_negative` field in bool queries spec.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-api-specification/issues/638

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
