### PR TITLE
Fixed /_search/scroll/{scroll_id}, missing search tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed snapshot status numeric property types ([#729](https://github.com/opensearch-project/opensearch-api-specification/pull/729))
 - Fixed request schema for `PATCH /_plugins/_security/api/nodesdn` ([#731](https://github.com/opensearch-project/opensearch-api-specification/pull/731))
 - Fixed response schema for `GET /_plugins/_security/api/nodesdn/{cluster_name}` ([#731](https://github.com/opensearch-project/opensearch-api-specification/pull/731))
+- Fixed request body for `/_search/scroll/{scroll_id}` ([#732](https://github.com/opensearch-project/opensearch-api-specification/pull/732))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2523,9 +2523,6 @@ components:
                 $ref: '../schemas/_common.yaml#/components/schemas/Duration'
               scroll_id:
                 $ref: '../schemas/_common.yaml#/components/schemas/ScrollId'
-            required:
-              - scroll_id
-            description: The scroll ID if not passed by URL or query parameter.
     search:
       content:
         application/json:

--- a/tests/default/_core/point_in_time/all.yaml
+++ b/tests/default/_core/point_in_time/all.yaml
@@ -1,0 +1,33 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test point-in-time.
+version: '>= 2.4'
+epilogues:
+  - path: /_search/point_in_time/_all
+    method: DELETE
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: movies}}
+        - {title: The Cruise, year: 1998}
+        - {create: {_index: movies}}
+        - {title: Drive, year: 1960}
+  - path: /movies/_search/point_in_time
+    method: POST
+    parameters:
+      keep_alive: 1m
+chapters:
+  - synopsis: Get all point in time.
+    path: /_search/point_in_time/_all
+    method: GET
+  - synopsis: Delete all point in time.
+    path: /_search/point_in_time/_all
+    method: DELETE

--- a/tests/default/_core/search.yaml
+++ b/tests/default/_core/search.yaml
@@ -1,0 +1,19 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test search.
+chapters:
+  - synopsis: Search across all indexes (GET).
+    path: /_search
+    method: GET
+    request:
+      payload:
+        query:
+          match_all: {}
+  - synopsis: Search across all indexes (POST).
+    path: /_search
+    method: POST
+    request:
+      payload:
+        query:
+          match_all: {}
+  

--- a/tests/default/_core/search/pipeline.yaml
+++ b/tests/default/_core/search/pipeline.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test the creation of a search pipeline.
-version: '>= 2.8'
+version: '>= 2.9'
 epilogues:
   - path: /_search/pipeline/empty-pipeline
     method: DELETE

--- a/tests/default/_core/search/pipeline.yaml
+++ b/tests/default/_core/search/pipeline.yaml
@@ -1,0 +1,33 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test the creation of a search pipeline.
+version: '>= 2.8'
+epilogues:
+  - path: /_search/pipeline/empty-pipeline
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create search pipeline.
+    path: /_search/pipeline/{id}
+    method: PUT
+    parameters:
+      id: empty-pipeline
+    request:
+      payload: {}
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Query all pipelines.
+    path: /_search/pipeline
+    method: GET
+  - synopsis: Query created pipeline.
+    path: /_search/pipeline/{id}
+    method: GET
+    parameters:
+      id: empty-pipeline
+  - synopsis: Delete created pipeline.
+    path: /_search/pipeline/{id}
+    method: DELETE
+    parameters:
+      id: empty-pipeline

--- a/tests/default/_core/search/pipeline/response_processor/rename_field.yaml
+++ b/tests/default/_core/search/pipeline/response_processor/rename_field.yaml
@@ -13,7 +13,7 @@ prologues:
         name: Drive
     status: [201]
 epilogues:
-  - path: /_search/pipeline/names_pipeline
+  - path: /_search/pipeline/rename-field
     method: DELETE
     status: [200, 404]
   - path: /movies
@@ -24,7 +24,7 @@ chapters:
     path: /_search/pipeline/{id}
     method: PUT
     parameters:
-      id: names_pipeline
+      id: rename-field
     request:
       payload:
         response_processors:
@@ -35,13 +35,6 @@ chapters:
       status: 200
       payload:
         acknowledged: true
-  - synopsis: Query created pipeline.
-    path: /_search/pipeline/{id}
-    method: GET
-    parameters:
-      id: names_pipeline
-    response:
-      status: 200
   - synopsis: Search.
     warnings:
       multiple-paths-detected: false
@@ -49,7 +42,7 @@ chapters:
     method: GET
     parameters:
       index: movies
-      search_pipeline: names_pipeline
+      search_pipeline: rename-field
     response:
       status: 200
       payload:

--- a/tests/default/_core/search/point_in_time.yaml
+++ b/tests/default/_core/search/point_in_time.yaml
@@ -1,0 +1,37 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test point-in-time.
+version: '>= 2.4'
+epilogues:
+  - path: /_search/point_in_time/_all
+    method: DELETE
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: movies}}
+        - {title: The Cruise, year: 1998}
+        - {create: {_index: movies}}
+        - {title: Drive, year: 1960}
+  - path: /movies/_search/point_in_time
+    id: pit
+    method: POST
+    parameters:
+      keep_alive: 1m
+    output:
+      id: payload.pit_id
+chapters:
+  - synopsis: Delete all pits.
+    path: /_search/point_in_time
+    request:
+      payload:
+        pit_id:
+          - ${pit.id}
+    method: DELETE

--- a/tests/default/_core/search/scroll.yaml
+++ b/tests/default/_core/search/scroll.yaml
@@ -1,0 +1,107 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test search scroll.
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: movies}}
+        - {title: The Lion King, year: 1994}
+        - {create: {_index: movies}}
+        - {title: Drive, year: 2011}
+        - {create: {_index: movies}}
+        - {title: Frozen, year: 2013}
+        - {create: {_index: movies}}
+        - {title: Moneyball, year: 2011}
+        - {create: {_index: movies}}
+        - {title: The Cruise, year: 1998}
+  - path: /movies/_search
+    method: GET
+    id: scroll
+    parameters:
+      scroll: 10m
+    request:
+      payload:
+        query:
+          match_all: {}
+        size: 1
+    output:
+      scroll_id: payload._scroll_id
+epilogues:
+  - path: /_search/scroll/_all
+    method: DELETE
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Get the next batch of results (GET).
+    method: GET
+    path: /_search/scroll
+    request:
+      payload:
+        scroll: 10m
+        scroll_id: ${scroll.scroll_id}
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _index: movies
+              _source:
+                title: Drive
+  - synopsis: Get the next batch of results (POST).
+    method: POST
+    path: /_search/scroll
+    request:
+      payload:
+        scroll: 10m
+        scroll_id: ${scroll.scroll_id}
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _index: movies
+              _source:
+                title: Frozen
+  - synopsis: Get the next batch of results (GET).
+    method: GET
+    path: /_search/scroll/{scroll_id}
+    parameters:
+      scroll_id: ${scroll.scroll_id}
+    request:
+      payload:
+        scroll: 10m
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _index: movies
+              _source:
+                title: Moneyball
+  - synopsis: Get the next batch of results (POST).
+    method: POST
+    path: /_search/scroll/{scroll_id}
+    parameters:
+      scroll_id: ${scroll.scroll_id}
+    request:
+      payload:
+        scroll: 10m
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _index: movies
+              _source:
+                title: The Cruise
+  - synopsis: Delete the scroll.
+    method: DELETE
+    path: /_search/scroll/{scroll_id}
+    parameters:
+      scroll_id: ${scroll.scroll_id}

--- a/tests/default/indices/search.yaml
+++ b/tests/default/indices/search.yaml
@@ -36,4 +36,3 @@ chapters:
       payload:
         query:
           match_all: {}
-  

--- a/tests/default/indices/search.yaml
+++ b/tests/default/indices/search.yaml
@@ -1,0 +1,39 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test search.
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: movies, _id: movie1}}
+        - {director: Quentin Tarantino, title: Pulp Fiction, year: 1994}
+        - {create: {_index: movies, _id: movie2}}
+        - {director: Christopher Nolan, title: Inception, year: 2010}
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Search in an index (GET).
+    path: /{index}/_search
+    method: GET
+    parameters:
+      index: movies
+    request:
+      payload:
+        query:
+          match_all: {}
+  - synopsis: Search across all indices (POST).
+    path: /{index}/_search
+    method: POST
+    parameters:
+      index: movies
+    request:
+      payload:
+        query:
+          match_all: {}
+  

--- a/tests/default/indices/search/point_in_time.yaml
+++ b/tests/default/indices/search/point_in_time.yaml
@@ -1,0 +1,30 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test point-in-time.
+version: '>= 2.4'
+epilogues:
+  - path: /_search/point_in_time/_all
+    method: DELETE
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: movies}}
+        - {title: The Cruise, year: 1998}
+        - {create: {_index: movies}}
+        - {title: Drive, year: 1960}
+chapters:
+  - synopsis: Create a point in time.
+    path: /{index}/_search/point_in_time
+    method: POST
+    parameters:
+      index:
+        - movies
+      keep_alive: 1m


### PR DESCRIPTION
### Description

- The `/_search/scroll/{scroll_id}` deprecated variant does not require `scroll_id` in the body because it's already in the path.
- Tests for `GET` and `POST /_search`.
- Tests for `GET /_search/pipeline` and `DELETE /_search/pipeline/{id}`.
- Tests for remainder of `_search/point_in_time`.

### Issues Resolved

Part of #663.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
