### PR TITLE
Adjust Vale rules to ignore links

### DIFF
--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -45,8 +45,8 @@ export default class KeepDescriptions {
       } else if (inside_text && line.match(/^[\s]*[\w\\$]*:/)) {
         inside_text = false
       } else if (inside_text) {
-        const cleanedLine = line.replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1');
-        fs.writeSync(writer, this.prune_vars(cleanedLine));
+        const cleaned_line = line.replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1');
+        fs.writeSync(writer, this.prune_vars(cleaned_line));
       }
       if (line.length > 0) {
         fs.writeSync(writer, "\n")

--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -41,9 +41,9 @@ export default class KeepDescriptions {
       if (line.match(/^[\s]+((description|x-deprecation-message): \|)/)) {
         inside_text = true
       } else if (line.match(/^[\s]+((description|x-deprecation-message):)[\s]+/)) {
-        var cleaned_line = this.prune(line, /(description|x-deprecation-message):/, ' ')
-        cleaned_line = this.remove_links(line)
+        let cleaned_line = this.prune(line, /(description|x-deprecation-message):/, ' ')
         cleaned_line = this.prune_vars(cleaned_line)
+        cleaned_line = this.remove_links(cleaned_line)
         fs.writeSync(writer, cleaned_line)
       } else if (inside_text && line.match(/^[\s]*[\w\\$]*:/)) {
         inside_text = false

--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -45,8 +45,8 @@ export default class KeepDescriptions {
       } else if (inside_text && line.match(/^[\s]*[\w\\$]*:/)) {
         inside_text = false
       } else if (inside_text) {
-        const cleaned_line = line.replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1');
-        fs.writeSync(writer, this.prune_vars(cleaned_line));
+        const cleaned_line = line.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        fs.writeSync(writer, this.prune_vars(cleaned_line))
       }
       if (line.length > 0) {
         fs.writeSync(writer, "\n")

--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -70,8 +70,8 @@ export default class KeepDescriptions {
 
   remove_links(line: string): string {
     return line.replace(/\[([^\]]+)\]\([^)]+\)/g, (match, p1) => {
-      const spaces = ' '.repeat(match.length - p1.length-1);
-      return ' ' + p1 + spaces;
-    });
+      const spaces = ' '.repeat(match.length - p1.length - 1)
+      return ' ' + p1 + spaces
+    })
   }
 }

--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -45,7 +45,7 @@ export default class KeepDescriptions {
       } else if (inside_text && line.match(/^[\s]*[\w\\$]*:/)) {
         inside_text = false
       } else if (inside_text) {
-        const cleaned_line = line.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        const cleaned_line = this.remove_links(line)
         fs.writeSync(writer, this.prune_vars(cleaned_line))
       }
       if (line.length > 0) {
@@ -62,5 +62,9 @@ export default class KeepDescriptions {
     return line.replace(regex, (match) => {
       return Array(match.length + 1).join(char)
     })
+  }
+
+  remove_links(line: string): string {
+    return line.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
   }
 }

--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -69,6 +69,9 @@ export default class KeepDescriptions {
   }
 
   remove_links(line: string): string {
-    return line.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    return line.replace(/\[([^\]]+)\]\([^)]+\)/g, (match, p1) => {
+      const spaces = ' '.repeat(match.length - p1.length-1);
+      return ' ' + p1 + spaces;
+    });
   }
 }

--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -41,12 +41,16 @@ export default class KeepDescriptions {
       if (line.match(/^[\s]+((description|x-deprecation-message): \|)/)) {
         inside_text = true
       } else if (line.match(/^[\s]+((description|x-deprecation-message):)[\s]+/)) {
-        fs.writeSync(writer, this.prune_vars(this.prune(line, /(description|x-deprecation-message):/, ' ')))
+        var cleaned_line = this.prune(line, /(description|x-deprecation-message):/, ' ')
+        cleaned_line = this.remove_links(line)
+        cleaned_line = this.prune_vars(cleaned_line)
+        fs.writeSync(writer, cleaned_line)
       } else if (inside_text && line.match(/^[\s]*[\w\\$]*:/)) {
         inside_text = false
       } else if (inside_text) {
-        const cleaned_line = this.remove_links(line)
-        fs.writeSync(writer, this.prune_vars(cleaned_line))
+        let cleaned_line = this.remove_links(line)
+        cleaned_line = this.prune_vars(cleaned_line)
+        fs.writeSync(writer, cleaned_line)
       }
       if (line.length > 0) {
         fs.writeSync(writer, "\n")

--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -45,7 +45,8 @@ export default class KeepDescriptions {
       } else if (inside_text && line.match(/^[\s]*[\w\\$]*:/)) {
         inside_text = false
       } else if (inside_text) {
-        fs.writeSync(writer, this.prune_vars(line))
+        const cleanedLine = line.replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1');
+        fs.writeSync(writer, this.prune_vars(cleanedLine));
       }
       if (line.length > 0) {
         fs.writeSync(writer, "\n")

--- a/tools/tests/prepare-for-vale/fixtures/spec.txt
+++ b/tools/tests/prepare-for-vale/fixtures/spec.txt
@@ -9,15 +9,15 @@
 
 
 
-                       For a successful response, this value is always true. On failure, an exception is returned instead Supported units.
+                       For a successful response, this value is always true. On failure, an exception is returned instead  Supported units                                                          .
 
 
 
-        The item level REST category class codes during indexing link with a title.
+        The item level REST category class codes during indexing  link with a title                                 .
 
 
 
-        Here is link one and link two.
+        Here is  link one                          and  link two                          .
         Line two
 
 

--- a/tools/tests/prepare-for-vale/fixtures/spec.txt
+++ b/tools/tests/prepare-for-vale/fixtures/spec.txt
@@ -9,15 +9,15 @@
 
 
 
-                       For a successful response, this value is always true. On failure, an exception is returned instead.
+                       For a successful response, this value is always true. On failure, an exception is returned instead Supported units.
 
 
 
-        The item level REST category class codes during indexing.
+        The item level REST category class codes during indexing link with a title.
 
 
 
-        Line one
+        Here is link one and link two.
         Line two
 
 

--- a/tools/tests/prepare-for-vale/fixtures/spec.yaml
+++ b/tools/tests/prepare-for-vale/fixtures/spec.yaml
@@ -9,15 +9,15 @@ components:
       type: object
       properties:
         acknowledged:
-          description: For a successful response, this value is always true. On failure, an exception is returned instead.
+          description: For a successful response, this value is always true. On failure, an exception is returned instead [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
           type: boolean
     ObjectWithMultilineDescriptionOneLine:
       description: |-
-        The item level REST category class codes during indexing.
+        The item level REST category class codes during indexing [link with a title](https://opensearch.org "title").
       type: object
     ObjectWithMultilineDescriptionTwoLines:
       description: |-
-        Line one
+        Here is [link one](https://opensearch.org) and [link two](https://opensearch.org/).
         Line two
     ObjectWithAColonInDescription:
       type: object

--- a/tools/tests/prepare-for-vale/prepare-for-vale.test.ts
+++ b/tools/tests/prepare-for-vale/prepare-for-vale.test.ts
@@ -20,29 +20,3 @@ const spec = (args: string[]): any => {
 test('--help', () => {
   expect(spec(['--help']).stdout).toContain('Usage: prepare-for-vale [options]')
 })
-
-test('process single link', () => {
-  const input = ['description: This is a [link](https://opensearch.org).']
-  expect(spec(input).stdout).toContain('description: This is a link.\n')
-})
-
-test('process two links', () => {
-  const input = ['description: Here is [link one](https://opensearch.org) and [link two](https://opensearch.org/).']
-  const expected_output = 'description: Here is link one and link two.\n'
-  const result = spec(input).stdout
-  expect(result).toBe(expected_output)
-})
-
-test('process plain text without links', () => {
-  const input = ['description: This is plain text without any links.']
-  const expected_output = 'description: This is plain text without any links.\n'
-  const result = spec(input).stdout
-  expect(result).toBe(expected_output)
-})
-
-test('process complex link structures', () => {
-  const input = ['description: Check this [link with a title](https://opensearch.org "title").']
-  const expected_output = 'description: Check this link with a title.\n'
-  const result = spec(input).stdout
-  expect(result).toBe(expected_output)
-})

--- a/tools/tests/prepare-for-vale/prepare-for-vale.test.ts
+++ b/tools/tests/prepare-for-vale/prepare-for-vale.test.ts
@@ -20,3 +20,31 @@ const spec = (args: string[]): any => {
 test('--help', () => {
   expect(spec(['--help']).stdout).toContain('Usage: prepare-for-vale [options]')
 })
+
+test('process single link', () => {
+  const input = ['description: This is a [link](https://opensearch.org).']
+  const expectedOutput = 'description: This is a link.\n'
+  const result = spec(input).stdout
+  expect(result).toBe(expectedOutput)
+})
+
+test('process two links', () => {
+  const input = ['description: Here is [link one](https://opensearch.org) and [link two](https://opensearch.org/).']
+  const expectedOutput = 'description: Here is link one and link two.\n'
+  const result = spec(input).stdout
+  expect(result).toBe(expectedOutput)
+})
+
+test('process plain text without links', () => {
+  const input = ['description: This is plain text without any links.']
+  const expectedOutput = 'description: This is plain text without any links.\n'
+  const result = spec(input).stdout
+  expect(result).toBe(expectedOutput)
+})
+
+test('process complex link structures', () => {
+  const input = ['description: Check this [link with a title](https://opensearch.org "title").']
+  const expectedOutput = 'description: Check this link with a title.\n'
+  const result = spec(input).stdout
+  expect(result).toBe(expectedOutput)
+})

--- a/tools/tests/prepare-for-vale/prepare-for-vale.test.ts
+++ b/tools/tests/prepare-for-vale/prepare-for-vale.test.ts
@@ -23,28 +23,26 @@ test('--help', () => {
 
 test('process single link', () => {
   const input = ['description: This is a [link](https://opensearch.org).']
-  const expectedOutput = 'description: This is a link.\n'
-  const result = spec(input).stdout
-  expect(result).toBe(expectedOutput)
+  expect(spec(input).stdout).toContain('description: This is a link.\n')
 })
 
 test('process two links', () => {
   const input = ['description: Here is [link one](https://opensearch.org) and [link two](https://opensearch.org/).']
-  const expectedOutput = 'description: Here is link one and link two.\n'
+  const expected_output = 'description: Here is link one and link two.\n'
   const result = spec(input).stdout
-  expect(result).toBe(expectedOutput)
+  expect(result).toBe(expected_output)
 })
 
 test('process plain text without links', () => {
   const input = ['description: This is plain text without any links.']
-  const expectedOutput = 'description: This is plain text without any links.\n'
+  const expected_output = 'description: This is plain text without any links.\n'
   const result = spec(input).stdout
-  expect(result).toBe(expectedOutput)
+  expect(result).toBe(expected_output)
 })
 
 test('process complex link structures', () => {
   const input = ['description: Check this [link with a title](https://opensearch.org "title").']
-  const expectedOutput = 'description: Check this link with a title.\n'
+  const expected_output = 'description: Check this link with a title.\n'
   const result = spec(input).stdout
-  expect(result).toBe(expectedOutput)
+  expect(result).toBe(expected_output)
 })


### PR DESCRIPTION
### Description
Updated the `process_file` method to remove markdown links, leaving only their text content. This ensures the tool processes `description` and `x-deprecation-message` fields cleanly, aligning with Vale style-checking requirements.

### Issues Resolved
[#752]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
