### PR TITLE
Added tests for `GET /_stats/{metric}`.

### DIFF
--- a/tests/default/_core/stats.yaml
+++ b/tests/default/_core/stats.yaml
@@ -1,0 +1,25 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test stats.
+chapters:
+  - synopsis: Get global stats.
+    path: /_stats
+    method: GET
+    response:
+      status: 200
+  - synopsis: Get global stats with human fields.
+    path: /_stats
+    method: GET
+    parameters:
+      human: true
+    response:
+      status: 200
+  - synopsis: Get stats for a given metric.
+    path: /_stats/{metric}
+    method: GET
+    parameters:
+      metric: docs
+      expand_wildcards: all
+      forbid_closed_indices: false
+      groups: '*'
+      level: indices

--- a/tests/default/indices/stats.yaml
+++ b/tests/default/indices/stats.yaml
@@ -9,18 +9,6 @@ epilogues:
     method: DELETE
     status: [200, 404]
 chapters:
-  - synopsis: Get global stats.
-    path: /_stats
-    method: GET
-    response:
-      status: 200
-  - synopsis: Get global stats with human fields.
-    path: /_stats
-    method: GET
-    parameters:
-      human: true
-    response:
-      status: 200
   - synopsis: Get stats for an index.
     path: /{index}/_stats
     method: GET


### PR DESCRIPTION
### Description

Added tests for `GET /_stats/{metric}`.

### Issues Resolved

Part of #663.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
