### PR TITLE
Added test for POST /_plugins/_replication/{index}/_stop.

### DIFF
--- a/tests/plugins/replication/stop.yaml
+++ b/tests/plugins/replication/stop.yaml
@@ -1,0 +1,52 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test stopping a replication.
+version: '>= 1.1'
+warnings:
+  multiple-paths-detected: false
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: music, _id: music_1392214}}
+        - {author: Selena Gomez, title: Love you like a love song, year: 2011}
+        - {create: {_index: music, _id: music_1392215}}
+        - {author: Justin Bieber, title: Baby, year: 2010}
+  - path: /_cluster/settings
+    method: PUT
+    request:
+      payload:
+        persistent:
+          cluster:
+            remote:
+              leader-cluster:
+                seeds: ['172.22.0.3:9300']
+  - path: /_plugins/_replication/{index}/_start
+    method: PUT
+    parameters:
+      index: music-names
+    request:
+      payload:
+        leader_alias: leader-cluster
+        leader_index: music
+        use_roles: 
+          leader_cluster_role: all_access
+          follower_cluster_role: all_access
+epilogues:
+  - path: /music
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Stop replication.
+    path: /_plugins/_replication/{index}/_stop
+    method: POST
+    parameters:
+      index: music-names
+    request:
+      payload: {}
+    response:
+      status: 200


### PR DESCRIPTION
### Description

Added missing test for POST /_plugins/_replication/{index}/_stop.

### Issues Resolved

Part of #663.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
