### PR TITLE
Run merge coverage on push.

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -105,7 +105,6 @@ jobs:
 
   merge-coverage:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     needs: test-opensearch-spec
     steps:
       - uses: actions/checkout@v4
@@ -141,6 +140,7 @@ jobs:
           cat ./coverage/coverage.json
 
       - name: Construct Comment Data Payload
+        if: github.event_name == 'pull_request'
         shell: bash -eo pipefail {0}
         run: |
           jq \
@@ -161,6 +161,7 @@ jobs:
 
       - name: Upload PR Comment Payload
         uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request'
         with:
           name: pr-comment
           path: pr-comment.json


### PR DESCRIPTION
### Description

Allows to see the current coverage status when pushed to main, not just in pull requests.

Passing [here](https://github.com/dblock/opensearch-api-specification/actions/runs/11823960964/job/32944516663) on push.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
