### PR TITLE
Corrected /{index}/_create/{id} 201 response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed incorrect `style` in `indices.get_mapping::query.index` ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))
 - Removed invalid `required` from `ppl` responses ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))
 - Added schema for security API error responses ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))
+- Fixed `/{index}/_create/{id}` returning `201` ([#669](https://github.com/opensearch-project/opensearch-api-specification/pull/669))
 
 ## [0.1.0] - 2024-10-25
 

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -1241,8 +1241,8 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/create'
       responses:
-        '200':
-          $ref: '#/components/responses/create@200'
+        '201':
+          $ref: '#/components/responses/create@201'
     put:
       operationId: create.1
       x-operation-group: create
@@ -1266,8 +1266,8 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/create'
       responses:
-        '200':
-          $ref: '#/components/responses/create@200'
+        '201':
+          $ref: '#/components/responses/create@201'
   /{index}/_delete_by_query:
     post:
       operationId: delete_by_query.0
@@ -2834,7 +2834,7 @@ components:
             required:
               - _shards
               - count
-    create@200:
+    create@201:
       content:
         application/json:
           schema:

--- a/tests/default/indices/create.yaml
+++ b/tests/default/indices/create.yaml
@@ -1,0 +1,32 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test inserting and retrieving a doc.
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create a document it doesn't already exist (POST).
+    path: /{index}/_create/{id}
+    method: POST
+    parameters:
+      index: movies
+      id: '1'
+    request:
+      payload:
+        title: Beauty and the Beast
+        year: 1991
+    response:
+      status: 201
+  - synopsis: Create a document it doesn't already exist (PUT).
+    path: /{index}/_create/{id}
+    method: PUT
+    parameters:
+      index: movies
+      id: '2'
+    request:
+      payload:
+        title: To Kill a Mockingbird
+        year: 1960
+    response:
+      status: 201


### PR DESCRIPTION
### Description

A successful response from `/{index}/_create/{id}` is always a 201 it seems like.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
