### PR TITLE
Fail CI with unused test files.

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -124,7 +124,22 @@ jobs:
         with:
           path: coverage
 
-      - name: Display Missing Test Paths
+      - name: Collect Test File Names
+        run: |
+          find tests/. -name "*.yaml" | xargs realpath | jq -Rn '{ files: [inputs | "\(.)"] }' > test-files.json
+
+      - name: Display Unused Test Files
+        run: |
+          jq -r -sc '
+              (map(.stories) | add | unique) as $stories |
+              (map(.files) | add | unique) as $all |
+              $all-$stories |
+              .[]
+            ' $(find ./ -name "test-spec-coverage-*.json") test-files.json > ./coverage/files.txt
+          cat ./coverage/files.txt | sed -e 's/^/::error::/'
+          test ! -s ./coverage/files.txt || { echo "::error::Unused test files detected."; exit 1; }
+
+      - name: Collect and Display Missing Test Paths
         run: |
           jq -r -sc '
               (map(.operations) | add | unique) as $all |

--- a/tools/src/tester/TestResults.ts
+++ b/tools/src/tester/TestResults.ts
@@ -19,6 +19,7 @@ export default class TestResults {
   protected _evaluated_operations?: Operation[]
   protected _unevaluated_operations?: Operation[]
   protected _operations?: Operation[]
+  protected _stories?: string[]
 
   constructor(spec: MergedOpenApiSpec, evaluations: StoryEvaluations) {
     this._spec = spec
@@ -59,6 +60,14 @@ export default class TestResults {
     return this._operations
   }
 
+  stories(): string[] {
+    if (this._stories !== undefined) return this._stories
+    this._stories = _.uniqWith(_.compact(_.flatMap(this._evaluations.evaluations, (evaluation) =>
+      evaluation.full_path
+    )), isEqual)
+    return this._stories
+  }
+
   test_coverage(): SpecTestCoverage {
     return {
       summary: {
@@ -69,7 +78,8 @@ export default class TestResults {
         ) / 100 : 0
       },
       operations: this.operations(),
-      evaluated_operations: this.evaluated_operations()
+      evaluated_operations: this.evaluated_operations(),
+      stories: this.stories()
     }
   }
 

--- a/tools/src/tester/types/test.types.ts
+++ b/tools/src/tester/types/test.types.ts
@@ -17,4 +17,5 @@ export interface SpecTestCoverage {
   },
   operations: Operation[]
   evaluated_operations: Operation[]
+  stories: string[]
 }

--- a/tools/tests/tester/TestResults.test.ts
+++ b/tools/tests/tester/TestResults.test.ts
@@ -85,6 +85,9 @@ describe('TestResults', () => {
         { method: 'POST', path: '/cluster_manager' },
         { method: 'GET', path: '/index' },
         { method: 'GET', path: '/nodes' }
+      ],
+      stories: [
+        'full_path'
       ]
     })
     fs.unlinkSync(filename)


### PR DESCRIPTION
### Description

Failed run with an extra test file: https://github.com/dblock/opensearch-api-specification/actions/runs/12128482379

Include the list of files in the coverage report, then compare it to the actual list of files.

![Screenshot 2024-12-02 at 4 45 11 PM](https://github.com/user-attachments/assets/eb62fbb4-d5c6-4c4c-b7c3-e8de24349eda)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
