### PR TITLE
More tests, fixes ExplanationDetail/value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `/{index}/_create/{id}` returning `201` ([#669](https://github.com/opensearch-project/opensearch-api-specification/pull/669))
 - Fixed `ml._common.yaml#SearchModelsResponse` and `SearchModelsHitsHit` ([#672](https://github.com/opensearch-project/opensearch-api-specification/pull/672))
 - Fixed `refresh` options to allow `boolean` and `string` ([#673](https://github.com/opensearch-project/opensearch-api-specification/pull/673))
+- Fixed `value` type in `ExplanationDetail` and added `_type` to `explain@200` ([#685](https://github.com/opensearch-project/opensearch-api-specification/pull/685))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2926,6 +2926,8 @@ components:
           schema:
             type: object
             properties:
+              _type:
+                $ref: '../schemas/_common.yaml#/components/schemas/Type'
               _index:
                 $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
               _id:

--- a/spec/schemas/_core.explain.yaml
+++ b/spec/schemas/_core.explain.yaml
@@ -39,7 +39,7 @@ components:
           items:
             $ref: '#/components/schemas/ExplanationDetail'
         value:
-          oneOf:
+          anyOf:
             - type: integer
               format: int32
             - type: integer

--- a/tests/default/indices/block.yaml
+++ b/tests/default/indices/block.yaml
@@ -1,0 +1,25 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test limiting certain operations on a specified index.
+prologues:
+  - path: /movies
+    method: PUT
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Disable any write operations made to the index.
+    path: /{index}/_block/{block}
+    method: PUT
+    parameters:
+      index: movies
+      block: write
+    response:
+      status: 200
+      payload:
+        shards_acknowledged: true
+        acknowledged: true
+        indices:
+          - name: movies
+            blocked: true

--- a/tests/default/indices/clone.yaml
+++ b/tests/default/indices/clone.yaml
@@ -41,7 +41,7 @@ chapters:
   - synopsis: Clone an index (wait_for_completion).
     version: '>= 2.7'
     path: /{index}/_clone/{target}
-    method: POST
+    method: PUT
     parameters:
       index: movies
       target: games2
@@ -51,7 +51,7 @@ chapters:
   - synopsis: Clone an index (cluster_manager_timeout).
     version: '>= 2.0'
     path: /{index}/_clone/{target}
-    method: POST
+    method: PUT
     parameters:
       index: movies
       target: games3

--- a/tests/default/indices/explain.yaml
+++ b/tests/default/indices/explain.yaml
@@ -1,0 +1,51 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test getting an explanation of how the relevance score is calculated for every result.
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: movies, _id: movie1}}
+        - {director: Bennett Miller, title: The Cruise, year: 1998}
+        - {create: {_index: movies, _id: movie2}}
+        - {director: Nicolas Winding Refn, title: Drive, year: 1960}
+chapters:
+  - synopsis: Explain the score for a match query (GET).
+    path: /{index}/_explain/{id}
+    method: GET
+    parameters:
+      index: movies
+      id: movie1
+    request:
+      payload:
+        query:
+          match:
+            year: 1998
+    response:
+      status: 200
+  - synopsis: Explain the score for a match query (POST).
+    path: /{index}/_explain/{id}
+    method: POST
+    parameters:
+      index: movies
+      id: movie2
+      preference: _local
+      routing: primary
+      _source: true
+      _source_excludes: title
+      _source_includes: director
+    request:
+      payload:
+        query:
+          match:
+            title: Drive
+    response:
+      status: 200


### PR DESCRIPTION
### Description

- `PUT /{index}/_block/{block}`
- `PUT /{index}/_clone/{target}`
- `GET` and `POST /{index}/_explain/{id}`.
- Fixes `ExplanationDetail` type of `value` (an int32 is also an int64).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
