### PR TITLE
Added test for DELETE /_plugins/_observability/object.

### DIFF
--- a/tests/default/observability/object.yaml
+++ b/tests/default/observability/object.yaml
@@ -138,6 +138,60 @@ chapters:
     method: DELETE
     parameters:
       object_id: test_object
+  - synopsis: Create another observability object.
+    path: /_plugins/_observability/object
+    method: POST
+    request:
+      payload:
+        objectId: test_object
+        operationalPanel:
+          name: test_panel
+          visualizations: []
+          timeRange:
+            from: now-1h
+            to: now
+          queryFilter:
+            query: ''
+            language: ppl
+          applicationId: test_app
+        savedVisualization:
+          name: viz1
+          description: desc1
+          query: ''
+          type: line
+          selected_date_range:
+            start: now-1d
+            end: now
+            text: Last 24 hours
+          selected_timestamp:
+            name: timestamp
+            type: time
+          selected_fields:
+            text: field1
+            tokens:
+              - name: field1
+                type: text
+        savedQuery:
+          name: query1
+          description: desc1
+          query: ''
+          selected_date_range:
+            start: now-1d
+            end: now
+            text: Last 24 hours
+          selected_timestamp:
+            name: timestamp
+            type: time
+          selected_fields:
+            text: field1
+            tokens:
+              - name: field1
+                type: text
+  - synopsis: Delete an observability object (query string).
+    path: /_plugins/_observability/object
+    method: DELETE
+    parameters:
+      objectId: test_object
 epilogues:
   - path: /_plugins/_observability/object/{object_id}
     method: DELETE


### PR DESCRIPTION
### Description

Added missing test for `DELETE /_plugins/_observability/object`.

Part of https://github.com/opensearch-project/opensearch-api-specification/issues/663.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
