### PR TITLE
Added tests for the Lucene query string parameters.

### DIFF
--- a/tests/default/indices/explain.yaml
+++ b/tests/default/indices/explain.yaml
@@ -49,3 +49,32 @@ chapters:
             title: Drive
     response:
       status: 200
+  - synopsis: Explain the score using the Lucene query string syntax in the request body.
+    path: /{index}/_explain/{id}
+    method: POST
+    parameters:
+      index: movies
+      id: movie2
+    request:
+      payload:
+        query:
+          query_string:
+            default_field: title
+            query: Drive
+            analyzer: english
+    response:
+      status: 200
+  - synopsis: Explain the score using the Lucene query string syntax in parameters.
+    path: /{index}/_explain/{id}
+    method: GET
+    parameters:
+      index: movies
+      id: movie2
+      q: Drive
+      df: title
+      lenient: true
+      analyzer: english
+      default_operator: and
+      analyze_wildcard: true
+    response:
+      status: 200


### PR DESCRIPTION
### Description

Coming from https://github.com/opensearch-project/documentation-website/issues/8789, added working samples for the remaining `_explain` parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
