### PR TITLE
Added FlatObjectProperty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added Python and Ruby spec validators ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))
 - Added verbose output of the story being evaluated ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))
 - Added `_search` with `sort: direction` ([#658](https://github.com/opensearch-project/opensearch-api-specification/pull/658))
+- Added `_common.mapping:FlatObjectProperty` ([#661](https://github.com/opensearch-project/opensearch-api-specification/pull/661)) 
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/spec/schemas/_common.mapping.yaml
+++ b/spec/schemas/_common.mapping.yaml
@@ -128,6 +128,7 @@ components:
         - $ref: '#/components/schemas/DenseVectorProperty'
         - $ref: '#/components/schemas/SparseVectorProperty'
         - $ref: '#/components/schemas/FlattenedProperty'
+        - $ref: '#/components/schemas/FlatObjectProperty'
         - $ref: '#/components/schemas/NestedProperty'
         - $ref: '#/components/schemas/ObjectProperty'
         - $ref: '#/components/schemas/CompletionProperty'
@@ -612,6 +613,21 @@ components:
               type: string
               enum:
                 - flattened
+          required:
+            - type
+    FlatObjectProperty:
+      allOf:
+        - $ref: '#/components/schemas/PropertyBase'
+        - type: object
+          properties:
+            searchable:
+              type: boolean
+            aggregatable:
+              type: boolean
+            type:
+              type: string
+              enum:
+                - flat_object
           required:
             - type
     NestedProperty:

--- a/tests/default/_core/mapping.yaml
+++ b/tests/default/_core/mapping.yaml
@@ -1,54 +1,9 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test mappings endpoints.
-prologues:
-  - path: /{index}
-    method: PUT
-    parameters:
-      index: movies
-    request:
-      payload:
-        mappings:
-          properties:
-            director:
-              type: text
-            year:
-              type: integer
-            location:
-              type: ip
-              ignore_malformed: true
-epilogues:
-  - path: /movies
-    method: DELETE
-    status: [200, 404]
 chapters:
-  - synopsis: Get mappings for an index (index in query).
+  - synopsis: Get all mappings.
     path: /_mapping
     method: GET
-    parameters:
-      index: movies
     response:
       status: 200
-      payload:
-        movies:
-          mappings:
-            properties:
-              director:
-                type: text
-              year:
-                type: integer
-  - synopsis: Get mappings for an index (index in path).
-    path: /{index}/_mapping
-    method: GET
-    parameters:
-      index: movies
-    response:
-      status: 200
-      payload:
-        movies:
-          mappings:
-            properties:
-              director:
-                type: text
-              year:
-                type: integer


### PR DESCRIPTION
### Description

- We already have index mapping tests in https://github.com/opensearch-project/opensearch-api-specification/blob/main/tests/default/indices/mapping.yaml, so no need to duplicate them under core.
- Added `FlatObjectProperty` index mapping returned in `.opensearch-observability`.
- Added a test to get mappings for all indices, seems to not run into #384 anymore.
 
### Issues Resolved

Closes #384.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
