### PR TITLE
Fix: model training intermittent test failure.

### DIFF
--- a/spec/namespaces/knn.yaml
+++ b/spec/namespaces/knn.yaml
@@ -283,7 +283,11 @@ components:
       required: true
   responses:
     knn.delete_model@200: {}
-    knn.get_model@200: {}
+    knn.get_model@200:
+      content:
+        application/json:
+          schema:
+            type: object
     knn.search_models@200: {}
     knn.stats@200: {}
     knn.train_model@200:

--- a/tests/default/knn/train_model.yaml
+++ b/tests/default/knn/train_model.yaml
@@ -41,6 +41,9 @@ prologues:
         - {index: {_index: movies, _id: '9'}}
         - {recommendation_vector: [9.5, 9.5, 9.5, 9.5, 9.5, 9.5, 9.5, 9.5], duration: 8.9}
     status: [200]
+  - method: POST
+    path: /_refresh
+    status: [200]
 epilogues:
   - path: /movies
     method: DELETE
@@ -71,3 +74,17 @@ chapters:
       status: 200
     output:
       test_model_id: payload.model_id
+  - synopsis: Wait for the model to get trained.
+    warnings:
+      multiple-paths-detected: false
+    method: GET
+    path: /_plugins/_knn/models/{model_id}
+    parameters:
+      model_id: ${train_model.test_model_id}
+    retry:
+      count: 3
+    response:
+      status: 200
+      payload:
+        model_id: ${train_model.test_model_id}
+        state: created


### PR DESCRIPTION
### Description

The reason this was a flake was that half the time the model would successfully begin training, and half the time would not.

The time it would not it would fail with the following error:

```
Error: 'nx >= k' failed: Number of training points (0) should be at least as large as number of clusters (4)
```

This was caused by the fact that a refresh cycle had yet to run, so the model had 0 documents to use. However when a refresh cycle would happen in time, the model would begin training. In that case it could not be deleted until training was complete, causing the CI failure.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/issues/614.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
