### PR TITLE
README: fix "validate spec" status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Test Tools (Unit)](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/test-tools-unit.yml/badge.svg)](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/test-tools-unit.yml)
 [![Test Tools (Integration)](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/test-tools-integ.yml/badge.svg)](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/test-tools-integ.yml)
 [![Test Spec](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/test-spec.yml/badge.svg)](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/test-spec.yml)
-[![Validate Spec](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/validate-spec.yml/badge.svg)](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/validate-spec.yml)
+[![Validate Spec](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/validate-spec-lint.yml/badge.svg)](https://github.com/opensearch-project/opensearch-api-specification/actions/workflows/validate-spec-lint.yml)
 
 - [OpenSearch API Specification](#opensearch-api-specification)
 - [Welcome!](#welcome)


### PR DESCRIPTION
### Description
the workflow got renamed in commit 2a39edd (#646), thus the link is no longer valid. this was not caught by the "check links" test as the link was still valid until the PR got merged. this currently blocks all other PRs.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
