### PR TITLE
Fixed content-type of `GET /_plugins/_observability/_local/stats`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added missing `status` to `/_search/template` response ([#702](https://github.com/opensearch-project/opensearch-api-specification/pull/702))
 - Added `_type` to `rank_eval` API specs ([#704](https://github.com/opensearch-project/opensearch-api-specification/pull/704))
 - Added request body to `_search_shards` API specs ([#709](https://github.com/opensearch-project/opensearch-api-specification/pull/709))
+- Added missing `repository` query parameter to `/_cat/snapshots` ([#700](https://github.com/opensearch-project/opensearch-api-specification/pull/700))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))
@@ -51,9 +52,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `/_ingest/pipeline/{id}/_simulate` response `docs/_source` field schema ([#689](https://github.com/opensearch-project/opensearch-api-specification/pull/689))
 - Fixed `/_scripts/painless/_execute` request and response schema ([#699](https://github.com/opensearch-project/opensearch-api-specification/pull/699))
 - Fixed `fields` in `Hit` allowing primitive arrays ([#699](https://github.com/opensearch-project/opensearch-api-specification/pull/699))
-- Added missing `repository` query parameter to `/_cat/snapshots` ([#700](https://github.com/opensearch-project/opensearch-api-specification/pull/700))
 - Fixed `hits` in `rank_eval` allowing numbers ([#704](https://github.com/opensearch-project/opensearch-api-specification/pull/704))
 - Fixed query DSL schemas ([#706](https://github.com/opensearch-project/opensearch-api-specification/pull/706))
+- Fixed content-type of `GET /_plugins/_observability/_local/stats` ([#711](https://github.com/opensearch-project/opensearch-api-specification/pull/711))
+- Fixed `tenant` in `ObservabilityObject` request body to not be required ([#711](https://github.com/opensearch-project/opensearch-api-specification/pull/711))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/spec/namespaces/observability.yaml
+++ b/spec/namespaces/observability.yaml
@@ -8,8 +8,8 @@ paths:
     get:
       operationId: observability.get_localstats.0
       x-operation-group: observability.get_localstats
-      x-version-added: '1.1'
-      description: Retrieves Local Stats of all observability objects.
+      x-version-added: '2.5'
+      description: Retrieves local stats of all observability objects.
       responses:
         '200':
           $ref: '#/components/responses/observability.get_localstats@200'
@@ -177,7 +177,7 @@ components:
     observability.get_localstats@200:
       description: Retrieves
       content:
-        application/json:
+        text/plain:
           schema:
             type: string
   parameters:

--- a/spec/schemas/observability._common.yaml
+++ b/spec/schemas/observability._common.yaml
@@ -44,7 +44,6 @@ components:
           $ref: '#/components/schemas/SavedQuery'
       required:
         - objectId
-        - tenant
 
     OperationalPanel:
       type: object

--- a/tests/default/observability/local/stats.yaml
+++ b/tests/default/observability/local/stats.yaml
@@ -1,0 +1,12 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test backend stats.
+version: '>= 2.5'
+
+chapters:
+  - synopsis: Get observability stats.
+    path: /_plugins/_observability/_local/stats
+    method: GET
+    response:
+      status: 200
+      content_type: text/plain

--- a/tests/default/observability/object.yaml
+++ b/tests/default/observability/object.yaml
@@ -2,13 +2,9 @@ $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Test various operations of the OpenSearch Observability Object API.
 
-prologues:
-  - path: /_plugins/_observability/object/{object_id}
-    method: DELETE
-    parameters:
-      object_id: test_object
-    status: [200, 404]
-  - path: /_plugins/_observability/object
+chapters:
+  - synopsis: Create an observability object.
+    path: /_plugins/_observability/object
     method: POST
     request:
       payload:
@@ -56,12 +52,12 @@ prologues:
             tokens:
               - name: field1
                 type: text
-    status: [200]
-  - path: /_refresh
+  - synopsis: Refresh index.
+    path: /_refresh
     method: POST
-    status: [200]
-chapters:
-  - synopsis: Retrieve specific Observability object after creation.
+    warnings:
+      multiple-paths-detected: false
+  - synopsis: Retrieve an observability object.
     path: /_plugins/_observability/object/{object_id}
     id: observatory_object
     method: GET
@@ -74,7 +70,7 @@ chapters:
         totalHits: 1
         totalHitRelation: eq
         observabilityObjectList: []
-  - synopsis: Update specific Observability object.
+  - synopsis: Update an observability object.
     path: /_plugins/_observability/object/{object_id}
     method: PUT
     parameters:
@@ -82,7 +78,6 @@ chapters:
     request:
       payload:
         objectId: test_object
-        tenant: ''
         operationalPanel:
           name: updated_test_panel
           visualizations: []
@@ -128,19 +123,7 @@ chapters:
       status: 200
       payload:
         objectId: test_object
-  - synopsis: Retrieve specific Observability object after update.
-    path: /_plugins/_observability/object/{object_id}
-    method: GET
-    parameters:
-      object_id: test_object
-    response:
-      status: 200
-      payload:
-        startIndex: 0
-        totalHits: 1
-        totalHitRelation: eq
-        observabilityObjectList: []
-  - synopsis: Retrieve list of Observability objects.
+  - synopsis: Retrieve all observability objects.
     path: /_plugins/_observability/object
     method: GET
     response:
@@ -150,6 +133,11 @@ chapters:
         totalHits: 1
         totalHitRelation: eq
         observabilityObjectList: []
+  - synopsis: Delete an observability object.
+    path: /_plugins/_observability/object/{object_id}
+    method: DELETE
+    parameters:
+      object_id: test_object
 epilogues:
   - path: /_plugins/_observability/object/{object_id}
     method: DELETE


### PR DESCRIPTION
### Description

- Fixed content-type of `GET /_plugins/_observability/_local/stats`.
- Removed `tenant` from `ObservabilityObject` being required.
- Added missing observability tests.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-api-specification/issues/663.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
