### PR TITLE
Fix: merging coverage includes plugin tests.

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -77,12 +77,16 @@ jobs:
         working-directory: tests/${{ matrix.entry.tests || 'default' }}
         run: docker compose up -d
 
+      - name: Generate Test Files Hash
+        id: tests
+        run: echo "hash=${{ matrix.entry.version }}-${{ hashFiles(format('tests/{0}', matrix.entry.tests || 'default')) }}" >> $GITHUB_OUTPUT
+
       - name: Run Tests
         run: |
           npm run test:spec -- \
             --opensearch-insecure \
             --opensearch-version=${{ matrix.entry.version }} \
-            --coverage coverage/test-spec-coverage-${{ matrix.entry.version }}-${{ matrix.entry.tests || 'default' }}.json \
+            --coverage coverage/test-spec-coverage-${{ steps.tests.outputs.hash }}.json \
             --tests=tests/${{ matrix.entry.tests || 'default' }}
 
       - name: Get Container Logs
@@ -96,8 +100,8 @@ jobs:
       - name: Upload Test Coverage Results
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.entry.version }}-${{ hashFiles(format('tests/{0}', matrix.entry.tests || 'default')) }}
-          path: coverage/test-spec-coverage-${{ matrix.entry.version }}-${{ matrix.entry.tests || 'default' }}.json
+          name: coverage-${{ matrix.entry.version }}-${{ steps.tests.outputs.hash }}
+          path: coverage/test-spec-coverage-${{ steps.tests.outputs.hash }}.json
 
   merge-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -115,6 +115,17 @@ jobs:
         with:
           path: coverage
 
+      - name: Display Missing Test Paths
+        run: |
+          jq -sc '
+            (map(.operations) | add | unique) as $all |
+            (map(.evaluated_operations) | add | unique) as $evaluated |
+            $all-$evaluated |
+            sort_by(.path) |
+            .[] |
+            "\(.method) \(.path)"
+          ' $(find ./ -name "test-spec-coverage-*.json")
+
       - name: Combine Test Coverage Data
         shell: bash -eo pipefail {0}
         run: |


### PR DESCRIPTION
### Description

We used `coverage/test-spec-coverage-${{ matrix.entry.version }}-${{ matrix.entry.tests || 'default' }}.json` to make the coverage output file name, which may have contained `/` in cases like `plugins/index-management`. This caused the coverage merge code not to pickup those files because it's looking for `test-spec-coverage-*`.

This fixes that by using the hash instead of the path name. The version still needs to be there to make it unique.

The result as expected is slightly better than in previous PRs (e.g. here vs. https://github.com/opensearch-project/opensearch-api-specification/pull/661).

<img width="578" alt="Screenshot 2024-11-11 at 2 43 16 PM" src="https://github.com/user-attachments/assets/6c545186-b39b-4ea8-8cd4-5b50c250ceb2">

<img width="609" alt="Screenshot 2024-11-11 at 2 43 50 PM" src="https://github.com/user-attachments/assets/a80e3c13-9d08-45fe-8118-269077cf7af5">

We also display paths that don't have tests when merging results so it's easier to identify tests to fill out.

![image](https://github.com/user-attachments/assets/db2f23da-f5b1-4a0b-86b2-8372a8079a9b)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
