### PR TITLE
Do not run Vale on push.

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,6 @@
 name: Style
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   check:


### PR DESCRIPTION
### Description

Reviewdog fails on push saying it should be in a PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
