### PR TITLE
Added test for GET /_plugins/_rollup/jobs/{id}.

### DIFF
--- a/tests/default/rollups/jobs.yaml
+++ b/tests/default/rollups/jobs.yaml
@@ -60,6 +60,17 @@ chapters:
         rollup:
           rollup_id: books
           enabled: true
+  - synopsis: Get an index rollup job.
+    path: /_plugins/_rollup/jobs/{id}
+    method: GET
+    parameters:
+      id: books
+    response:
+      status: 200
+      payload:
+        _id: books
+        rollup:
+          rollup_id: books
   - synopsis: Delete an index rollup job.
     path: /_plugins/_rollup/jobs/{id}
     method: DELETE


### PR DESCRIPTION
### Description

Added missing test for `GET /_plugins/_rollup/jobs/{id}`.

### Issues Resolved

Part of #663.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
