### PR TITLE
Split coverage checklist into its own workflow.

### DIFF
--- a/.github/workflows/analyze-pr-changes.yml
+++ b/.github/workflows/analyze-pr-changes.yml
@@ -116,18 +116,6 @@ jobs:
             $AFTER_COVERAGE \
             | tee $COVERAGE_DIFF
 
-      - name: Display Coverage Checklist
-        shell: bash -eo pipefail {0}
-        run: |
-          jq -sc '
-            (map(.endpoints .uncovered | to_entries | sort_by(.value) | map((.value[] | ascii_upcase) + " " + .key)) | .[] | to_entries | map({path: .value, covered: false})) as $uncovered |
-            (map(.endpoints .covered | to_entries | sort_by(.value) | map((.value[] | ascii_upcase) + " " + .key)) | .[] | to_entries | map({path: .value, covered: true})) as $covered |
-            $covered+$uncovered |
-            sort_by(.path) |
-            map(if .covered then "- [x] \(.path)" else "- [ ] \(.path)" end) |
-            .[]
-          ' $AFTER_COVERAGE | jq -r
-
       - name: Upload Coverage Data
         id: upload-coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,73 @@
+name: Analyze Spec Coverage
+
+on:
+  push:
+    paths:
+      - .github/workflows/coverage.yml
+      - package*.json
+      - spec/**
+      - tsconfig.json
+  pull_request:
+    paths:
+      - .github/workflows/coverage.yml
+      - package*.json
+      - spec/**
+      - tsconfig.json
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Dump OpenSearch Cluster's API
+        shell: bash -eo pipefail {0}
+        run: |
+          docker build coverage --tag opensearch-with-api-plugin
+
+          docker run \
+            --name opensearch \
+            --rm -d \
+            -p 9200:9200 -p 9600:9600 \
+            -e "discovery.type=single-node" \
+            -e OPENSEARCH_INITIAL_ADMIN_PASSWORD="$OPENSEARCH_PASSWORD" \
+            opensearch-with-api-plugin
+
+          npm ci
+
+          npm run dump-cluster-spec -- --opensearch-insecure --output build/opensearch-cluster.yaml
+
+          docker stop opensearch
+        env:
+          OPENSEARCH_PASSWORD: BobgG7YrtsdKf9M
+
+      - name: Build Spec
+        shell: bash -eo pipefail {0}
+        run: |
+          npm ci
+          npm run merge -- --source ./spec --output build/opensearch-openapi.yaml
+
+      - name: Calculate Coverage
+        shell: bash -eo pipefail {0}
+        run: |
+          npm run coverage:spec -- \
+              --cluster build/opensearch-cluster.yaml \
+              --specification build/opensearch-openapi.yaml \
+              --output build/coverage.yaml
+
+          jq . build/coverage.yaml
+
+      - name: Display Coverage Checklist
+        shell: bash -eo pipefail {0}
+        run: |
+          jq -sc '
+            (map(.endpoints .uncovered | to_entries | sort_by(.value) | map((.value[] | ascii_upcase) + " " + .key)) | .[] | to_entries | map({path: .value, covered: false})) as $uncovered |
+            (map(.endpoints .covered | to_entries | sort_by(.value) | map((.value[] | ascii_upcase) + " " + .key)) | .[] | to_entries | map({path: .value, covered: true})) as $covered |
+            $covered+$uncovered |
+            sort_by(.path) |
+            map(if .covered then "- [x] \(.path)" else "- [ ] \(.path)" end) |
+            .[]
+          ' build/coverage.yaml | jq -r

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -21,6 +21,7 @@
     - [Tools Linting](#tools-linting)
   - [Workflows](#workflows)
     - [Analyze PR Changes](#analyze-pr-changes)
+    - [Analyze Spec Coverage](#analyze-spec-coverage)
     - [Build](#build)
     - [Deploy GitHub Pages](#deploy-github-pages)
     - [Comment on PR](#comment-on-pr)
@@ -355,7 +356,11 @@ npm run lint--fix
 
 ### [Analyze PR Changes](.github/workflows/analyze-pr-changes.yml)
 
-This workflow runs on all pull requests to analyze any potential changes to the specification. It uses the [coverage](#coverage) tool and [openapi-changes](https://pb33f.io/openapi-changes/) to calculate coverage metrics and provide a report on the changes when comparing with the commit at which the PR was branched off. In addition, the "Display Coverage Checklist" step will output a list of OpenSearch APIs with a checkbox indicating whether the API exists in the spec that can be directly copy-pasted into the [Add Missing API Specs issue](https://github.com/opensearch-project/opensearch-api-specification/issues/168).
+This workflow runs on all pull requests to analyze any potential changes to the specification. It uses the [coverage](#coverage) tool and [openapi-changes](https://pb33f.io/openapi-changes/) to calculate coverage metrics and provide a report on the changes when comparing with the commit at which the PR was branched off.
+
+### [Analyze Spec Coverage](.github/workflows/coverage.yml)
+
+This workflow uses the [coverage](#coverage) tool and [openapi-changes](https://pb33f.io/openapi-changes/) to calculate coverage metrics showing the APIs described by the spec vs. registered in OpenSearch. The "Display Coverage Checklist" step will output a list of OpenSearch APIs with a checkbox indicating whether the API exists in the spec that can be directly copy-pasted into the [Add Missing API Specs issue](https://github.com/opensearch-project/opensearch-api-specification/issues/168).
 
 ### [Build](.github/workflows/build.yml)
 


### PR DESCRIPTION
### Description

We want to know spec coverage on push as well.

Passing builds: https://github.com/dblock/opensearch-api-specification/actions/workflows/coverage.yml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
