### PR TITLE
Remaining alias-related tests.

### DIFF
--- a/tests/default/indices/alias/rollover.yaml
+++ b/tests/default/indices/alias/rollover.yaml
@@ -1,0 +1,29 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test rolling over aliases.
+epilogues:
+  - path: /games
+    method: DELETE
+    status: [200, 404]
+  - path: /rollover
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: games
+    method: PUT
+  - path: /games/_alias/jeux
+    method: POST
+chapters:
+  - synopsis: Manually roll over an index.
+    path: /{alias}/_rollover/{new_index}
+    method: POST
+    parameters:
+      alias: jeux
+      new_index: rollover
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+        old_index: games
+        new_index: rollover
+        rolled_over: true

--- a/tests/default/indices/aliases/aliases.yaml
+++ b/tests/default/indices/aliases/aliases.yaml
@@ -11,11 +11,20 @@ prologues:
 chapters:
   - synopsis: Create an alias by name.
     path: /{index}/_aliases/{name}
+    method: POST
+    parameters:
+      index: games
+      name: jeux
+  - synopsis: Update an alias by name (query).
+    path: /{index}/_aliases/{name}
     method: PUT
     parameters:
       index: games
       name: jeux
-  - synopsis: Update an alias.
+    request:
+      payload:
+        is_write_index: true
+  - synopsis: Update an alias by name (payload).
     path: /{index}/_aliases
     method: PUT
     parameters:

--- a/tests/default/indices/data_stream/rollover.yaml
+++ b/tests/default/indices/data_stream/rollover.yaml
@@ -30,8 +30,6 @@ epilogues:
     status: [200, 404]
 chapters:
   - synopsis: Manually roll over a data stream.
-    warnings:
-      multiple-paths-detected: false
     path: /{alias}/_rollover
     method: POST
     parameters:


### PR DESCRIPTION
### Description

- Added test for `POST /{index}/_aliases/{name}`.
- Added test for `POST /{alias}/_rollover/{new_index}`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
