### PR TITLE
Remove SourceField mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added API specs for query groups lifecycle APIs ([#649](https://github.com/opensearch-project/opensearch-api-specification/pull/649))
 
+### Removed
+- Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#]())
+
 ## [0.1.0] - 2024-10-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added API specs for query groups lifecycle APIs ([#649](https://github.com/opensearch-project/opensearch-api-specification/pull/649))
 
 ### Removed
-- Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#]())
+- Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))
 
 ## [0.1.0] - 2024-10-25
 

--- a/spec/_info.yaml
+++ b/spec/_info.yaml
@@ -1,5 +1,5 @@
 $schema: ./json_schemas/_info.schema.yaml
 
 title: OpenSearch API Specification
-version: 0.1.1
+version: 0.2.0
 x-api-version: 2.16.0

--- a/spec/schemas/_common.mapping.yaml
+++ b/spec/schemas/_common.mapping.yaml
@@ -1202,14 +1202,6 @@ components:
           type: array
           items:
             type: string
-        mode:
-          $ref: '#/components/schemas/SourceFieldMode'
-    SourceFieldMode:
-      type: string
-      enum:
-        - disabled
-        - stored
-        - synthetic
     DataStreamTimestamp:
       type: object
       properties:


### PR DESCRIPTION
### Description
Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
