### PR TITLE
Upgrade to 2.18.0 GA.

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -27,26 +27,26 @@ jobs:
             admin_password: admin
           - version: 2.0.0
             admin_password: admin
-          - version: 2.16.0
-          - version: 2.16.0
-            tests: plugins/index_state_management
-          - version: 2.16.0
-            tests: plugins/ml
-          - version: 2.16.0
-            tests: routing
-          - version: 2.16.0
-            tests: snapshot
-          - version: 2.17.0
-            tests: plugins/streaming
-          - version: 2.17.0
-            tests: plugins/notifications
-          - version: 2.17.0
-            tests: plugins/query_insights
-          - version: 2.17.0
-            tests: plugins/workload-management
           - version: 2.18.0
+          - version: 2.18.0
+            tests: plugins/index_state_management
+          - version: 2.18.0
+            tests: plugins/ml
+          - version: 2.18.0
+            tests: routing
+          - version: 2.18.0
+            tests: snapshot
+          - version: 2.18.0
+            tests: plugins/streaming
+          - version: 2.18.0
+            tests: plugins/notifications
+          - version: 2.18.0
+            tests: plugins/query_insights
+          - version: 2.18.0
+            tests: plugins/workload-management
+          - version: 2.19.0
             hub: opensearchstaging
-            ref: '@sha256:57a1cd1142d68c203e2e4aa0666d9a691e1e409a5d14aa4a8f5044036f05cf06'
+            ref: '@sha256:4da23e0137b2b67206d23b36fcf0914cc39b3bf19310c782f536e4934b86f6cc'
           - version: 3.0.0
             hub: opensearchstaging
             ref: '@sha256:727643acdfebed77bfdb26362dbcff536b7ea02a0cc4ae2da2521729171333de'

--- a/tests/default/cat/fielddata.yaml
+++ b/tests/default/cat/fielddata.yaml
@@ -10,7 +10,7 @@ chapters:
     response:
       status: 200
   - synopsis: List the memory size used by each field per node with data from security-analytics.
-    version: '>= 2.4'
+    version: '>= 2.4 < 2.19'
     path: /_cat/fielddata
     method: GET
     parameters:
@@ -21,7 +21,7 @@ chapters:
       payload:
         - field: log_types
   - synopsis: List the memory size used by each field per node with data from security-analytics.
-    version: '>= 2.4'
+    version: '>= 2.4 < 2.19'
     path: /_cat/fielddata/{fields}
     method: GET
     parameters:

--- a/tests/plugins/streaming/indices/bulk/stream.yaml
+++ b/tests/plugins/streaming/indices/bulk/stream.yaml
@@ -1,13 +1,13 @@
 $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test bulk streaming index endpoint.
+version: '>= 2.17'
 epilogues:
   - path: /books,movies
     method: DELETE
     status: [200, 404]
 chapters:
   - synopsis: Create an index.
-    version: '2.17'
     path: /{index}/_bulk/stream
     method: POST
     parameters:
@@ -18,7 +18,6 @@ chapters:
         - {create: {}}
         - {director: Bennett Miller, title: Moneyball, year: 2011}
   - synopsis: Delete document in an index.
-    version: '>= 2.17'
     path: /{index}/_bulk/stream
     method: PUT
     parameters:
@@ -38,7 +37,6 @@ chapters:
               result: not_found
               status: 404
   - synopsis: Bulk index document CRUD.
-    version: '>= 2.17'
     method: POST
     path: /{index}/_bulk/stream
     parameters:


### PR DESCRIPTION
### Description

- [x] Upgrade to 2.18.0 GA.
- [x] Increment to a build of 2.19 for next version.
        ~Current 2.19 is missing security-analytics, marked a test < 2.19 for now.~

~- [ ] Update to a newer 3.0.~ lots of plugins missing in recent 3.0 builds :( https://github.com/opensearch-project/opensearch-build/issues/3747#issuecomment-2470482312


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
