### PR TITLE
Fixed schema validation for invalid properties in retry configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed type in `_msearch/template` ([#735](https://github.com/opensearch-project/opensearch-api-specification/pull/735))
 - Fixed indices API schemas ([#750](https://github.com/opensearch-project/opensearch-api-specification/pull/750))
 - Fixed cluster API schemas ([#754](https://github.com/opensearch-project/opensearch-api-specification/pull/754))
+- Fixed schema validation for invalid properties in `retry` configuration ([#X](https://github.com/opensearch-project/opensearch-api-specification/pull/X))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed type in `_msearch/template` ([#735](https://github.com/opensearch-project/opensearch-api-specification/pull/735))
 - Fixed indices API schemas ([#750](https://github.com/opensearch-project/opensearch-api-specification/pull/750))
 - Fixed cluster API schemas ([#754](https://github.com/opensearch-project/opensearch-api-specification/pull/754))
-- Fixed schema validation for invalid properties in `retry` configuration ([#X](https://github.com/opensearch-project/opensearch-api-specification/pull/X))
+- Fixed schema validation for invalid properties in `retry` configuration ([#758](https://github.com/opensearch-project/opensearch-api-specification/pull/758))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/json_schemas/test_story.schema.yaml
+++ b/json_schemas/test_story.schema.yaml
@@ -155,17 +155,17 @@ definitions:
   Retry:
     description: |
       Number of times to retry on error.
-    oneOf:
-      - type: object
-        properties:
-          count: 
-            type: integer
-            description: Number of retries.
-          wait:
-            type: integer
-            description: Number of milliseconds to wait before retrying.
-        required:
-          - count
+    type: object
+    properties:
+      count: 
+        type: integer
+        description: Number of retries.
+      wait:
+        type: integer
+        description: Number of milliseconds to wait before retrying.
+    required:
+      - count
+    additionalProperties: false
 
   Request:
     type: object

--- a/tools/tests/tester/StoryValidator.test.ts
+++ b/tools/tests/tester/StoryValidator.test.ts
@@ -45,6 +45,13 @@ describe('StoryValidator', () => {
       "data/chapters/0/synopsis must match pattern \"^\\p{Lu}[\\s\\S]*\\.$|^\\p{Lu}[\\s\\S]*\\. \\[(GET|PUT|POST|DELETE|PATCH|HEAD|OPTIONS)\\]$\"")
   })
 
+  test('invalid property', () => {
+    const evaluation = validate('tools/tests/tester/fixtures/invalid_property.yaml')
+    expect(evaluation?.result).toBe('ERROR')
+    expect(evaluation?.message).toBe("Invalid Story: " +
+      "data/prologues/0/retry contains unsupported properties: until")
+  })
+
   test('valid story', () => {
     const evaluation = validate('tools/tests/tester/fixtures/valid_story.yaml')
     expect(evaluation).toBeUndefined()

--- a/tools/tests/tester/fixtures/invalid_property.yaml
+++ b/tools/tests/tester/fixtures/invalid_property.yaml
@@ -1,0 +1,20 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: This story has invalid property for retry configuration when validated against test_story.schema.yaml.
+prologues:
+  - path: /{index}
+    method: GET
+    retry:
+      count: 5
+      wait: 30000
+      until: # invalid property
+        - path: payload.state
+          equal: COMPLETED
+epilogues:
+  - path: /{index}
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Delete index.
+    path: /{index}
+    method: DELETE


### PR DESCRIPTION
### Description
Prevents invalid properties for being added in `retry` configuration in the test story.

### Issues Resolved
Resolve https://github.com/opensearch-project/opensearch-api-specification/issues/757

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
