### PR TITLE
Fixes to the Vale preprocessor.

### DIFF
--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -43,7 +43,7 @@ export default class KeepDescriptions {
         inside_description = true
       } else if (line.match(/^[\s]+(description:)[\s]+/)) {
         fs.writeSync(writer, this.prune(line).replace("description:", "            "))
-      } else if (inside_description && line.match(/^[\s]*[\w]*:/)) {
+      } else if (inside_description && line.match(/^[\s]*[\w\\$]*:/)) {
         inside_description = false
       } else if (inside_description) {
         fs.writeSync(writer, this.prune(line))

--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -36,17 +36,16 @@ export default class KeepDescriptions {
     const contents = fs.readFileSync(filename, 'utf-8')
     var writer = fs.openSync(filename, 'w+')
 
-    var inside_description = false
+    var inside_text = false
     contents.split(/\r?\n/).forEach((line) => {
-      // TODO: keep x-deprecation-message
-      if (line.match(/^[\s]+(description: \|)/)) {
-        inside_description = true
-      } else if (line.match(/^[\s]+(description:)[\s]+/)) {
-        fs.writeSync(writer, this.prune(line).replace("description:", "            "))
-      } else if (inside_description && line.match(/^[\s]*[\w\\$]*:/)) {
-        inside_description = false
-      } else if (inside_description) {
-        fs.writeSync(writer, this.prune(line))
+      if (line.match(/^[\s]+((description|x-deprecation-message): \|)/)) {
+        inside_text = true
+      } else if (line.match(/^[\s]+((description|x-deprecation-message):)[\s]+/)) {
+        fs.writeSync(writer, this.prune_vars(this.prune(line, /(description|x-deprecation-message):/, ' ')))
+      } else if (inside_text && line.match(/^[\s]*[\w\\$]*:/)) {
+        inside_text = false
+      } else if (inside_text) {
+        fs.writeSync(writer, this.prune_vars(line))
       }
       if (line.length > 0) {
         fs.writeSync(writer, "\n")
@@ -54,9 +53,13 @@ export default class KeepDescriptions {
     })
   }
 
-  prune(line: string): string {
-    return line.replace(/([`])(?:(?=(\\?))\2.)*?\1/g, (match) => {
-      return Array(match.length + 1).join('*')
+  prune_vars(line: string): string {
+    return this.prune(line, /([`])(?:(?=(\\?))\2.)*?\1/g, '*')
+  }
+
+  prune(line: string, regex: RegExp, char: string): string {
+    return line.replace(regex, (match) => {
+      return Array(match.length + 1).join(char)
     })
   }
 }

--- a/tools/tests/prepare-for-vale/fixtures/spec.txt
+++ b/tools/tests/prepare-for-vale/fixtures/spec.txt
@@ -35,3 +35,13 @@
 
         Line one.
 
+
+
+                             Deprecation message.
+                   Line one.
+
+
+
+        Line one.
+        Line two.
+                   Line one.

--- a/tools/tests/prepare-for-vale/fixtures/spec.txt
+++ b/tools/tests/prepare-for-vale/fixtures/spec.txt
@@ -30,3 +30,8 @@
         Line one
         Line with backticks: that includes *******.
         Line with two backticks: that includes ******* and *******.
+
+
+
+        Line one.
+

--- a/tools/tests/prepare-for-vale/fixtures/spec.yaml
+++ b/tools/tests/prepare-for-vale/fixtures/spec.yaml
@@ -35,3 +35,13 @@ components:
       description: |-
         Line one.
       $ref: '_common.yaml#/components/schemas/HumanReadableByteCount'
+    ObjectWithDeprecationMessageOneLine:
+      type: object
+      x-deprecation-message: Deprecation message.
+      description: Line one.
+    ObjectWithDeprecationMessageTwoLines:
+      type: object
+      x-deprecation-message: |-
+        Line one.
+        Line two.
+      description: Line one.

--- a/tools/tests/prepare-for-vale/fixtures/spec.yaml
+++ b/tools/tests/prepare-for-vale/fixtures/spec.yaml
@@ -30,3 +30,8 @@ components:
         Line one
         Line with backticks: that includes `x.y.z`.
         Line with two backticks: that includes `x.y.z` and `z.y.x`.
+    ObjectWithDescriptionAndRef:
+      type: object
+      description: |-
+        Line one.
+      $ref: '_common.yaml#/components/schemas/HumanReadableByteCount'


### PR DESCRIPTION
### Description

1. Properly captures `$ref`.
2. Adds `x-deprecation-message` to text to preserve so Vale can run on it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
