### PR TITLE
Fix: _cat/snapshots takes a repository in the query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `/_ingest/pipeline/{id}/_simulate` response `docs/_source` field schema ([#689](https://github.com/opensearch-project/opensearch-api-specification/pull/689))
 - Fixed `/_scripts/painless/_execute` request and response schema ([#699](https://github.com/opensearch-project/opensearch-api-specification/pull/699))
 - Fixed `fields` in `Hit` allowing primitive arrays ([#699](https://github.com/opensearch-project/opensearch-api-specification/pull/699))
+- Added missing `repository` query parameter to `/_cat/snapshots` ([#700](https://github.com/opensearch-project/opensearch-api-specification/pull/700))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -636,6 +636,7 @@ paths:
         - $ref: '#/components/parameters/cat.snapshots::query.help'
         - $ref: '#/components/parameters/cat.snapshots::query.ignore_unavailable'
         - $ref: '#/components/parameters/cat.snapshots::query.master_timeout'
+        - $ref: '#/components/parameters/cat.snapshots::query.repository'
         - $ref: '#/components/parameters/cat.snapshots::query.s'
         - $ref: '#/components/parameters/cat.snapshots::query.time'
         - $ref: '#/components/parameters/cat.snapshots::query.v'
@@ -658,6 +659,7 @@ paths:
         - $ref: '#/components/parameters/cat.snapshots::query.help'
         - $ref: '#/components/parameters/cat.snapshots::query.ignore_unavailable'
         - $ref: '#/components/parameters/cat.snapshots::query.master_timeout'
+        - $ref: '#/components/parameters/cat.snapshots::query.repository'
         - $ref: '#/components/parameters/cat.snapshots::query.s'
         - $ref: '#/components/parameters/cat.snapshots::query.time'
         - $ref: '#/components/parameters/cat.snapshots::query.v'
@@ -2544,6 +2546,17 @@ components:
         type: boolean
         default: false
         description: Verbose mode. Display column headers.
+    cat.snapshots::query.repository:
+      in: query
+      name: repository
+      description: |-
+        A comma-separated list of snapshot repositories used to limit the request.
+        Accepts wildcard expressions.
+        `_all` returns all repositories.
+        If any repository fails during the request, OpenSearch returns an error.
+      required: true
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/Names'
     cat.snapshots::path.repository:
       in: path
       name: repository

--- a/tests/snapshot/cat/snapshots.yaml
+++ b/tests/snapshot/cat/snapshots.yaml
@@ -2,6 +2,9 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test cat/snapshots endpoints.
 epilogues:
+  - path: /_snapshot/my-fs-repository/my-test-snapshot
+    method: DELETE
+    status: [200, 404]
   - path: /_snapshot/my-fs-repository
     method: DELETE
     status: [200, 404]
@@ -13,8 +16,29 @@ prologues:
         type: fs
         settings:
           location: /tmp/opensearch/repo
+  - path: /_snapshot/my-fs-repository/my-test-snapshot
+    method: PUT
+    parameters:
+      wait_for_completion: true
+    request:
+      payload:
+        indices: '*'
+        ignore_unavailable: true
+        include_global_state: false
+        partial: true
 chapters:
-  - synopsis: List all snapshots for a repository.
+  - synopsis: List all snapshots for a repository (query).
+    path: /_cat/snapshots
+    method: GET
+    parameters:
+      format: json
+      repository: my-fs-repository
+    response:
+      status: 200
+      payload:
+        - id: my-test-snapshot
+          status: SUCCESS
+  - synopsis: List all snapshots for a repository (path).
     path: /_cat/snapshots/{repository}
     method: GET
     parameters:
@@ -22,3 +46,6 @@ chapters:
       repository: my-fs-repository
     response:
       status: 200
+      payload:
+        - id: my-test-snapshot
+          status: SUCCESS


### PR DESCRIPTION
### Description

The `_cat/snapshots` API takes a repository in the query.

### Issues Resolved

Coming from https://github.com/opensearch-project/OpenSearch/issues/16648.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
