### PR TITLE
Splitting `Upgrade API` specs

### DIFF
--- a/tests/default/_core/upgrade.yaml
+++ b/tests/default/_core/upgrade.yaml
@@ -1,0 +1,20 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test upgrading indices using both GET and POST methods.
+chapters:
+  - synopsis: Trigger upgrade (POST).
+    path: /_upgrade
+    method: POST
+    request:
+      payload:
+        allow_no_indices: false
+        expand_wildcards: closed
+        ignore_unavailable: false
+    response:
+      status: 200
+
+  - synopsis: Check upgrade status (GET).
+    path: /_upgrade
+    method: GET
+    response:
+      status: 200

--- a/tests/default/indices/upgrade.yaml
+++ b/tests/default/indices/upgrade.yaml
@@ -38,20 +38,3 @@ chapters:
       index: [movies]
     response:
       status: 200
-
-  - synopsis: Trigger upgrade (POST).
-    path: /_upgrade
-    method: POST
-    request:
-      payload:
-        allow_no_indices: false
-        expand_wildcards: closed
-        ignore_unavailable: false
-    response:
-      status: 200
-
-  - synopsis: Check upgrade status (GET).
-    path: /_upgrade
-    method: GET
-    response:
-      status: 200


### PR DESCRIPTION
### Description
Splitting upgrade API specs to different folders
Technical debt from [previous PR ](https://github.com/opensearch-project/opensearch-api-specification/pull/690)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
