### PR TITLE
Replaced all indices with indexes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `_common.mapping:FlatObjectProperty` ([#661](https://github.com/opensearch-project/opensearch-api-specification/pull/661)) 
 - Added `HEAD /{index}/_doc/{id}` returning `404` ([#670](https://github.com/opensearch-project/opensearch-api-specification/pull/670))
 - Added `_common.mapping:IcuCollationKeywordProperty` ([#666](https://github.com/opensearch-project/opensearch-api-specification/pull/666))
+- Added `/_cluster/stats/{metric}/nodes/{node_id}` and `/_cluster/stats/{metric}/{index_metric}/nodes/{node_id}` ([#639](https://github.com/opensearch-project/opensearch-api-specification/pull/639))
+- Added `PhoneAnalyzer` from `analysis-phonenumber` plugin ([#609](https://github.com/opensearch-project/opensearch-api-specification/pull/609))
+- Added `/_list/indices` & `/_list/shards` api specs ([#613](https://github.com/opensearch-project/opensearch-api-specification/pull/613))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))
@@ -135,8 +138,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added API spec for `adjust_pure_negative` for bool queries ([#641](https://github.com/opensearch-project/opensearch-api-specification/pull/641))
 - Added a spec style checker [#620](https://github.com/opensearch-project/opensearch-api-specification/pull/620).
 - Added `remote_store` to node `Stats` ([#643](https://github.com/opensearch-project/opensearch-api-specification/pull/643))
-- Added `/_cluster/stats/{metric}/nodes/{node_id}` and `/_cluster/stats/{metric}/{index_metric}/nodes/{node_id}` ([#639](https://github.com/opensearch-project/opensearch-api-specification/pull/639))
-- Added `PhoneAnalyzer` from `analysis-phonenumber` plugin ([#609](https://github.com/opensearch-project/opensearch-api-specification/pull/609))
 
 ### Changed
 
@@ -161,7 +162,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Changed `cluster.reroute`'s `metric` path param to use an enum of metrics ([#586](https://github.com/opensearch-project/opensearch-api-specification/pull/586))
 - Changed `indices.stats`'s `metric` path param to use an enum of metrics ([#586](https://github.com/opensearch-project/opensearch-api-specification/pull/586))
 - Changed `CleanupRepositoryResults`' properties to be `int64`s ([#587](https://github.com/opensearch-project/opensearch-api-specification/pull/587))
-- Added `/_list/indices` & `/_list/shards` api specs ([#613](https://github.com/opensearch-project/opensearch-api-specification/pull/613))
 
 ### Deprecated
 

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -97,7 +97,7 @@ Remember to set the `OPENSEARCH_PASSWORD` or `AWS_ACCESS_KEY_ID` and `AWS_SECRET
 
 #### FORBIDDEN/10/cluster create-index blocked (api)
 
-The cluster is most likely hitting a disk watermark threshold. This example sets the disk watermark thresholds to 1500MB low, 100MB high, and 500MB flood stage, allowing the cluster to create indices even if the disk is almost full.
+The cluster is most likely hitting a disk watermark threshold. This example sets the disk watermark thresholds to 1500MB low, 100MB high, and 500MB flood stage, allowing the cluster to create indexes even if the disk is almost full.
 
 ```bash
 curl -k -X PUT --user "admin:${OPENSEARCH_PASSWORD}" https://localhost:9200/_cluster/settings -H 'Content-Type: application/json' -d'

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -201,7 +201,7 @@ paths:
       operationId: field_caps.0
       x-operation-group: field_caps
       x-version-added: '1.0'
-      description: Returns the information about the capabilities of fields among multiple indices.
+      description: Returns the information about the capabilities of fields among multiple indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/field-types/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
       parameters:
@@ -219,7 +219,7 @@ paths:
       operationId: field_caps.1
       x-operation-group: field_caps
       x-version-added: '1.0'
-      description: Returns the information about the capabilities of fields among multiple indices.
+      description: Returns the information about the capabilities of fields among multiple indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/field-types/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
       parameters:
@@ -1014,7 +1014,7 @@ paths:
       operationId: search_shards.0
       x-operation-group: search_shards
       x-version-added: '1.0'
-      description: Returns information about the indices and shards that a search request would be executed against.
+      description: Returns information about the indexes and shards that a search request would be executed against.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -1031,7 +1031,7 @@ paths:
       operationId: search_shards.1
       x-operation-group: search_shards
       x-version-added: '1.0'
-      description: Returns information about the indices and shards that a search request would be executed against.
+      description: Returns information about the indexes and shards that a search request would be executed against.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -1534,7 +1534,7 @@ paths:
       operationId: field_caps.2
       x-operation-group: field_caps
       x-version-added: '1.0'
-      description: Returns the information about the capabilities of fields among multiple indices.
+      description: Returns the information about the capabilities of fields among multiple indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/field-types/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
       parameters:
@@ -1553,7 +1553,7 @@ paths:
       operationId: field_caps.3
       x-operation-group: field_caps
       x-version-added: '1.0'
-      description: Returns the information about the capabilities of fields among multiple indices.
+      description: Returns the information about the capabilities of fields among multiple indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/field-types/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
       parameters:
@@ -1992,7 +1992,7 @@ paths:
       operationId: search_shards.2
       x-operation-group: search_shards
       x-version-added: '1.0'
-      description: Returns information about the indices and shards that a search request would be executed against.
+      description: Returns information about the indexes and shards that a search request would be executed against.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -2010,7 +2010,7 @@ paths:
       operationId: search_shards.3
       x-operation-group: search_shards
       x-version-added: '1.0'
-      description: Returns information about the indices and shards that a search request would be executed against.
+      description: Returns information about the indexes and shards that a search request would be executed against.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -2286,7 +2286,7 @@ components:
             properties:
               scroll_id:
                 $ref: '../schemas/_common.yaml#/components/schemas/ScrollIds'
-            description: Comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter
+            description: Comma-separated list of scroll IDs to clear if none was specified using the `scroll_id` parameter
     count:
       content:
         application/json:
@@ -2549,7 +2549,7 @@ components:
               track_total_hits:
                 $ref: '../schemas/_core.search.yaml#/components/schemas/TrackHits'
               indices_boost:
-                description: Boosts the _score of documents from specified indices.
+                description: Boosts the `_score` of documents from specified indexes.
                 type: array
                 items:
                   type: object
@@ -2624,7 +2624,7 @@ components:
                   Use with caution.
                   OpenSearch applies this parameter to each shard handling the request.
                   When possible, let OpenSearch perform early termination automatically.
-                  Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
+                  Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
                   If set to `0` (default), the query does not terminate early.
                 type: integer
                 format: int32
@@ -2651,7 +2651,7 @@ components:
                 description: |-
                   Stats groups to associate with the search.
                   Each group maintains a statistics aggregation for its associated searches.
-                  You can retrieve these stats using the indices stats API.
+                  You can retrieve these stats using the indexes stats API.
                 type: array
                 items:
                   type: string
@@ -3515,9 +3515,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases to search.
+        Comma-separated list of data streams, indexes, and aliases to search.
         Supports wildcards (`*`).
-        To search all data streams and indices, omit this parameter or use `*` or `_all`.
+        To search all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -3526,8 +3526,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -3581,7 +3581,7 @@ components:
     count::query.ignore_throttled:
       in: query
       name: ignore_throttled
-      description: If `true`, concrete, expanded or aliased indices are ignored when frozen.
+      description: If `true`, concrete, expanded or aliased indexes are ignored when frozen.
       schema:
         type: boolean
       style: form
@@ -3723,10 +3723,10 @@ components:
     create_pit::path.index:
       name: index
       in: path
-      description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+      description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
       schema:
         type: array
-        description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+        description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
         items:
           type: string
       required: true
@@ -3740,7 +3740,7 @@ components:
     create_pit::query.expand_wildcards:
       name: expand_wildcards
       in: query
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
     create_pit::query.keep_alive:
@@ -3849,9 +3849,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases to search.
+        Comma-separated list of data streams, indexes, and aliases to search.
         Supports wildcards (`*`).
-        To search all data streams or indices, omit this parameter or use `*` or `_all`.
+        To search all data streams or indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -3893,8 +3893,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -4105,7 +4105,7 @@ components:
         Use with caution.
         OpenSearch applies this parameter to each shard handling the request.
         When possible, let OpenSearch perform early termination automatically.
-        Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
+        Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
       schema:
         type: integer
         format: int32
@@ -4207,7 +4207,7 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -4303,7 +4303,7 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -4489,7 +4489,7 @@ components:
     field_caps::path.index:
       in: path
       name: index
-      description: Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.
+      description: Comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indexes, omit this parameter or use * or _all.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4499,7 +4499,7 @@ components:
       name: allow_no_indices
       description: |-
         If false, the request returns an error if any wildcard expression, index alias,
-        or `_all` value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request
+        or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request
         targeting `foo*,bar*` returns an error if an index starts with foo but no index starts with bar.
       schema:
         type: boolean
@@ -4521,7 +4521,7 @@ components:
     field_caps::query.ignore_unavailable:
       in: query
       name: ignore_unavailable
-      description: If `true`, missing or closed indices are not included in the response.
+      description: If `true`, missing or closed indexes are not included in the response.
       schema:
         type: boolean
       style: form
@@ -4912,7 +4912,7 @@ components:
     msearch::path.index:
       in: path
       name: index
-      description: Comma-separated list of data streams, indices, and index aliases to search.
+      description: Comma-separated list of data streams, indexes, and index aliases to search.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4976,9 +4976,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases to search.
+        Comma-separated list of data streams, indexes, and aliases to search.
         Supports wildcards (`*`).
-        To search all data streams and indices, omit this parameter or use `*`.
+        To search all data streams and indexes, omit this parameter or use `*`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -5190,8 +5190,8 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.
-        To target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.
+        Comma-separated list of data streams, indexes, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.
+        To target all data streams and indexes in a cluster, omit this parameter or use `_all` or `*`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -5199,21 +5199,21 @@ components:
     rank_eval::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+      description: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
       style: form
     rank_eval::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
     rank_eval::query.ignore_unavailable:
       in: query
       name: ignore_unavailable
-      description: If `true`, missing or closed indices are not included in the response.
+      description: If `true`, missing or closed indexes are not included in the response.
       schema:
         type: boolean
       style: form
@@ -5355,9 +5355,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases to search.
+        Comma-separated list of data streams, indexes, and aliases to search.
         Supports wildcards (`*`).
-        To search all data streams and indices, omit this parameter or use `*` or `_all`.
+        To search all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -5400,8 +5400,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -5510,7 +5510,7 @@ components:
     search::query.ignore_throttled:
       in: query
       name: ignore_throttled
-      description: If `true`, concrete, expanded or aliased indices will be ignored when frozen.
+      description: If `true`, concrete, expanded or aliased indexes will be ignored when frozen.
       schema:
         type: boolean
       style: form
@@ -5740,7 +5740,7 @@ components:
         Use with caution.
         OpenSearch applies this parameter to each shard handling the request.
         When possible, let OpenSearch perform early termination automatically.
-        Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
+        Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
         If set to `0` (default), the query does not terminate early.
       schema:
         type: integer
@@ -5797,7 +5797,7 @@ components:
     search_shards::path.index:
       in: path
       name: index
-      description: Returns the indices and shards that a search request would be executed against.
+      description: Returns the indexes and shards that a search request would be executed against.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -5806,8 +5806,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -5859,7 +5859,7 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices,
+        Comma-separated list of data streams, indexes,
         and aliases to search. Supports wildcards (*).
       required: true
       schema:
@@ -5869,8 +5869,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -5904,7 +5904,7 @@ components:
     search_template::query.ignore_throttled:
       in: query
       name: ignore_throttled
-      description: If `true`, specified concrete, expanded, or aliased indices are not included in the response when throttled.
+      description: If `true`, specified concrete, expanded, or aliased indexes are not included in the response when throttled.
       schema:
         type: boolean
       style: form
@@ -6195,9 +6195,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases to search.
+        Comma-separated list of data streams, indexes, and aliases to search.
         Supports wildcards (`*`).
-        To search all data streams or indices, omit this parameter or use `*` or `_all`.
+        To search all data streams or indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -6239,8 +6239,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
         For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
       schema:
         type: boolean
@@ -6456,7 +6456,7 @@ components:
         Use with caution.
         OpenSearch applies this parameter to each shard handling the request.
         When possible, let OpenSearch perform early termination automatically.
-        Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
+        Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
       schema:
         type: integer
         format: int32

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -20,7 +20,7 @@ paths:
       operationId: cat.aliases.0
       x-operation-group: cat.aliases
       x-version-added: '1.0'
-      description: Shows information about currently configured aliases to indices including filter and routing infos.
+      description: Shows information about currently configured aliases to indexes including filter and routing info.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/
       parameters:
@@ -39,7 +39,7 @@ paths:
       operationId: cat.aliases.1
       x-operation-group: cat.aliases
       x-version-added: '1.0'
-      description: Shows information about currently configured aliases to indices including filter and routing infos.
+      description: Shows information about currently configured aliases to indexes including filter and routing info.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cat/cat-aliases/
       parameters:
@@ -122,7 +122,7 @@ paths:
       operationId: cat.count.0
       x-operation-group: cat.count
       x-version-added: '1.0'
-      description: Provides quick access to the document count of the entire cluster, or individual indices.
+      description: Provides quick access to the document count of the entire cluster, or individual indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cat/cat-count/
       parameters:
@@ -139,7 +139,7 @@ paths:
       operationId: cat.count.1
       x-operation-group: cat.count
       x-version-added: '1.0'
-      description: Provides quick access to the document count of the entire cluster, or individual indices.
+      description: Provides quick access to the document count of the entire cluster, or individual indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cat/cat-count/
       parameters:
@@ -215,7 +215,7 @@ paths:
       operationId: cat.indices.0
       x-operation-group: cat.indices
       x-version-added: '1.0'
-      description: 'Returns information about indices: number of primaries and replicas, document counts, disk size, ...'
+      description: 'Returns information about indexes: number of primaries and replicas, document counts, disk size, ...'
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cat/cat-indices/
       parameters:
@@ -241,7 +241,7 @@ paths:
       operationId: cat.indices.1
       x-operation-group: cat.indices
       x-version-added: '1.0'
-      description: 'Returns information about indices: number of primaries and replicas, document counts, disk size, ...'
+      description: 'Returns information about indexes: number of primaries and replicas, document counts, disk size, ...'
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cat/cat-indices/
       parameters:
@@ -1066,7 +1066,7 @@ components:
     cat.aliases::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
@@ -1331,8 +1331,8 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
-        Supports wildcards (`*`). To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
+        Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -1515,8 +1515,8 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
-        Supports wildcards (`*`). To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
+        Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -1563,7 +1563,7 @@ components:
     cat.indices::query.health:
       in: query
       name: health
-      description: The health status used to limit returned indices. By default, the response includes indices of any health status.
+      description: The health status used to limit returned indexes. By default, the response includes indexes of any health status.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/HealthStatus'
       style: form
@@ -2066,8 +2066,8 @@ components:
       in: path
       name: index
       description: |-
-        A comma-separated list of data streams, indices, and aliases used to limit the request.
-        Supports wildcards (`*`). To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        A comma-separated list of data streams, indexes, and aliases used to limit the request.
+        Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -2247,10 +2247,10 @@ components:
     cat.segment_replication::query.allow_no_indices:
       name: allow_no_indices
       in: query
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
+      description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
       schema:
         type: boolean
-        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
+        description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
     cat.segment_replication::query.bytes:
       name: bytes
       in: query
@@ -2276,7 +2276,7 @@ components:
     cat.segment_replication::query.expand_wildcards:
       name: expand_wildcards
       in: query
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
     cat.segment_replication::query.format:
@@ -2308,17 +2308,17 @@ components:
     cat.segment_replication::query.ignore_throttled:
       name: ignore_throttled
       in: query
-      description: Whether specified concrete, expanded or aliased indices should be ignored when throttled.
+      description: Whether specified concrete, expanded or aliased indexes should be ignored when throttled.
       schema:
         type: boolean
-        description: Whether specified concrete, expanded or aliased indices should be ignored when throttled.
+        description: Whether specified concrete, expanded or aliased indexes should be ignored when throttled.
     cat.segment_replication::query.ignore_unavailable:
       name: ignore_unavailable
       in: query
-      description: Whether specified concrete indices should be ignored when unavailable (missing or closed).
+      description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
       schema:
         type: boolean
-        description: Whether specified concrete indices should be ignored when unavailable (missing or closed).
+        description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
     cat.segment_replication::query.index:
       name: index
       in: query
@@ -2376,9 +2376,9 @@ components:
       in: path
       name: index
       description: |-
-        A comma-separated list of data streams, indices, and aliases used to limit the request.
+        A comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -2455,9 +2455,9 @@ components:
       in: path
       name: index
       description: |-
-        A comma-separated list of data streams, indices, and aliases used to limit the request.
+        A comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'

--- a/spec/namespaces/cluster.yaml
+++ b/spec/namespaces/cluster.yaml
@@ -539,8 +539,8 @@ components:
               allow_auto_create:
                 description: |-
                   This setting overrides the value of the `action.auto_create_index` cluster setting.
-                  If set to `true` in a template, then indices can be automatically created using that
-                  template even if auto-creation of indices is disabled via `actions.auto_create_index`.
+                  If set to `true` in a template, then indexes can be automatically created using that
+                  template even if auto-creation of indexes is disabled using `actions.auto_create_index`.
                   If set to `false` then data streams matching the template must always be explicitly created.
                 type: boolean
               template:
@@ -1009,7 +1009,7 @@ components:
     cluster.health::path.index:
       in: path
       name: index
-      description: Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard expressions (*) are supported. To target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.
+      description: Comma-separated list of data streams, indexes, and index aliases used to limit the request. Wildcard expressions (*) are supported. To target all data streams and indexes in a cluster, omit this parameter or use `_all` or `*`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -1031,14 +1031,14 @@ components:
     cluster.health::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
     cluster.health::query.level:
       in: query
       name: level
-      description: Can be one of cluster, indices or shards. Controls the details level of the health information returned.
+      description: Can be one of cluster, indexes or shards. Controls the details level of the health information returned.
       schema:
         $ref: '../schemas/cluster.health.yaml#/components/schemas/Level'
       style: form
@@ -1175,7 +1175,7 @@ components:
       description: |-
         Name of the component template to create.
         OpenSearch includes the following built-in component templates: `logs-mappings`; 'logs-settings`; `metrics-mappings`; `metrics-settings`;`synthetics-mapping`; `synthetics-settings`.
-        OpenSearch Agent uses these templates to configure backing indices for its data streams.
+        OpenSearch Agent uses these templates to configure backing indexes for its data streams.
         If you use OpenSearch Agent and want to overwrite one of these templates, set the `version` for your replacement template higher than the current version.
         If you don't use OpenSearch Agent and want to disable all built-in component and index templates, set `stack.templates.enabled` to `false` using the cluster update settings API.
       required: true
@@ -1330,7 +1330,7 @@ components:
     cluster.state::path.index:
       in: path
       name: index
-      description: A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+      description: A comma-separated list of index names; use `_all` or empty string to perform the operation on all indexes
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -1348,7 +1348,7 @@ components:
     cluster.state::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+      description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified)
       schema:
         type: boolean
       style: form
@@ -1362,7 +1362,7 @@ components:
     cluster.state::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
@@ -1377,7 +1377,7 @@ components:
     cluster.state::query.ignore_unavailable:
       in: query
       name: ignore_unavailable
-      description: Whether specified concrete indices should be ignored when unavailable (missing or closed)
+      description: Whether specified concrete indexes should be ignored when unavailable (missing or closed)
       schema:
         type: boolean
       style: form

--- a/spec/namespaces/dangling_indices.yaml
+++ b/spec/namespaces/dangling_indices.yaml
@@ -9,7 +9,7 @@ paths:
       operationId: dangling_indices.list_dangling_indices.0
       x-operation-group: dangling_indices.list_dangling_indices
       x-version-added: '1.0'
-      description: Returns all dangling indices.
+      description: Returns all dangling indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/
       parameters: []

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -198,7 +198,7 @@ paths:
       x-distributions-excluded:
         - amazon-managed
         - amazon-serverless
-      description: Clears all or specific caches for one or more indices.
+      description: Clears all or specific caches for one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/clear-index-cache/
       parameters:
@@ -295,7 +295,7 @@ paths:
       operationId: indices.flush.0
       x-operation-group: indices.flush
       x-version-added: '1.0'
-      description: Performs the flush operation on one or more indices.
+      description: Performs the flush operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -311,7 +311,7 @@ paths:
       operationId: indices.flush.1
       x-operation-group: indices.flush
       x-version-added: '1.0'
-      description: Performs the flush operation on one or more indices.
+      description: Performs the flush operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -331,7 +331,7 @@ paths:
       x-distributions-excluded:
         - amazon-managed
         - amazon-serverless
-      description: Performs the force merge operation on one or more indices.
+      description: Performs the force merge operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -507,7 +507,7 @@ paths:
       operationId: indices.get_mapping.0
       x-operation-group: indices.get_mapping
       x-version-added: '1.0'
-      description: Returns mappings for one or more indices.
+      description: Returns mappings for one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/field-types/index/#get-a-mapping
       parameters:
@@ -558,7 +558,7 @@ paths:
       operationId: indices.refresh.0
       x-operation-group: indices.refresh
       x-version-added: '1.0'
-      description: Performs the refresh operation in one or more indices.
+      description: Performs the refresh operation in one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
       parameters:
@@ -572,7 +572,7 @@ paths:
       operationId: indices.refresh.1
       x-operation-group: indices.refresh
       x-version-added: '1.0'
-      description: Performs the refresh operation in one or more indices.
+      description: Performs the refresh operation in one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
       parameters:
@@ -587,7 +587,7 @@ paths:
       operationId: indices.resolve_index.0
       x-operation-group: indices.resolve_index
       x-version-added: '1.0'
-      description: Returns information about any matching indices, aliases, and data streams.
+      description: Returns information about any matching indexes, aliases, and data streams.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -623,7 +623,7 @@ paths:
       x-distributions-excluded:
         - amazon-managed
         - amazon-serverless
-      description: Returns settings for one or more indices.
+      description: Returns settings for one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/get-settings/
       parameters:
@@ -664,7 +664,7 @@ paths:
       operationId: indices.get_settings.1
       x-operation-group: indices.get_settings
       x-version-added: '1.0'
-      description: Returns settings for one or more indices.
+      description: Returns settings for one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/get-settings/
       parameters:
@@ -685,7 +685,7 @@ paths:
       operationId: indices.shard_stores.0
       x-operation-group: indices.shard_stores
       x-version-added: '1.0'
-      description: Provides store information for shard copies of indices.
+      description: Provides store information for shard copies of indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -971,7 +971,7 @@ paths:
       operationId: indices.get.0
       x-operation-group: indices.get
       x-version-added: '1.0'
-      description: Returns information about one or more indices.
+      description: Returns information about one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/get-index/
       parameters:
@@ -1300,7 +1300,7 @@ paths:
       operationId: indices.clear_cache.1
       x-operation-group: indices.clear_cache
       x-version-added: '1.0'
-      description: Clears all or specific caches for one or more indices.
+      description: Clears all or specific caches for one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/clear-index-cache/
       parameters:
@@ -1385,7 +1385,7 @@ paths:
       operationId: indices.flush.2
       x-operation-group: indices.flush
       x-version-added: '1.0'
-      description: Performs the flush operation on one or more indices.
+      description: Performs the flush operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -1402,7 +1402,7 @@ paths:
       operationId: indices.flush.3
       x-operation-group: indices.flush
       x-version-added: '1.0'
-      description: Performs the flush operation on one or more indices.
+      description: Performs the flush operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -1420,7 +1420,7 @@ paths:
       operationId: indices.forcemerge.1
       x-operation-group: indices.forcemerge
       x-version-added: '1.0'
-      description: Performs the force merge operation on one or more indices.
+      description: Performs the force merge operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -1441,7 +1441,7 @@ paths:
       operationId: indices.get_mapping.1
       x-operation-group: indices.get_mapping
       x-version-added: '1.0'
-      description: Returns mappings for one or more indices.
+      description: Returns mappings for one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/field-types/index/#get-a-mapping
       parameters:
@@ -1559,7 +1559,7 @@ paths:
       operationId: indices.refresh.2
       x-operation-group: indices.refresh
       x-version-added: '1.0'
-      description: Performs the refresh operation in one or more indices.
+      description: Performs the refresh operation in one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
       parameters:
@@ -1574,7 +1574,7 @@ paths:
       operationId: indices.refresh.3
       x-operation-group: indices.refresh
       x-version-added: '1.0'
-      description: Performs the refresh operation in one or more indices.
+      description: Performs the refresh operation in one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
       parameters:
@@ -1610,7 +1610,7 @@ paths:
       operationId: indices.get_settings.2
       x-operation-group: indices.get_settings
       x-version-added: '1.0'
-      description: Returns settings for one or more indices.
+      description: Returns settings for one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/get-settings/
       parameters:
@@ -1653,7 +1653,7 @@ paths:
       operationId: indices.get_settings.3
       x-operation-group: indices.get_settings
       x-version-added: '1.0'
-      description: Returns settings for one or more indices.
+      description: Returns settings for one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/get-settings/
       parameters:
@@ -1675,7 +1675,7 @@ paths:
       operationId: indices.shard_stores.1
       x-operation-group: indices.shard_stores
       x-version-added: '1.0'
-      description: Provides store information for shard copies of indices.
+      description: Provides store information for shard copies of indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -2005,7 +2005,7 @@ components:
               is_write_index:
                 description: |-
                   If `true`, sets the write index or data stream for the alias.
-                  If an alias points to multiple indices or data streams and `is_write_index` isn't set, the alias rejects write requests.
+                  If an alias points to multiple indexes or data streams and `is_write_index` isn't set, the alias rejects write requests.
                   If an index alias points to one index and `is_write_index` isn't set, the index automatically acts as the write index.
                   Data stream aliases don't automatically set a write data stream, even if the alias points to one data stream.
                 type: boolean
@@ -2125,7 +2125,7 @@ components:
               index_patterns:
                 description: |-
                   Array of wildcard expressions used to match the names
-                  of indices during creation.
+                  of indexes during creation.
                 oneOf:
                   - type: string
                   - type: array
@@ -2203,8 +2203,8 @@ components:
               allow_auto_create:
                 description: |-
                   This setting overrides the value of the `action.auto_create_index` cluster setting.
-                  If set to `true` in a template, then indices can be automatically created using that template even if auto-creation of indices is disabled via `actions.auto_create_index`.
-                  If set to `false`, then indices or data streams matching the template must always be explicitly created, and may never be automatically created.
+                  If set to `true` in a template, then indexes can be automatically created using that template even if auto-creation of indexes is disabled using `actions.auto_create_index`.
+                  If set to `false`, then indexes or data streams matching the template must always be explicitly created, and may never be automatically created.
                 type: boolean
               index_patterns:
                 $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -2374,7 +2374,7 @@ components:
               _shards:
                 $ref: '../schemas/_common.yaml#/components/schemas/ShardStatistics'
               backing_indices:
-                description: Total number of backing indices for the selected data streams.
+                description: Total number of backing indexes for the selected data streams.
                 type: number
               data_stream_count:
                 description: Total number of selected data streams.
@@ -2771,7 +2771,7 @@ components:
     indices.add_block::path.index:
       in: path
       name: index
-      description: A comma separated list of indices to add a block to
+      description: A comma separated list of indexes to add a block to
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -2779,7 +2779,7 @@ components:
     indices.add_block::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+      description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified)
       schema:
         type: boolean
       style: form
@@ -2793,14 +2793,14 @@ components:
     indices.add_block::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
     indices.add_block::query.ignore_unavailable:
       in: query
       name: ignore_unavailable
-      description: Whether specified concrete indices should be ignored when unavailable (missing or closed)
+      description: Whether specified concrete indexes should be ignored when unavailable (missing or closed)
       schema:
         type: boolean
       style: form
@@ -2843,9 +2843,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -2854,8 +2854,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -2905,13 +2905,13 @@ components:
     indices.clear_cache::query.index:
       name: index
       in: query
-      description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+      description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+        description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
       explode: true
     indices.clear_cache::query.query:
       in: query
@@ -3007,8 +3007,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -3141,7 +3141,7 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of indices to delete.
+        Comma-separated list of indexes to delete.
         You cannot specify index aliases.
         By default, this parameter does not support wildcards (`*`) or `_all`.
         To use wildcards or `_all`, set the `action.destructive_requires_name` cluster setting to `false`.
@@ -3153,8 +3153,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
         default: false
@@ -3210,7 +3210,7 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams or indices used to limit the request.
+        Comma-separated list of data streams or indexes used to limit the request.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -3335,7 +3335,7 @@ components:
     indices.exists::path.index:
       in: path
       name: index
-      description: Comma-separated list of data streams, indices, and aliases. Supports wildcards (`*`).
+      description: Comma-separated list of data streams, indexes, and aliases. Supports wildcards (`*`).
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -3351,8 +3351,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
         default: false
@@ -3404,8 +3404,8 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams or indices used to limit the request. Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        Comma-separated list of data streams or indexes used to limit the request. Supports wildcards (`*`).
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -3422,8 +3422,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -3441,7 +3441,7 @@ components:
     indices.exists_alias::query.ignore_unavailable:
       in: query
       name: ignore_unavailable
-      description: If `false`, requests that include a missing data stream or index in the target indices or data streams return an error.
+      description: If `false`, requests that include a missing data stream or index in the target indexes or data streams return an error.
       schema:
         type: boolean
       style: form
@@ -3539,9 +3539,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases to flush.
+        Comma-separated list of data streams, indexes, and aliases to flush.
         Supports wildcards (`*`).
-        To flush all data streams and indices, omit this parameter or use `*` or `_all`.
+        To flush all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -3550,8 +3550,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -3593,7 +3593,7 @@ components:
     indices.forcemerge::path.index:
       in: path
       name: index
-      description: A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+      description: A comma-separated list of index names; use `_all` or empty string to perform the operation on all indexes
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -3601,14 +3601,14 @@ components:
     indices.forcemerge::query.allow_no_indices:
       in: query
       name: allow_no_indices
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
+      description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified)
       schema:
         type: boolean
       style: form
     indices.forcemerge::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
@@ -3623,7 +3623,7 @@ components:
     indices.forcemerge::query.ignore_unavailable:
       in: query
       name: ignore_unavailable
-      description: Whether specified concrete indices should be ignored when unavailable (missing or closed)
+      description: Whether specified concrete indexes should be ignored when unavailable (missing or closed)
       schema:
         type: boolean
       style: form
@@ -3666,7 +3666,7 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and index aliases used to limit the request.
+        Comma-separated list of data streams, indexes, and index aliases used to limit the request.
         Wildcard expressions (*) are supported.
       required: true
       schema:
@@ -3677,7 +3677,7 @@ components:
       name: allow_no_indices
       description: |-
         If false, the request returns an error if any wildcard expression, index alias, or _all value targets only
-        missing or closed indices. This behavior applies even if the request targets other open indices. For example,
+        missing or closed indexes. This behavior applies even if the request targets other open indexes. For example,
         a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.
       schema:
         type: boolean
@@ -3746,9 +3746,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams or indices used to limit the request.
+        Comma-separated list of data streams or indexes used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -3768,8 +3768,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -3821,9 +3821,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -3832,8 +3832,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -3915,9 +3915,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -3926,8 +3926,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -3960,9 +3960,9 @@ components:
       in: query
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
       style: form
@@ -3990,9 +3990,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit
+        Comma-separated list of data streams, indexes, and aliases used to limit
         the request. Supports wildcards (`*`). To target all data streams and
-        indices, omit this parameter or use `*` or `_all`.
+        indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4010,8 +4010,8 @@ components:
       name: allow_no_indices
       description: |-
         If `false`, the request returns an error if any wildcard expression, index
-        alias, or `_all` value targets only missing or closed indices. This
-        behavior applies even if the request targets other open indices. For
+        alias, or `_all` value targets only missing or closed indexes. This
+        behavior applies even if the request targets other open indexes. For
         example, a request targeting `foo*,bar*` returns an error if an index
         starts with foo but no index starts with `bar`.
       schema:
@@ -4129,40 +4129,40 @@ components:
     indices.get_upgrade::path.index:
       name: index
       in: path
-      description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+      description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
       schema:
         type: array
-        description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+        description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
         items:
           type: string
       required: true
     indices.get_upgrade::query.allow_no_indices:
       name: allow_no_indices
       in: query
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
+      description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
       schema:
         type: boolean
-        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
+        description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
     indices.get_upgrade::query.expand_wildcards:
       name: expand_wildcards
       in: query
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
     indices.get_upgrade::query.ignore_unavailable:
       name: ignore_unavailable
       in: query
-      description: Whether specified concrete indices should be ignored when unavailable (missing or closed).
+      description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
       schema:
         type: boolean
-        description: Whether specified concrete indices should be ignored when unavailable (missing or closed).
+        description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
     indices.open::path.index:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        By default, you must explicitly name the indices you using to limit the request.
+        By default, you must explicitly name the indexes you using to limit the request.
         To limit a request using `_all`, `*`, or other wildcard expressions, change the `action.destructive_requires_name` setting to false.
         You can update this setting in the `opensearch.yml` file or using the cluster update settings API.
       required: true
@@ -4173,8 +4173,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -4252,9 +4252,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams or indices to add.
+        Comma-separated list of data streams or indexes to add.
         Supports wildcards (`*`).
-        Wildcard patterns that match both data streams and indices return an error.
+        Wildcard patterns that match both data streams and indexes return an error.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4341,7 +4341,7 @@ components:
     indices.put_mapping::path.index:
       in: path
       name: index
-      description: A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.
+      description: A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indexes.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4350,8 +4350,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -4413,9 +4413,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit
+        Comma-separated list of data streams, indexes, and aliases used to limit
         the request. Supports wildcards (`*`). To target all data streams and
-        indices, omit this parameter or use `*` or `_all`.
+        indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4425,8 +4425,8 @@ components:
       name: allow_no_indices
       description: |-
         If `false`, the request returns an error if any wildcard expression, index
-        alias, or `_all` value targets only missing or closed indices. This
-        behavior applies even if the request targets other open indices. For
+        alias, or `_all` value targets only missing or closed indexes. This
+        behavior applies even if the request targets other open indexes. For
         example, a request targeting `foo*,bar*` returns an error if an index
         starts with `foo` but no index starts with `bar`.
       schema:
@@ -4461,7 +4461,7 @@ components:
     indices.put_settings::query.ignore_unavailable:
       in: query
       name: ignore_unavailable
-      description: Whether specified concrete indices should be ignored when unavailable (missing or closed).
+      description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
       schema:
         type: boolean
       style: form
@@ -4546,9 +4546,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4573,9 +4573,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4584,8 +4584,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -4611,7 +4611,7 @@ components:
       in: path
       name: name
       description: |-
-        Comma-separated name(s) or index pattern(s) of the indices, aliases, and data streams to resolve.
+        Comma-separated name(s) or index pattern(s) of the indexes, aliases, and data streams to resolve.
         Resources on remote clusters can be specified using the `<cluster>`:`<name>` syntax.
       required: true
       schema:
@@ -4696,9 +4696,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
         Supports wildcards (`*`).
-        To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4707,8 +4707,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -4741,7 +4741,7 @@ components:
     indices.shard_stores::path.index:
       in: path
       name: index
-      description: List of data streams, indices, and aliases used to limit the request.
+      description: List of data streams, indexes, and aliases used to limit the request.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -4751,8 +4751,8 @@ components:
       name: allow_no_indices
       description: |-
         If false, the request returns an error if any wildcard expression, index alias, or _all
-        value targets only missing or closed indices. This behavior applies even if the request
-        targets other open indices.
+        value targets only missing or closed indexes. This behavior applies even if the request
+        targets other open indexes.
       schema:
         type: boolean
       style: form
@@ -4768,7 +4768,7 @@ components:
     indices.shard_stores::query.ignore_unavailable:
       in: query
       name: ignore_unavailable
-      description: If true, missing or closed indices are not included in the response.
+      description: If true, missing or closed indexes are not included in the response.
       schema:
         type: boolean
       style: form
@@ -5029,7 +5029,7 @@ components:
     indices.stats::path.index:
       in: path
       name: index
-      description: A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices
+      description: A comma-separated list of index names; use `_all` or empty string to perform the operation on all indexes
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -5080,7 +5080,7 @@ components:
     indices.stats::query.forbid_closed_indices:
       in: query
       name: forbid_closed_indices
-      description: If true, statistics are not collected from closed indices.
+      description: If true, statistics are not collected from closed indexes.
       schema:
         type: boolean
         default: true
@@ -5150,33 +5150,33 @@ components:
     indices.upgrade::path.index:
       name: index
       in: path
-      description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+      description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
       schema:
         type: array
-        description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+        description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
         items:
           type: string
       required: true
     indices.upgrade::query.allow_no_indices:
       name: allow_no_indices
       in: query
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
+      description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
       schema:
         type: boolean
-        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
+        description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
     indices.upgrade::query.expand_wildcards:
       name: expand_wildcards
       in: query
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
     indices.upgrade::query.ignore_unavailable:
       name: ignore_unavailable
       in: query
-      description: Whether specified concrete indices should be ignored when unavailable (missing or closed).
+      description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
       schema:
         type: boolean
-        description: Whether specified concrete indices should be ignored when unavailable (missing or closed).
+        description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
     indices.upgrade::query.only_ancient_segments:
       name: only_ancient_segments
       in: query
@@ -5197,9 +5197,9 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases to search.
+        Comma-separated list of data streams, indexes, and aliases to search.
         Supports wildcards (`*`).
-        To search all data streams or indices, omit this parameter or use `*` or `_all`.
+        To search all data streams or indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -5215,8 +5215,8 @@ components:
       in: query
       name: allow_no_indices
       description: |-
-        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
-        This behavior applies even if the request targets other open indices.
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
       schema:
         type: boolean
       style: form

--- a/spec/namespaces/ism.yaml
+++ b/spec/namespaces/ism.yaml
@@ -399,7 +399,7 @@ components:
       name: index
       in: query
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -408,7 +408,7 @@ components:
       name: index
       in: path
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -418,7 +418,7 @@ components:
       name: index
       in: query
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -427,7 +427,7 @@ components:
       name: index
       in: query
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -436,7 +436,7 @@ components:
       name: index
       in: path
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -446,7 +446,7 @@ components:
       name: index
       in: path
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -456,7 +456,7 @@ components:
       name: index
       in: path
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -466,7 +466,7 @@ components:
       name: index
       in: query
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -475,7 +475,7 @@ components:
       name: index
       in: path
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:
@@ -485,7 +485,7 @@ components:
       name: index
       in: path
       description: |-
-        Comma-separated list of data streams, indices, and aliases.
+        Comma-separated list of data streams, indexes, and aliases.
         Supports wildcards (`*`).
       required: true
       schema:

--- a/spec/namespaces/knn.yaml
+++ b/spec/namespaces/knn.yaml
@@ -354,10 +354,10 @@ components:
     knn.search_models::query.allow_no_indices:
       name: allow_no_indices
       in: query
-      description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
+      description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
       schema:
         type: boolean
-        description: Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified).
+        description: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
     knn.search_models::query.allow_partial_search_results:
       name: allow_partial_search_results
       in: query
@@ -425,7 +425,7 @@ components:
     knn.search_models::query.expand_wildcards:
       name: expand_wildcards
       in: query
-      description: Whether to expand wildcard expression to concrete indices that are open, closed or both.
+      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
     knn.search_models::query.explain:
@@ -447,17 +447,17 @@ components:
     knn.search_models::query.ignore_throttled:
       name: ignore_throttled
       in: query
-      description: Whether specified concrete, expanded or aliased indices should be ignored when throttled.
+      description: Whether specified concrete, expanded or aliased indexes should be ignored when throttled.
       schema:
         type: boolean
-        description: Whether specified concrete, expanded or aliased indices should be ignored when throttled.
+        description: Whether specified concrete, expanded or aliased indexes should be ignored when throttled.
     knn.search_models::query.ignore_unavailable:
       name: ignore_unavailable
       in: query
-      description: Whether specified concrete indices should be ignored when unavailable (missing or closed).
+      description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
       schema:
         type: boolean
-        description: Whether specified concrete indices should be ignored when unavailable (missing or closed).
+        description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
     knn.search_models::query.lenient:
       name: lenient
       in: query
@@ -724,10 +724,10 @@ components:
     knn.warmup::path.index:
       name: index
       in: path
-      description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+      description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
       schema:
         type: array
-        description: Comma-separated list of indices; use `_all` or empty string to perform the operation on all indices.
+        description: Comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
         items:
           type: string
       required: true

--- a/spec/namespaces/nodes.yaml
+++ b/spec/namespaces/nodes.yaml
@@ -506,7 +506,7 @@ components:
     nodes.stats::path.index_metric:
       in: path
       name: index_metric
-      description: Limit the information returned for indices metric to the specific index metrics. It can be used only if indices (or all) metric is specified.
+      description: Limit the information returned for indexes metric to the specific index metrics. It can be used only if indexes (or all) metric is specified.
       required: true
       schema:
         type: array

--- a/spec/namespaces/security.yaml
+++ b/spec/namespaces/security.yaml
@@ -362,7 +362,7 @@ paths:
       x-distributions-excluded:
         - amazon-managed
         - amazon-serverless
-      description: Creates or replaces the allowlisted APIs. Accessible via Super Admin certificate or REST API permission.
+      description: Creates or replaces the permitted APIs. Accessible using Super Admin certificate or REST API permission.
       externalDocs:
         url: https://opensearch.org/docs/latest/security/access-control/api/#access-control-for-the-api
       requestBody:

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -223,7 +223,7 @@ paths:
       operationId: snapshot.clone.0
       x-operation-group: snapshot.clone
       x-version-added: '1.0'
-      description: Clones indices from one snapshot into another snapshot in the same repository.
+      description: Clones indexes from one snapshot into another snapshot in the same repository.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
@@ -294,22 +294,22 @@ components:
             type: object
             properties:
               ignore_unavailable:
-                description: If `true`, the request ignores data streams and indices in `indices` that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed.
+                description: If `true`, the request ignores data streams and indexes in `indices` that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed.
                 type: boolean
               include_global_state:
-                description: If `true`, the current cluster state is included in the snapshot. The cluster state includes persistent cluster settings, composable index templates, legacy index templates, ingest pipelines, and ILM policies. It also includes data stored in system indices, such as Watches and task records (configurable via `feature_states`).
+                description: If `true`, the current cluster state is included in the snapshot. The cluster state includes persistent cluster settings, composable index templates, legacy index templates, ingest pipelines, and ILM policies. It also includes data stored in system indexes, such as Watches and task records (configurable with `feature_states`).
                 type: boolean
               indices:
                 $ref: '../schemas/_common.yaml#/components/schemas/Indices'
               feature_states:
-                description: Feature states to include in the snapshot. Each feature state includes one or more system indices containing related data. You can view a list of eligible features using the get features API. If `include_global_state` is `true`, all current feature states are included by default. If `include_global_state` is `false`, no feature states are included by default.
+                description: Feature states to include in the snapshot. Each feature state includes one or more system indexes containing related data. You can view a list of eligible features using the get features API. If `include_global_state` is `true`, all current feature states are included by default. If `include_global_state` is `false`, no feature states are included by default.
                 type: array
                 items:
                   type: string
               metadata:
                 $ref: '../schemas/_common.yaml#/components/schemas/Metadata'
               partial:
-                description: If `true`, allows restoring a partial snapshot of indices with unavailable shards. Only shards that were successfully included in the snapshot will be restored. All missing shards will be recreated as empty. If `false`, the entire restore operation will fail if one or more indices included in the snapshot do not have all primary shards available.
+                description: If `true`, allows restoring a partial snapshot of indexes with unavailable shards. Only shards that were successfully included in the snapshot will be restored. All missing shards will be recreated as empty. If `false`, the entire restore operation will fail if one or more indexes included in the snapshot do not have all primary shards available.
                 type: boolean
             description: The snapshot definition
     snapshot.create_repository:

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -760,7 +760,7 @@ components:
               $ref: '#/components/schemas/IgnoreUnmapped'
               description: |-
                 Indicates whether to ignore an unmapped `parent_type` and not return any documents instead of an error.
-                You can use this parameter to query multiple indices that may not contain the `parent_type`.
+                You can use this parameter to query multiple indexes that may not contain the `parent_type`.
             inner_hits:
               $ref: '_core.search.yaml#/components/schemas/InnerHits'
             parent_type:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -429,16 +429,16 @@ components:
           description: Match any index, including hidden ones.
         - type: string
           const: closed
-          description: Match closed, non-hidden indices.
+          description: Match closed, non-hidden indexes.
         - type: string
           const: hidden
-          description: Match hidden indices. Must be combined with open, closed, or both.
+          description: Match hidden indexes. Must be combined with open, closed, or both.
         - type: string
           const: none
           description: Wildcard expressions are not accepted.
         - type: string
           const: open
-          description: Match open, non-hidden indices.
+          description: Match open, non-hidden indexes.
     VersionString:
       type: string
     SearchType:

--- a/spec/schemas/asynchronous_search._common.yaml
+++ b/spec/schemas/asynchronous_search._common.yaml
@@ -67,7 +67,7 @@ components:
         track_total_hits:
           $ref: '_core.search.yaml#/components/schemas/TrackHits'
         indices_boost:
-          description: Boosts the _score of documents from specified indices.
+          description: Boosts the `_score` of documents from specified indexes.
           type: array
           items:
             type: object
@@ -132,7 +132,7 @@ components:
             Use with caution.
             OpenSearch applies this parameter to each shard handling the request.
             When possible, let OpenSearch perform early termination automatically.
-            Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
+            Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
             If set to `0` (default), the query does not terminate early.
           type: integer
           format: int32
@@ -159,7 +159,7 @@ components:
           description: |-
             Stats groups to associate with the search.
             Each group maintains a statistics aggregation for its associated searches.
-            You can retrieve these stats using the indices stats API.
+            You can retrieve these stats using the indexes stats API.
           type: array
           items:
             type: string

--- a/spec/schemas/cat.snapshots.yaml
+++ b/spec/schemas/cat.snapshots.yaml
@@ -36,7 +36,7 @@ components:
         duration:
           $ref: '_common.yaml#/components/schemas/Duration'
         indices:
-          description: The number of indices in the snapshot.
+          description: The number of indexes in the snapshot.
           type: string
         successful_shards:
           description: The number of successful shards in the snapshot.

--- a/spec/schemas/cluster.stats.yaml
+++ b/spec/schemas/cluster.stats.yaml
@@ -37,7 +37,7 @@ components:
         completion:
           $ref: '_common.yaml#/components/schemas/CompletionStats'
         count:
-          description: Total number of indices with shards assigned to selected nodes.
+          description: Total number of indexes with shards assigned to selected nodes.
           type: number
         docs:
           $ref: '_common.yaml#/components/schemas/DocStats'
@@ -119,7 +119,7 @@ components:
           description: The number of occurrences of the field type in selected nodes.
           type: number
         index_count:
-          description: The number of indices containing the field type in selected nodes.
+          description: The number of indexes containing the field type in selected nodes.
           type: number
         indexed_vector_count:
           description: For dense_vector field types, number of indexed vector types in selected nodes.
@@ -192,7 +192,7 @@ components:
           description: Total number of fields in all non-system indices.
           type: number
         total_deduplicated_field_count:
-          description: Total number of fields in all non-system indices, accounting for mapping deduplication.
+          description: Total number of fields in all non-system indexes, accounting for mapping deduplication.
           type: number
         total_deduplicated_mapping_size:
           $ref: '_common.yaml#/components/schemas/HumanReadableByteCount'

--- a/spec/schemas/indices._common.yaml
+++ b/spec/schemas/indices._common.yaml
@@ -386,7 +386,7 @@ components:
           description: |-
             The index alias to update when the index rolls over. Specify when using a policy that contains a rollover action.
             When the index rolls over, the alias is updated to reflect that the index is no longer the write index. For more
-            information about rolling indices, see Rollover.
+            information about rolling indexes, see Rollover.
           type: string
       required:
         - name
@@ -708,7 +708,7 @@ components:
           $ref: '#/components/schemas/StorageType'
         allow_mmap:
           description: |-
-            You can restrict the use of the mmapfs and the related hybridfs store type via the setting node.store.allow_mmap.
+            You can restrict the use of the `mmapfs` and the related `hybridfs` store types with the setting `node.store.allow_mmap`.
             This is a boolean setting indicating whether or not memory-mapping is allowed. The default is to allow it. This
             setting is useful, for example, if you are in an environment where you can not control the ability to create a lot
             of memory maps so you need disable the ability to use memory-mapping.
@@ -773,7 +773,7 @@ components:
         is_hidden:
           description: |-
             If `true`, the alias is hidden.
-            All indices for the alias must have the same `is_hidden` value.
+            All indexes for the alias must have the same `is_hidden` value.
           type: boolean
     IndexState:
       type: object
@@ -800,7 +800,7 @@ components:
         is_hidden:
           description: |-
             If `true`, the alias is hidden.
-            All indices for the alias must have the same `is_hidden` value.
+            All indexes for the alias must have the same `is_hidden` value.
           type: boolean
         is_write_index:
           description: If `true`, the index is the write index for the alias.
@@ -832,7 +832,7 @@ components:
           type: boolean
         indices:
           description: |-
-            Array of objects containing information about the data stream's backing indices.
+            Array of objects containing information about the data stream's backing indexes.
             The last item in this array contains information about the stream's current write index.
           type: array
           items:

--- a/spec/schemas/indices.data_streams_stats.yaml
+++ b/spec/schemas/indices.data_streams_stats.yaml
@@ -10,7 +10,7 @@ components:
       type: object
       properties:
         backing_indices:
-          description: Current number of backing indices for the data stream.
+          description: Current number of backing indexes for the data stream.
           type: number
         data_stream:
           $ref: '_common.yaml#/components/schemas/Name'

--- a/spec/schemas/insights._common.yaml
+++ b/spec/schemas/insights._common.yaml
@@ -50,7 +50,7 @@ components:
           type: array
           items:
             type: string
-          description: The indices involved in the query.
+          description: The indexes involved in the query.
         phase_latency_map:
           type: object
         measurements:
@@ -111,7 +111,7 @@ components:
         track_total_hits:
           $ref: '_core.search.yaml#/components/schemas/TrackHits'
         indices_boost:
-          description: Boosts the _score of documents from specified indices.
+          description: Boosts the `_score` of documents from specified indexes.
           type: array
           items:
             type: object
@@ -174,7 +174,7 @@ components:
             Use with caution.
             OpenSearch applies this parameter to each shard handling the request.
             When possible, let OpenSearch perform early termination automatically.
-            Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
+            Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
             If set to `0` (default), the query does not terminate early.
           type: integer
           format: int32
@@ -201,7 +201,7 @@ components:
           description: |-
             Stats groups to associate with the search.
             Each group maintains a statistics aggregation for its associated searches.
-            You can retrieve these stats using the indices stats API.
+            You can retrieve these stats using the indexes stats API.
           type: array
           items:
             type: string

--- a/tests/default/_core/refresh.yaml
+++ b/tests/default/_core/refresh.yaml
@@ -3,7 +3,7 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 description: Test _refresh.
 
 chapters:
-  - synopsis: Refresh all indices in the cluster.
+  - synopsis: Refresh all indexes in the cluster.
     path: /_refresh
     method: GET
     response:

--- a/tests/default/cat/segments.yaml
+++ b/tests/default/cat/segments.yaml
@@ -11,7 +11,7 @@ epilogues:
     method: DELETE
     status: [200, 404]
 chapters:
-  - synopsis: List Lucene segment-level information for all indices.
+  - synopsis: List Lucene segment-level information for all indexes.
     path: /_cat/segments
     method: GET
     parameters:

--- a/tests/default/indices/mapping.yaml
+++ b/tests/default/indices/mapping.yaml
@@ -41,7 +41,7 @@ chapters:
                 type: text
               year:
                 type: integer
-  - synopsis: Get mappings for multiple indices.
+  - synopsis: Get mappings for multiple indexes.
     path: /{index}/_mapping
     method: GET
     parameters:

--- a/tests/default/ism/explain.yaml
+++ b/tests/default/ism/explain.yaml
@@ -26,10 +26,10 @@ prologues:
       payload:
         policy_id: ${policy.id}
 chapters:
-  - synopsis: Get the total managed indices count (GET).
+  - synopsis: Get the total managed indexes count (GET).
     path: /_plugins/_ism/explain
     method: GET
-  - synopsis: Get the total managed indices count (POST).
+  - synopsis: Get the total managed indexes count (POST).
     version: '>= 2.12'
     path: /_plugins/_ism/explain
     method: POST

--- a/tests/default/security/api/internalusers/authtoken.yaml
+++ b/tests/default/security/api/internalusers/authtoken.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test internalusers/authtoken endpoint.
-version: '> 2.16' # Fixed via https://github.com/opensearch-project/security/pull/4628
+version: '> 2.16' # Fixed in https://github.com/opensearch-project/security/pull/4628
 distributions:
   excluded:
     - amazon-managed

--- a/tests/default/security/api/securityconfig/config.yaml
+++ b/tests/default/security/api/securityconfig/config.yaml
@@ -37,7 +37,7 @@ chapters:
               authentication_backend: 
                 type: intern
                 config: {}
-              description: Authenticate via HTTP Basic against internal users database
+              description: Authenticate using HTTP Basic against internal users database.
           auth_failure_listeners: {}
           do_not_fail_on_forbidden: false
           multi_rolespan_enabled: true

--- a/tests/default/security/api/user/authtoken.yaml
+++ b/tests/default/security/api/user/authtoken.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../../../json_schemas/test_story.schema.yaml
 
 description: Test authtoken endpoints for user.
-version: '> 2.16' # Fixed via https://github.com/opensearch-project/security/pull/4628
+version: '> 2.16' # Fixed in https://github.com/opensearch-project/security/pull/4628
 distributions:
   excluded:
     - amazon-managed

--- a/tests/default/security/authinfo.yaml
+++ b/tests/default/security/authinfo.yaml
@@ -12,7 +12,7 @@ chapters:
     version: < 2.13
     response:
       status: 200
-  - synopsis: Get auth info via POST.
+  - synopsis: Get auth info using POST.
     path: /_plugins/_security/authinfo
     method: POST
     version: < 2.13

--- a/tests/default/security/dashboardsinfo.yaml
+++ b/tests/default/security/dashboardsinfo.yaml
@@ -11,7 +11,7 @@ chapters:
     method: GET
     response:
       status: 200
-  - synopsis: Get dashboards info via POST.
+  - synopsis: Get dashboards info using POST.
     path: /_plugins/_security/dashboardsinfo
     method: POST
     response:

--- a/tests/default/security/health.yaml
+++ b/tests/default/security/health.yaml
@@ -17,7 +17,7 @@ chapters:
         message: null
         mode: strict
         status: UP
-  - synopsis: Get security health info via POST.
+  - synopsis: Get security health info using POST.
     path: /_plugins/_security/health
     method: POST
     parameters:

--- a/tests/default/security/tenantinfo.yaml
+++ b/tests/default/security/tenantinfo.yaml
@@ -12,7 +12,7 @@ chapters:
     response: 
       status: 403 # only allowed for super-admin or dashboards-server role mapping
       content_type: text/plain
-  - synopsis: Get tenant info via POST.
+  - synopsis: Get tenant info using POST.
     path: /_plugins/_security/tenantinfo
     method: POST
     response:

--- a/tests/default/security/whoami.yaml
+++ b/tests/default/security/whoami.yaml
@@ -16,7 +16,7 @@ chapters:
         dn: null
         is_admin: false
         is_node_certificate_request: false
-  - synopsis: Get current user info via POST.
+  - synopsis: Get current user info using POST.
     path: /_plugins/_security/whoami
     method: POST
     response:

--- a/tools/tests/merger/fixtures/extractor/opensearch/expected_1.3.yaml
+++ b/tools/tests/merger/fixtures/extractor/opensearch/expected_1.3.yaml
@@ -114,13 +114,13 @@ components:
             type: object
       description: ''
     info___added-1.3-removed-2.0:
-      description: Added in 1.3, removed in 2.0 via attribute in response body.
+      description: Added in 1.3, removed in 2.0 using an attribute in response body.
       x-version-added: '1.3'
       x-version-removed: '2.0'
     info___distributed-all:
       description: Distributed in opensearch.org, AOS and AOSS.
     info___removed-2.0:
-      description: Removed in 2.0 via attribute next to ref.
+      description: Removed in 2.0 using an attribute next to ref.
     info___removed-2.0-refs:
       description: One of the ref values removed in 2.0.
       schema:

--- a/tools/tests/merger/fixtures/extractor/opensearch/expected_2.0.yaml
+++ b/tools/tests/merger/fixtures/extractor/opensearch/expected_2.0.yaml
@@ -154,7 +154,7 @@ components:
             type: object
       description: ''
     info___added-2.0:
-      description: Added in 2.0 via attribute next to ref.
+      description: Added in 2.0 using an attribute next to ref.
     info___distributed-all:
       description: Distributed in opensearch.org, AOS and AOSS.
     info___removed-2.0-refs:

--- a/tools/tests/merger/fixtures/specs/opensearch/namespaces/index.yaml
+++ b/tools/tests/merger/fixtures/specs/opensearch/namespaces/index.yaml
@@ -82,9 +82,9 @@ components:
             unevaluatedProperties:
               type: object
     info@added-2.0:
-      description: Added in 2.0 via attribute next to ref.
+      description: Added in 2.0 using an attribute next to ref.
     info@removed-2.0:
-      description: Removed in 2.0 via attribute next to ref.
+      description: Removed in 2.0 using an attribute next to ref.
     info@removed-2.0-refs:
       description: One of the ref values removed in 2.0.
       schema:
@@ -92,11 +92,11 @@ components:
           - $ref: '../schemas/_common.yaml#/components/schemas/Type'
           - $ref: '../schemas/_common.yaml#/components/schemas/OldId'
     info@added-1.3-removed-2.0:
-      description: Added in 1.3, removed in 2.0 via attribute in response body.
+      description: Added in 1.3, removed in 2.0 using an attribute in response body.
       x-version-added: '1.3'
       x-version-removed: '2.0'
     info@added-2.1:
-      description: Added in 2.1 via attribute in response body.
+      description: Added in 2.1 using an attribute in response body.
       x-version-added: '2.1'
     info@distributed-amazon-managed:
       description: Distributed only in AOS.

--- a/tools/tests/tester/fixtures/specs/complete/namespaces/index.yaml
+++ b/tools/tests/tester/fixtures/specs/complete/namespaces/index.yaml
@@ -80,15 +80,15 @@ components:
             unevaluatedProperties:
               type: object
     info@added-2.0:
-      description: Added in 2.0 via attribute next to ref.
+      description: Added in 2.0 using an attribute next to ref.
     info@removed-2.0:
-      description: Removed in 2.0 via attribute next to ref.
+      description: Removed in 2.0 using an attribute next to ref.
     info@added-1.3-removed-2.0:
-      description: Added in 1.3, removed in 2.0 via attribute in response body.
+      description: Added in 1.3, removed in 2.0 using an attribute in response body.
       x-version-added: '1.3'
       x-version-removed: '2.0'
     info@added-2.1:
-      description: Added in 2.1 via attribute in response body.
+      description: Added in 2.1 using an attribute in response body.
       x-version-added: '2.1'
     info@distributed-amazon-managed:
       description: Distributed only in AOS.

--- a/tools/tests/tester/fixtures/specs/excerpt.yaml
+++ b/tools/tests/tester/fixtures/specs/excerpt.yaml
@@ -31,7 +31,7 @@ paths:
       operationId: cat.indices.1
       x-operation-group: cat.indices
       x-version-added: '1.0'
-      description: 'Returns information about indices: number of primaries and replicas, document counts, disk size, ...'
+      description: 'Returns information about indexes: number of primaries and replicas, document counts, disk size, ...'
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cat/cat-indices/
       parameters:
@@ -201,8 +201,8 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of data streams, indices, and aliases used to limit the request.
-        Supports wildcards (`*`). To target all data streams and indices, omit this parameter or use `*` or `_all`.
+        Comma-separated list of data streams, indexes, and aliases used to limit the request.
+        Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '#/components/schemas/_common:Indices'
@@ -216,7 +216,7 @@ components:
       in: path
       name: index
       description: |-
-        Comma-separated list of indices to delete.
+        Comma-separated list of indexes to delete.
         You cannot specify index aliases.
         By default, this parameter does not support wildcards (`*`) or `_all`.
         To use wildcards or `_all`, set the `action.destructive_requires_name` cluster setting to `false`.
@@ -235,7 +235,7 @@ components:
     indices.exists::path.index:
       in: path
       name: index
-      description: Comma-separated list of data streams, indices, and aliases. Supports wildcards (`*`).
+      description: Comma-separated list of data streams, indexes, and aliases. Supports wildcards (`*`).
       required: true
       schema:
         $ref: '#/components/schemas/_common:Indices'


### PR DESCRIPTION
### Description

Replaces all "indices" with "indexes". 

There's a debate whether this is right in https://github.com/opensearch-project/documentation-website/issues/8696, but in the meantime this standardizes the language to match what we have in the documentation and runs a Vale pass on many descriptions and avoids tripping lots of future contributions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
