### PR TITLE
Add support for multiple test verbs and fix /_render/template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added schema for `/_plugins/_knn/stats`, `/_plugins/_knn/models/{model_id}`, `_train` and `_search` ([#704](https://github.com/opensearch-project/opensearch-api-specification/pull/704))
 - Added `retry` support in `prologues` and `epilogues` ([#713](https://github.com/opensearch-project/opensearch-api-specification/pull/713))
 - Added response schema for `DELETE /_plugins/_rollup/jobs/{id}`, `POST /_plugins/_rollup/jobs/{id}/_start` and `_stop` ([#716](https://github.com/opensearch-project/opensearch-api-specification/pull/716))
+- Added support for multiple test verbs ([#723](https://github.com/opensearch-project/opensearch-api-specification/pull/723))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))
@@ -62,6 +63,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed content-type of `GET /_plugins/_observability/_local/stats` ([#711](https://github.com/opensearch-project/opensearch-api-specification/pull/711))
 - Fixed `tenant` in `ObservabilityObject` request body to not be required ([#711](https://github.com/opensearch-project/opensearch-api-specification/pull/711))
 - Fixed response code in `PUT /_plugins/_rollup/jobs/{id}` ([#716](https://github.com/opensearch-project/opensearch-api-specification/pull/716))
+- Fixed response schema for `/_render/template` and `/_render/template/{id}` ([#723](https://github.com/opensearch-project/opensearch-api-specification/pull/723))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -12,6 +12,7 @@
       - [FAILED  Cat with a json response (from security-analytics).](#failed--cat-with-a-json-response-from-security-analytics)
   - [Writing Spec Tests](#writing-spec-tests)
     - [Simple Test Story](#simple-test-story)
+    - [Testing Multiple Verbs](#testing-multiple-verbs)
     - [Using Output from Previous Chapters](#using-output-from-previous-chapters)
     - [Managing Versions](#managing-versions)
     - [Managing Distributions](#managing-distributions)
@@ -180,6 +181,18 @@ chapters:
     method: DELETE
     parameters:
       index: books
+```
+
+### Testing Multiple Verbs
+
+Some APIs allow multiple verbs for the same effect. Specify multiple verbs as follows and the test tool will execute both.
+
+```yaml
+- synopsis: Use POST and PUT interchangeably.
+  path: /{index}
+  method:
+    - POST
+    - PUT
 ```
 
 ### Using Output from Previous Chapters

--- a/json_schemas/test_story.schema.yaml
+++ b/json_schemas/test_story.schema.yaml
@@ -80,7 +80,8 @@ definitions:
           - type: array
             items:
               type: string
-              enum: [DELETE,GET, HEAD, OPTIONS, PATCH, POST, PUT]
+              # eslint-disable-next-line yml/sort-sequence-values
+              enum: [GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS]
           - type: string
             # eslint-disable-next-line yml/sort-sequence-values
             enum: [GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS]

--- a/json_schemas/test_story.schema.yaml
+++ b/json_schemas/test_story.schema.yaml
@@ -67,6 +67,11 @@ definitions:
             items:
               type: integer
 
+  HttpMethod:
+    type: string
+    # eslint-disable-next-line yml/sort-sequence-values
+    enum: [GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS]
+
   ChapterRequest:
     type: object
     properties:
@@ -79,12 +84,8 @@ definitions:
         oneOf:
           - type: array
             items:
-              type: string
-              # eslint-disable-next-line yml/sort-sequence-values
-              enum: [GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS]
-          - type: string
-            # eslint-disable-next-line yml/sort-sequence-values
-            enum: [GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS]
+              $ref: '#/definitions/HttpMethod'
+          - $ref: '#/definitions/HttpMethod'
       parameters:
         type: object
         additionalProperties:

--- a/json_schemas/test_story.schema.yaml
+++ b/json_schemas/test_story.schema.yaml
@@ -76,9 +76,14 @@ definitions:
       path:
         type: string
       method:
-        type: string
-        # eslint-disable-next-line yml/sort-sequence-values
-        enum: [GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS]
+        oneOf:
+          - type: array
+            items:
+              type: string
+              enum: [DELETE,GET, HEAD, OPTIONS, PATCH, POST, PUT]
+          - type: string
+            # eslint-disable-next-line yml/sort-sequence-values
+            enum: [GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS]
       parameters:
         type: object
         additionalProperties:

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2482,16 +2482,15 @@ components:
           schema:
             type: object
             properties:
-              file:
-                type: string
+              id:
+                $ref: '../schemas/_common.yaml#/components/schemas/Id'
               params:
                 description: |-
                   Key-value pairs used to replace Mustache variables in the template.
                   The key is the variable name.
                   The value is the variable value.
                 type: object
-                additionalProperties:
-                  type: object
+                additionalProperties: true
               source:
                 description: |-
                   An inline search template.

--- a/tests/default/_core/render/template.yaml
+++ b/tests/default/_core/render/template.yaml
@@ -60,5 +60,3 @@ chapters:
           query:
             match:
               director: Christopher Nolan
-
-

--- a/tests/default/_core/render/template.yaml
+++ b/tests/default/_core/render/template.yaml
@@ -1,0 +1,64 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test rendering a search template as a search query.
+
+prologues:
+  - path: /_scripts/movie_template
+    method: POST
+    request:
+      content_type: application/json
+      payload:
+        script:
+          lang: mustache
+          source: >
+            {
+              "query": {
+                "match": {
+                  "{{field}}": "{{value}}"
+                }
+              }
+            }
+epilogues:
+  - path: /_scripts/movie_template
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Render the movie template (request payload).
+    path: /_render/template
+    method:
+      - GET
+      - POST
+    request:
+      payload:
+        id: movie_template
+        params:
+          field: director
+          value: Quentin Tarantino
+    response:
+      status: 200
+      payload:
+        template_output:
+          query:
+            match:
+              director: Quentin Tarantino
+  - synopsis: Render the movie template (path).
+    path: /_render/template/{id}
+    method:
+      - GET
+      - POST
+    parameters:
+      id: movie_template
+    request:
+      payload:
+        params:
+          field: director
+          value: Christopher Nolan
+    response:
+      status: 200
+      payload:
+        template_output:
+          query:
+            match:
+              director: Christopher Nolan
+
+

--- a/tests/default/search/template.yaml
+++ b/tests/default/search/template.yaml
@@ -5,6 +5,9 @@ epilogues:
   - path: /movies
     method: DELETE
     status: [200, 404]
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
 prologues:
   - path: /_bulk
     method: POST

--- a/tools/src/tester/ChapterReader.ts
+++ b/tools/src/tester/ChapterReader.ts
@@ -28,7 +28,7 @@ export default class ChapterReader {
     this.logger = logger
   }
 
-  async read (chapter: ChapterRequest, story_outputs: StoryOutputs): Promise<ActualResponse> {
+  async read (chapter: ChapterRequest, method: string, story_outputs: StoryOutputs): Promise<ActualResponse> {
     const response: Record<string, any> = {}
     const resolved_params = story_outputs.resolve_params(chapter.parameters ?? {})
     const [url_path, params] = this.#parse_url(chapter.path, resolved_params)
@@ -37,10 +37,10 @@ export default class ChapterReader {
       story_outputs.resolve_value(chapter.request.payload),
       content_type
     ) : undefined
-    this.logger.info(`=> ${chapter.method} ${url_path} (${to_json(params)}) [${content_type}] ${_.compact([to_json(headers), to_json(request_data)]).join(' | ')}`)
+    this.logger.info(`=> ${method} ${url_path} (${to_json(params)}) [${content_type}] ${_.compact([to_json(headers), to_json(request_data)]).join(' | ')}`)
     await this._client.request({
       url: url_path,
-      method: chapter.method,
+      method,
       headers: { 'Content-Type' : content_type, ...headers },
       params,
       data: request_data,

--- a/tools/src/tester/OperationLocator.ts
+++ b/tools/src/tester/OperationLocator.ts
@@ -21,12 +21,12 @@ export default class OperationLocator {
     this.spec = spec
   }
 
-  locate_operation (chapter: Chapter): ParsedOperation | undefined {
+  locate_operation (chapter: Chapter, method: string): ParsedOperation | undefined {
     const path = chapter.path
-    const method = chapter.method.toLowerCase() as OpenAPIV3.HttpMethods
+    const request_method = method.toLowerCase() as OpenAPIV3.HttpMethods
     const cache_key = path + method
     if (this.cached_operations[cache_key] != null) return this.cached_operations[cache_key]
-    const operation = this.spec.paths[path]?.[method]
+    const operation = this.spec.paths[path]?.[request_method]
     if (operation == null) return undefined
     this.#deref(operation)
     const parameters = _.keyBy(operation.parameters ?? [], 'name')

--- a/tools/src/tester/SupplementalChapterEvaluator.ts
+++ b/tools/src/tester/SupplementalChapterEvaluator.ts
@@ -26,14 +26,14 @@ export default class SupplementalChapterEvaluator {
     this.logger = logger
   }
 
-  async evaluate(chapter: SupplementalChapter, story_outputs: StoryOutputs): Promise<ChapterEvaluation> {
-    const title = `${chapter.method} ${chapter.path}`
+  async evaluate(chapter: SupplementalChapter, method: string, story_outputs: StoryOutputs): Promise<ChapterEvaluation> {
+    const title = `${method} ${chapter.path}`
 
     let tries = chapter.retry && chapter.retry?.count > 0 ? chapter.retry.count + 1 : 1
     let chapter_evaluation: EvaluationWithOutput
 
     do {
-      chapter_evaluation = await this.#evaluate(chapter, story_outputs)
+      chapter_evaluation = await this.#evaluate(chapter, method, story_outputs)
       if (chapter_evaluation.evaluation.result === Result.PASSED) break
       if (--tries == 0) break
       this.logger.info(`Failed, retrying, ${tries == 1 ? '1 retry left' : `${tries} retries left`} ...`)
@@ -45,8 +45,8 @@ export default class SupplementalChapterEvaluator {
     return result
   }
 
-  async #evaluate(chapter: SupplementalChapter, story_outputs: StoryOutputs): Promise<EvaluationWithOutput> {
-    const response = await this._chapter_reader.read(chapter, story_outputs)
+  async #evaluate(chapter: SupplementalChapter, method: string, story_outputs: StoryOutputs): Promise<EvaluationWithOutput> {
+    const response = await this._chapter_reader.read(chapter, method, story_outputs)
     const output_values_evaluation = ChapterOutput.extract_output_values(response, chapter.output)
     if (output_values_evaluation.output) this.logger.info(`$ ${to_json(output_values_evaluation.output)}`)
 

--- a/tools/src/tester/types/story.types.ts
+++ b/tools/src/tester/types/story.types.ts
@@ -115,7 +115,9 @@ export interface ChapterRequest {
    */
   id?: string;
   path: string;
-  method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
+  method:
+    | ('GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS')[]
+    | ('GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS');
   parameters?: {
     [k: string]: Parameter;
   };

--- a/tools/src/tester/types/story.types.ts
+++ b/tools/src/tester/types/story.types.ts
@@ -29,6 +29,11 @@ export type SupplementalChapter = ChapterRequest & {
 };
 /**
  * This interface was referenced by `Story`'s JSON-Schema
+ * via the `definition` "HttpMethod".
+ */
+export type HttpMethod = 'GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
+/**
+ * This interface was referenced by `Story`'s JSON-Schema
  * via the `definition` "Parameter".
  */
 export type Parameter = (string | number | boolean)[] | string | number | boolean;
@@ -115,9 +120,7 @@ export interface ChapterRequest {
    */
   id?: string;
   path: string;
-  method:
-    | ('GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS')[]
-    | ('GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS');
+  method: HttpMethod[] | HttpMethod;
   parameters?: {
     [k: string]: Parameter;
   };

--- a/tools/tests/tester/ChapterEvaluator.test.ts
+++ b/tools/tests/tester/ChapterEvaluator.test.ts
@@ -34,7 +34,7 @@ describe('ChapterEvaluator', () => {
           synopsis: 'Perform a GET on an invalid path.',
           path: '/invalid',
           method: 'GET'
-        }, false, story_outputs)).toEqual(
+        }, 'GET', false, story_outputs)).toEqual(
         {
           title: 'Perform a GET on an invalid path.',
           overall: {
@@ -59,7 +59,7 @@ describe('ChapterEvaluator', () => {
           request: {
             payload: {}
           }
-        }, false, story_outputs)).toEqual(
+        }, 'PUT', false, story_outputs)).toEqual(
         {
           title: 'Perform a PUT /{index}.',
           path: 'PUT /{index}',
@@ -95,7 +95,7 @@ describe('ChapterEvaluator', () => {
         request: {
           payload: {}
         }
-      }, false, story_outputs)
+      }, 'PUT', false, story_outputs)
 
       expect(result.overall.result).toEqual(Result.ERROR)
       expect(count).toEqual(5)

--- a/tools/tests/tester/ChapterReader.test.ts
+++ b/tools/tests/tester/ChapterReader.test.ts
@@ -46,13 +46,36 @@ describe('ChapterReader', () => {
         parameters: undefined,
         request: undefined,
         output: undefined
-      }, new StoryOutputs())
+      }, 'GET', new StoryOutputs())
 
       expect(result).toStrictEqual({ status: 200, content_type: 'application/json' })
       expect(mocked_axios.request.mock.calls).toEqual([
         [{
           url: 'path',
           method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+          params: {},
+          paramsSerializer: expect.any(Function),
+          data: undefined
+        }]
+      ])
+    })
+
+    it('sends a POST request with multiple methods tested', async () => {
+      const result = await reader.read({
+        id: 'id',
+        path: 'path',
+        method: ['GET', 'POST'],
+        parameters: undefined,
+        request: undefined,
+        output: undefined
+      }, 'POST', new StoryOutputs())
+
+      expect(result).toStrictEqual({ status: 200, content_type: 'application/json' })
+      expect(mocked_axios.request.mock.calls).toEqual([
+        [{
+          url: 'path',
+          method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           params: {},
           paramsSerializer: expect.any(Function),
@@ -69,7 +92,7 @@ describe('ChapterReader', () => {
         parameters: { index: 'books' },
         request: undefined,
         output: undefined
-      }, new StoryOutputs())
+      }, 'GET', new StoryOutputs())
 
       expect(result).toEqual({ status: 200, content_type: 'application/json' })
       expect(mocked_axios.request.mock.calls).toEqual([
@@ -92,7 +115,7 @@ describe('ChapterReader', () => {
         parameters: { indexes: ['book1', 'book2'] },
         request: undefined,
         output: undefined
-      }, new StoryOutputs())
+      }, 'GET', new StoryOutputs())
 
       expect(result).toEqual({ status: 200, content_type: 'application/json' })
       expect(mocked_axios.request.mock.calls).toEqual([
@@ -118,7 +141,7 @@ describe('ChapterReader', () => {
         parameters: { 'x': 1 },
         request: { payload: { "body": "present" } },
         output: undefined
-      }, new StoryOutputs())
+      }, 'POST', new StoryOutputs())
 
       expect(result).toEqual({ status: 200, content_type: 'application/json' })
       expect(mocked_axios.request.mock.calls).toEqual([
@@ -144,7 +167,7 @@ describe('ChapterReader', () => {
           payload: [{ "body": "present" }]
         },
         output: undefined
-      }, new StoryOutputs())
+      }, 'POST', new StoryOutputs())
 
       expect(result).toEqual({ status: 200, content_type: 'application/json' })
       expect(mocked_axios.request.mock.calls).toEqual([
@@ -172,7 +195,7 @@ describe('ChapterReader', () => {
           },
         },
         output: undefined
-      }, new StoryOutputs())
+      }, 'GET', new StoryOutputs())
 
       expect(result).toStrictEqual({ status: 200, content_type: 'application/json' })
       expect(mocked_axios.request.mock.calls).toStrictEqual([
@@ -203,7 +226,7 @@ describe('ChapterReader', () => {
           },
         },
         output: undefined
-      }, new StoryOutputs())
+      }, 'GET', new StoryOutputs())
 
       expect(result).toStrictEqual({ status: 200, content_type: 'application/json' })
       expect(mocked_axios.request.mock.calls).toStrictEqual([
@@ -239,7 +262,7 @@ describe('ChapterReader', () => {
         id: 'id',
         path: 'path',
         method: 'POST'
-      }, new StoryOutputs());
+      }, 'POST', new StoryOutputs());
 
       expect(result).toStrictEqual({
         status: 404,
@@ -268,7 +291,7 @@ describe('ChapterReader', () => {
         id: 'id',
         path: 'path',
         method: 'POST'
-      }, new StoryOutputs());
+      }, 'POST', new StoryOutputs());
 
       expect(result).toStrictEqual({
         status: 404,
@@ -291,7 +314,7 @@ describe('ChapterReader', () => {
         id: 'id',
         path: 'path',
         method: 'GET'
-      }, new StoryOutputs())
+      }, 'GET', new StoryOutputs())
 
       expect(result.content_type).toBeUndefined()
       expect(result.payload).toBeUndefined()
@@ -306,7 +329,7 @@ describe('ChapterReader', () => {
         data: '{"x":1}'
       });
 
-      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, new StoryOutputs())
+      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, 'POST', new StoryOutputs())
       expect(result.content_type).toEqual("text/plain")
       expect(result.payload).toEqual('{"x":1}')
     })
@@ -320,7 +343,7 @@ describe('ChapterReader', () => {
         data: '{"x":1}'
       });
 
-      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, new StoryOutputs())
+      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, 'POST', new StoryOutputs())
       expect(result.content_type).toEqual("application/json")
       expect(result.payload).toEqual({ "x": 1 })
     })
@@ -334,7 +357,7 @@ describe('ChapterReader', () => {
         data: "---\nx: 1"
       });
 
-      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, new StoryOutputs())
+      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, 'POST', new StoryOutputs())
       expect(result.content_type).toEqual("application/yaml")
       expect(result.payload).toEqual({ "x": 1 })
     })
@@ -348,7 +371,7 @@ describe('ChapterReader', () => {
         data: new Uint8Array([130, 97, 120, 161, 97, 121, 1]).buffer
       });
 
-      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, new StoryOutputs())
+      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, 'POST', new StoryOutputs())
       expect(result.content_type).toEqual("application/cbor")
       expect(result.payload).toEqual(["x", { "y": 1 }])
     })
@@ -366,7 +389,7 @@ describe('ChapterReader', () => {
         ]).buffer
       });
 
-      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, new StoryOutputs())
+      const result = await reader.read({ id: 'id', path: 'path', method: 'POST' }, 'POST', new StoryOutputs())
       expect(result.content_type).toEqual("application/smile")
       expect(result.payload).toEqual({ age: 25, name: "Bob", score: 96.8 })
     })

--- a/tools/tests/tester/StoryValidator.test.ts
+++ b/tools/tests/tester/StoryValidator.test.ts
@@ -32,7 +32,7 @@ describe('StoryValidator', () => {
     expect(evaluation?.message).toBe("Invalid Story: " +
       "data/epilogues/0 contains unsupported properties: response --- " +
       "data/chapters/0 MUST contain the missing properties: method --- " +
-      "data/chapters/1/method MUST be equal to one of the allowed values: GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS")
+      "data/chapters/1/method MUST be equal to one of the allowed values: GET, PUT, POST, DELETE, PATCH, HEAD, OPTIONS --- data/chapters/1/method must be array --- data/chapters/1/method must match exactly one schema in oneOf")
   })
 
   test('invalid description', () => {
@@ -45,6 +45,11 @@ describe('StoryValidator', () => {
 
   test('valid story', () => {
     const evaluation = validate('tools/tests/tester/fixtures/valid_story.yaml')
+    expect(evaluation).toBeUndefined()
+  })
+
+  test('multiple methods in a chapter', () => {
+    const evaluation = validate('tools/tests/tester/fixtures/multiple_methods.yaml')
     expect(evaluation).toBeUndefined()
   })
 })

--- a/tools/tests/tester/SupplementalChapterEvaluator.test.ts
+++ b/tools/tests/tester/SupplementalChapterEvaluator.test.ts
@@ -33,7 +33,7 @@ describe('SupplementalChapterEvaluator', () => {
         await supplemental_chapter_evaluator.evaluate({
           path: '/invalid',
           method: 'GET'
-        }, story_outputs)).toEqual(
+        }, 'GET', story_outputs)).toEqual(
         {
           title: 'GET /invalid',
           overall: {
@@ -53,7 +53,7 @@ describe('SupplementalChapterEvaluator', () => {
           request: {
             payload: {}
           }
-        }, story_outputs)).toEqual(
+        }, 'PUT', story_outputs)).toEqual(
         {
           title: 'PUT /test',
           overall: {
@@ -81,7 +81,7 @@ describe('SupplementalChapterEvaluator', () => {
         request: {
           payload: {}
         }
-      }, story_outputs)
+      }, 'PUT', story_outputs)
 
       expect(result.overall.result).toEqual(Result.ERROR)
       expect(count).toEqual(5)

--- a/tools/tests/tester/fixtures/evals/passed/multiple_methods.yaml
+++ b/tools/tests/tester/fixtures/evals/passed/multiple_methods.yaml
@@ -1,0 +1,64 @@
+display_path: passed/multiple_methods.yaml
+full_path: tools/tests/tester/fixtures/stories/passed/multiple_methods.yaml
+
+result: PASSED
+description: This story has multiple methods in its chapters.
+prologues:
+  - title: HEAD /movies
+    overall:
+      result: PASSED
+  - title: DELETE /movies
+    overall:
+      result: PASSED
+chapters:
+  - title: Create and update index.
+    path: 'PUT /{index}'
+    overall:
+      result: PASSED
+    operation:
+      method: PUT
+      path: /{index}
+    request:
+      parameters:
+        index:
+          result: PASSED
+      request:
+        result: PASSED
+    response:
+      output_values:
+        result: SKIPPED
+      payload_body:
+        result: PASSED
+      payload_schema:
+        result: PASSED
+      status:
+        result: PASSED
+  - title: Create and update index.
+    path: 'HEAD /{index}'
+    overall:
+      result: PASSED
+    operation:
+      method: HEAD
+      path: /{index}
+    request:
+      parameters:
+        index:
+          result: PASSED
+      request:
+        result: PASSED
+    response:
+      output_values:
+        result: SKIPPED
+      payload_body:
+        result: PASSED
+      payload_schema:
+        result: PASSED
+      status:
+        result: PASSED
+epilogues:
+  - title: HEAD /movies
+    overall:
+      result: PASSED
+  - title: DELETE /movies
+    overall:
+      result: PASSED

--- a/tools/tests/tester/fixtures/multiple_methods.yaml
+++ b/tools/tests/tester/fixtures/multiple_methods.yaml
@@ -1,0 +1,21 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: This story has multiple methods in its chapters.
+prologues:
+  - path: /one
+    method:
+      - POST
+      - PUT
+epilogues:
+  - path: /one
+    method:
+      - POST
+      - PUT
+chapters:
+  - synopsis: A PUT and POST method.
+    path: /{index}
+    method:
+      - POST
+      - PUT
+    parameters:
+      index: one

--- a/tools/tests/tester/fixtures/stories/passed/multiple_methods.yaml
+++ b/tools/tests/tester/fixtures/stories/passed/multiple_methods.yaml
@@ -1,0 +1,26 @@
+$schema: ../../../../../../json_schemas/test_story.schema.yaml
+
+description: This story has multiple methods in its chapters.
+prologues:
+  - path: /movies
+    method:
+      - DELETE
+      - HEAD
+    status:
+      - 404
+epilogues:
+  - path: /movies
+    method:
+      - DELETE
+      - HEAD
+    status:
+      - 200
+      - 404
+chapters:
+  - synopsis: Create and update index.
+    path: /{index}
+    method:
+      - HEAD
+      - PUT
+    parameters:
+      index: movies

--- a/tools/tests/tester/fixtures/stories/passed/multiple_methods.yaml
+++ b/tools/tests/tester/fixtures/stories/passed/multiple_methods.yaml
@@ -2,25 +2,22 @@ $schema: ../../../../../../json_schemas/test_story.schema.yaml
 
 description: This story has multiple methods in its chapters.
 prologues:
-  - path: /movies
-    method:
-      - DELETE
-      - HEAD
+  - path: /movies     
+    # eslint-disable-next-line yml/sort-sequence-values
+    method: [HEAD, DELETE]
     status:
       - 404
 epilogues:
   - path: /movies
-    method:
-      - DELETE
-      - HEAD
+    # eslint-disable-next-line yml/sort-sequence-values
+    method: [HEAD, DELETE]
     status:
       - 200
       - 404
 chapters:
   - synopsis: Create and update index.
     path: /{index}
-    method:
-      - HEAD
-      - PUT
+    # eslint-disable-next-line yml/sort-sequence-values
+    method: [PUT, HEAD]
     parameters:
       index: movies

--- a/tools/tests/tester/integ/TestRunner.test.ts
+++ b/tools/tests/tester/integ/TestRunner.test.ts
@@ -34,6 +34,7 @@ test('stories folder', async () => {
     'error/prologue_error',
     'failed/invalid_data',
     'failed/not_found',
+    'passed/multiple_methods',
     'passed/passed',
     'passed/value_type',
     'skipped/semver',


### PR DESCRIPTION
### Description

You can now do this:

```
- synopsis: Use POST and PUT interchangeably.
  path: /{index}
  method:
    - POST
    - PUT
```

Avoids duplicating the test.

Added tests and fixed `/_render/template`. 

### Issues Resolved

Part of #663.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
