### PR TITLE
Added `HEAD /{index}/_doc/{id}` returning `404`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added verbose output of the story being evaluated ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))
 - Added `_search` with `sort: direction` ([#658](https://github.com/opensearch-project/opensearch-api-specification/pull/658))
 - Added `_common.mapping:FlatObjectProperty` ([#661](https://github.com/opensearch-project/opensearch-api-specification/pull/661)) 
+- Added `HEAD /{index}/_doc/{id}` returning `404` ([#670](https://github.com/opensearch-project/opensearch-api-specification/pull/670))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -1393,6 +1393,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/exists@200'
+        '404':
+          $ref: '#/components/responses/exists@404'
     post:
       operationId: index.1
       x-operation-group: index
@@ -2903,6 +2905,9 @@ components:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     exists@200:
+      content:
+        application/json: {}
+    exists@404:
       content:
         application/json: {}
     exists_source@200:

--- a/tests/default/indices/doc.yaml
+++ b/tests/default/indices/doc.yaml
@@ -49,6 +49,14 @@ chapters:
       id: '1'
     response:
       status: 200
+  - synopsis: Check whether a document exists.
+    path: /{index}/_doc/{id}
+    method: HEAD
+    parameters:
+      index: movies
+      id: '1'
+    response:
+      status: 200
   - synopsis: Delete a document.
     path: /{index}/_doc/{id}
     method: DELETE
@@ -60,6 +68,14 @@ chapters:
   - synopsis: Retrieve a nonexistent document.
     path: /{index}/_doc/{id}
     method: GET
+    parameters:
+      index: movies
+      id: '1'
+    response:
+      status: 404
+  - synopsis: Check whether a nonexistent document exists.
+    path: /{index}/_doc/{id}
+    method: HEAD
     parameters:
       index: movies
       id: '1'


### PR DESCRIPTION
### Description

Added `HEAD /{index}/_doc/{id}` returning `404`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
