### PR TITLE
Added missing `cancelled` and `resource_stats` to `/_reindex/{task_id}/_rethrottle`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added response schema for `GET /_plugins/_knn/warmup/{index}` ([#717](https://github.com/opensearch-project/opensearch-api-specification/pull/717))
 - Added support for multiple test verbs ([#724](https://github.com/opensearch-project/opensearch-api-specification/pull/724))
 - Added support for using a certificate and key in tests ([#731](https://github.com/opensearch-project/opensearch-api-specification/pull/731))
+- Added missing `cancelled` and `resource_stats` to `/_reindex/{task_id}/_rethrottle` ([#740](https://github.com/opensearch-project/opensearch-api-specification/pull/740))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -470,7 +470,7 @@ paths:
       operationId: reindex_rethrottle.0
       x-operation-group: reindex_rethrottle
       x-version-added: '1.0'
-      description: Changes the number of requests per second for a particular Reindex operation.
+      description: Changes the number of requests per second for a particular reindex operation.
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:

--- a/spec/schemas/_core.reindex_rethrottle.yaml
+++ b/spec/schemas/_core.reindex_rethrottle.yaml
@@ -24,12 +24,16 @@ components:
           type: string
         cancellable:
           type: boolean
+        cancelled:
+          type: boolean
         description:
           type: string
         id:
           type: number
         node:
           $ref: '_common.yaml#/components/schemas/Name'
+        resource_stats:
+          $ref: '_common.yaml#/components/schemas/ResourceStats'
         running_time_in_nanos:
           $ref: '_common.yaml#/components/schemas/DurationValueUnitNanos'
         start_time_in_millis:

--- a/tests/default/_core/reindex/rethrottle.yaml
+++ b/tests/default/_core/reindex/rethrottle.yaml
@@ -1,0 +1,44 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test changing the number of requests per second for a particular reindex operation.
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+  - path: /videos
+    method: DELETE
+    status: [200, 404]
+prologues:
+  - path: /{index}/_doc
+    method: POST
+    parameters:
+      index: movies
+      refresh: true
+    request:
+      payload:
+        title: Beauty and the Beast
+        year: 91
+    status: [201]
+  - id: task
+    path: /_reindex
+    method: POST
+    parameters:
+      wait_for_completion: false
+      requests_per_second: 1
+    request:
+      payload:
+        source:
+          index: movies
+        dest:
+          index: videos
+    output:
+      task_id: payload.task
+chapters:
+  - synopsis: Change the value of `requests_per_second` on a running reindex.
+    path: /_reindex/{task_id}/_rethrottle
+    method: POST
+    parameters:
+      task_id: ${task.task_id}
+      requests_per_second: 2
+    response:
+      status: 200

--- a/tests/default/indices/delete_by_query/rethrottle.yaml
+++ b/tests/default/indices/delete_by_query/rethrottle.yaml
@@ -30,7 +30,7 @@ prologues:
     output:
       task_id: payload.task
 chapters:
-  - synopsis: Change the value of `requests_per_second``on a running delete by query.
+  - synopsis: Change the value of `requests_per_second` on a running delete by query.
     path: /_delete_by_query/{task_id}/_rethrottle
     method: POST
     parameters:


### PR DESCRIPTION
### Description

Added missing `cancelled` and `resource_stats` to `/_reindex/{task_id}/_rethrottle`.

### Issues Resolved

Part of #663.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
