### PR TITLE
Update Cat API query descriptions.

### DIFF
--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -1068,63 +1068,63 @@ components:
     cat.aliases::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
+      description: Expands wildcard expressions to concrete indexes. Combine multiple values with commas. Supported values are `all`, `open`, `closed`, `hidden`, and `none`. 
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
     cat.aliases::query.format:
       name: format
       in: query
-      description: A short version of the Accept header (for example, `json`, `yaml`).
+      description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
         type: string
-        description: A short version of the Accept header (for example, `json`, `yaml`).
+        description: A short version of the `Accept` header, such as `json` or `yaml`.
     cat.aliases::query.h:
       name: h
       in: query
-      description: Comma-separated list of column names to display.
+      description: A comma-separated list of column names to display.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: Comma-separated list of column names to display.
+        description: A comma-separated list of column names to display.
       explode: true
     cat.aliases::query.help:
       name: help
       in: query
-      description: Return help information.
+      description: Returns help information.
       schema:
-        description: Return help information.
+        description: Returns help information.
         type: boolean
         default: false
     cat.aliases::query.local:
       name: local
       in: query
-      description: Return local information, do not retrieve the state from cluster-manager node.
+      description: Whether to return information from the local node only instead of from the cluster manager node.
       schema:
         type: boolean
         default: false
-        description: Return local information, do not retrieve the state from cluster-manager node.
+        description: Whether to return information from the local node only instead of from the cluster manager node.
     cat.aliases::query.s:
       name: s
       in: query
-      description: Comma-separated list of column names or column aliases to sort by.
+      description: A comma-separated list of column names or column aliases to sort by.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: Comma-separated list of column names or column aliases to sort by.
+        description: A comma-separated list of column names or column aliases to sort by.
       explode: true
     cat.aliases::query.v:
       name: v
       in: query
-      description: Verbose mode. Display column headers.
+      description: Enables verbose mode, which displays column headers.
       schema:
         type: boolean
         default: false
-        description: Verbose mode. Display column headers.
+        description: Enables verbose mode, which displays column headers.
     cat.all_pit_segments::query.bytes:
       name: bytes
       in: query
@@ -1179,7 +1179,7 @@ components:
     cat.allocation::path.node_id:
       in: path
       name: node_id
-      description: Comma-separated list of node identifiers or names used to limit the returned information.
+      description: A comma-separated list of node IDs or names used to limit the returned information.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/NodeIds'
@@ -1187,55 +1187,55 @@ components:
     cat.allocation::query.bytes:
       in: query
       name: bytes
-      description: The unit used to display byte values.
+      description: The units used to display byte values.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ByteUnit'
       style: form
     cat.allocation::query.cluster_manager_timeout:
       name: cluster_manager_timeout
       in: query
-      description: Operation timeout for connection to cluster-manager node.
+      description: A timeout for connection to the cluster manager node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       x-version-added: '2.0'
     cat.allocation::query.format:
       name: format
       in: query
-      description: A short version of the Accept header (for example, `json`, `yaml`).
+      description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
       schema:
         type: string
-        description: A short version of the Accept header (for example, `json`, `yaml`).
+        description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
     cat.allocation::query.h:
       name: h
       in: query
-      description: Comma-separated list of column names to display.
+      description: A comma-separated list of column names to display.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: Comma-separated list of column names to display.
+        description: A comma-separated list of column names to display.
       explode: true
     cat.allocation::query.help:
       name: help
       in: query
-      description: Return help information.
+      description: Returns help information.
       schema:
         type: boolean
         default: false
-        description: Return help information.
+        description: Returns help information.
     cat.allocation::query.local:
       name: local
       in: query
-      description: Return local information, do not retrieve the state from cluster-manager node.
+      description: Returns local information but does not retrieve the state from cluster-manager node.
       schema:
         type: boolean
         default: false
-        description: Return local information, do not retrieve the state from cluster-manager node.
+        description: Returns local information but does not retrieve the state from cluster-manager node.
     cat.allocation::query.master_timeout:
       name: master_timeout
       in: query
-      description: Operation timeout for connection to cluster-manager node.
+      description: A timeout for connection to the cluster manager node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       x-version-deprecated: '2.0'
@@ -1244,46 +1244,46 @@ components:
     cat.allocation::query.s:
       name: s
       in: query
-      description: Comma-separated list of column names or column aliases to sort by.
+      description: A comma-separated list of column names or column aliases to sort by.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: Comma-separated list of column names or column aliases to sort by.
+        description: A comma-separated list of column names or column aliases to sort by.
       explode: true
     cat.allocation::query.v:
       name: v
       in: query
-      description: Verbose mode. Display column headers.
+      description: Enables verbose mode, which displays column headers.
       schema:
         type: boolean
         default: false
-        description: Verbose mode. Display column headers.
+        description: Enables verbose mode, which display column headers.
     cat.cluster_manager::query.cluster_manager_timeout:
       name: cluster_manager_timeout
       in: query
-      description: Operation timeout for connection to cluster-manager node.
+      description: 
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       x-version-added: '2.0'
     cat.cluster_manager::query.format:
       name: format
       in: query
-      description: A short version of the Accept header (for example, `json`, `yaml`).
+      description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
       schema:
         type: string
-        description: A short version of the Accept header (for example, `json`, `yaml`).
+        description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
     cat.cluster_manager::query.h:
       name: h
       in: query
-      description: Comma-separated list of column names to display.
+      description: A comma-separated list of column names to display.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: Comma-separated list of column names to display.
+        description: A comma-separated list of column names to display.
       explode: true
     cat.cluster_manager::query.help:
       name: help
@@ -1304,7 +1304,7 @@ components:
     cat.cluster_manager::query.master_timeout:
       name: master_timeout
       in: query
-      description: Operation timeout for connection to cluster-manager node.
+      description:  A timeout for connection to the cluster manager node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       x-version-deprecated: '2.0'
@@ -1313,22 +1313,22 @@ components:
     cat.cluster_manager::query.s:
       name: s
       in: query
-      description: Comma-separated list of column names or column aliases to sort by.
+      description: A comma-separated list of column names or column aliases to sort by.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: Comma-separated list of column names or column aliases to sort by.
+        description: A comma-separated list of column names or column aliases to sort by.
       explode: true
     cat.cluster_manager::query.v:
       name: v
       in: query
-      description: Verbose mode. Display column headers.
+      description: Enables verbose mode, which displays column headers.
       schema:
         type: boolean
         default: false
-        description: Verbose mode. Display column headers.
+        description: Enables verbose mode, which displays column headers.
     cat.count::path.index:
       in: path
       name: index

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -1259,11 +1259,11 @@ components:
       schema:
         type: boolean
         default: false
-        description: Enables verbose mode, which display column headers.
+        description: Enables verbose mode, which displays column headers.
     cat.cluster_manager::query.cluster_manager_timeout:
       name: cluster_manager_timeout
       in: query
-      description: 
+      description: A timeout for connection to the cluster manager node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       x-version-added: '2.0'

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -1304,7 +1304,7 @@ components:
     cat.cluster_manager::query.master_timeout:
       name: master_timeout
       in: query
-      description:  A timeout for connection to the cluster manager node.
+      description: A timeout for connection to the cluster manager node.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       x-version-deprecated: '2.0'


### PR DESCRIPTION
Updates the the query parameter descriptions for three APIs, Cat Aliases, Cat Allocation, and Cat Cluster Manager.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
