### PR TITLE
Fixed scripts endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `POST` and `DELETE /_dangling/{index_uuid}` returning `202` ([#686](https://github.com/opensearch-project/opensearch-api-specification/pull/686))
 - Fixed response schema for `/_nodes/reload_secure_settings` and `/_nodes/{node_id}/reload_secure_settings` ([#694](https://github.com/opensearch-project/opensearch-api-specification/pull/694))
 - Fixed `/_ingest/pipeline/{id}/_simulate` response `docs/_source` field schema ([#689](https://github.com/opensearch-project/opensearch-api-specification/pull/689))
+- Fixed `/_scripts/painless/_execute` request and response schema ([#699](https://github.com/opensearch-project/opensearch-api-specification/pull/699))
+- Fixed `fields` in `Hit` allowing primitive arrays ([#699](https://github.com/opensearch-project/opensearch-api-specification/pull/699))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -3171,7 +3171,10 @@ components:
             type: object
             properties:
               result:
-                type: object
+                oneOf:
+                  - type: number
+                  - type: string
+                  - type: boolean
             required:
               - result
     scroll@200:

--- a/spec/schemas/_core.scripts_painless_execute.yaml
+++ b/spec/schemas/_core.scripts_painless_execute.yaml
@@ -19,4 +19,3 @@ components:
       required:
         - document
         - index
-        - query

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -54,8 +54,7 @@ components:
           $ref: '_core.explain.yaml#/components/schemas/Explanation'
         fields:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         highlight:
           type: object
           additionalProperties:

--- a/tests/default/_core/recovery.yaml
+++ b/tests/default/_core/recovery.yaml
@@ -1,0 +1,13 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test _recovery endpoint.
+chapters:
+  - synopsis: Get information about any completed or ongoing shard recoveries for all indexes.
+    path: /_recovery
+    warnings:
+      multiple-paths-detected: false
+    method: GET
+    parameters:
+      human: true
+    response:
+      status: 200

--- a/tests/default/_core/script_language.yaml
+++ b/tests/default/_core/script_language.yaml
@@ -1,0 +1,11 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test the _script_context endpoint to retrieve available script contexts.
+
+chapters:
+  - synopsis: Retrieve available script languages.
+    version: '>= 2.1'
+    path: /_script_language
+    method: GET
+    response:
+      status: 200

--- a/tests/default/_core/scripts.yaml
+++ b/tests/default/_core/scripts.yaml
@@ -1,0 +1,128 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test the _scripts endpoint.
+
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: books}}
+        - {author: Harper Lee, title: To Kill a Mockingbird, year: 1960, ratings: [1, 2, 3]}
+        - {create: {_index: books}}
+        - {author: Elizabeth Rudnick, title: Beauty and the Beast, year: 1991, ratings: [3, 4, 5]}
+epilogues:
+  - path: /books
+    method: DELETE
+    status: [200, 404]
+  - path: /_scripts/add_ratings
+    method: DELETE
+    status: [200, 404]
+  - path: /_scripts/average_ratings
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create a painless script that sums the ratings (PUT).
+    path: /_scripts/{id}
+    method: PUT
+    parameters:
+      id: add_ratings
+    request:
+      payload:
+        script:
+          lang: painless
+          source: |-
+            int total = 0;
+            for (int i = 0; i < doc['ratings'].length; ++i) {
+              total += doc['ratings'][i];
+            }
+            return total;
+    response:
+      status: 200
+  - synopsis: Get ratings sum (PUT).
+    path: /{index}/_search
+    method: POST
+    warnings:
+      multiple-paths-detected: false
+    parameters:
+      index: books
+    request:
+      payload:
+        query:
+          match_all: {}
+        script_fields:
+          ratings_sum:
+            script:
+              id: add_ratings
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - fields:
+                ratings_sum:
+                  - 6
+            - fields:
+                ratings_sum:
+                  - 12
+  - synopsis: Create a painless script that calculates a ratings average (POST).
+    path: /_scripts/{id}
+    method: POST
+    parameters:
+      id: average_ratings
+    request:
+      payload:
+        script:
+          lang: painless
+          source: |-
+            if (doc['ratings'].length > 0) {
+              int total = 0;
+              for (int i = 0; i < doc['ratings'].length; ++i) {
+                total += doc['ratings'][i];
+              }
+              return total / doc['ratings'].length;
+            } else {
+              return 0;
+            }
+    response:
+      status: 200
+  - synopsis: Score results by ratings average (POST).
+    path: /{index}/_search
+    method: POST
+    warnings:
+      multiple-paths-detected: false
+    parameters:
+      index: books
+    request:
+      payload:
+        query:
+          script_score:
+            query:
+              match_all: {}
+            script:
+              id: average_ratings
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _score: 4
+            - _score: 2
+  - synopsis: Get a script.
+    path: /_scripts/{id}
+    method: GET
+    parameters:
+      id: add_ratings
+    response:
+      status: 200
+      payload:
+        _id: add_ratings
+        found: true
+  - synopsis: Delete script.
+    path: /_scripts/{id}
+    method: DELETE
+    parameters:
+      id: add_ratings

--- a/tests/default/_core/scripts/context.yaml
+++ b/tests/default/_core/scripts/context.yaml
@@ -1,0 +1,41 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test the _scripts contexts endpoint.
+
+prologues:
+  - path: /_scripts/add_ratings
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create a painless script that sums the ratings.
+    path: /_scripts/{id}/{context}
+    method: POST
+    parameters:
+      id: add_ratings
+      context: field
+    request:
+      payload:
+        script:
+          lang: painless
+          source: |-
+            int total = 0;
+            for (int i = 0; i < doc['ratings'].length; ++i) {
+              total += doc['ratings'][i];
+            }
+            return total;
+    response:
+      status: 200
+  - synopsis: Update a painless script that sums the ratings.
+    path: /_scripts/{id}/{context}
+    method: PUT
+    parameters:
+      id: add_ratings
+      context: field
+    request:
+      payload:
+        script:
+          lang: painless
+          source: |-
+            return 0;
+    response:
+      status: 200

--- a/tests/default/_core/scripts/painless/execute.yaml
+++ b/tests/default/_core/scripts/painless/execute.yaml
@@ -1,0 +1,69 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the _scripts execute endpoint.
+
+prologues:
+  - path: /movies
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            year:
+              type: integer
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Execute a painless script returning a string.
+    path: /_scripts/painless/_execute
+    method: GET
+    request:
+      payload:
+        script:
+          source: |-
+            (params.x + params.y)/2
+          params:
+            x: 80
+            y: 100
+    response:
+      status: 200
+      payload:
+        result: '90'
+  - synopsis: Execute a painless script returning `false`.
+    path: /_scripts/painless/_execute
+    method: POST
+    request:
+      payload:
+        context: filter
+        context_setup:
+          index: movies
+          document:
+            year: 1976
+        script:
+          source: |-
+            doc['year'].value > params.year
+          params:
+            year: 2000
+    response:
+      status: 200
+      payload:
+        result: false
+  - synopsis: Execute a painless script returning a number.
+    path: /_scripts/painless/_execute
+    method: POST
+    request:
+      payload:
+        context: score
+        context_setup:
+          index: movies
+          document:
+            year: 1976
+        script:
+          source: |-
+            doc['year'].value
+    response:
+      status: 200
+      payload:
+        result: 1976

--- a/tests/default/indices/recovery.yaml
+++ b/tests/default/indices/recovery.yaml
@@ -1,0 +1,32 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test _recovery endpoint.
+prologues:
+  - path: /movies
+    method: PUT
+    status: [200]
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Get information about any completed or ongoing shard recoveries for an index.
+    path: /{index}/_recovery
+    warnings:
+      multiple-paths-detected: false
+    method: GET
+    parameters:
+      index: movies
+    response:
+      status: 200
+      payload:
+        movies:
+          shards:
+            - stage: DONE
+              index:
+                size:
+                  total_in_bytes: 0
+              translog:
+                total: 0
+              verify_index:
+                total_time_in_millis: 0


### PR DESCRIPTION
### Description

- Fix response from `/_scripts/painless/_execute` which can only be a primitive.
- Fix request from `/_scripts/painless/_execute` which don't always require `query`.
- Fix `Hit` that can contain array fields with primitives (e.g. `ratings_sum: [6]`).
- Misc tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
