### PR TITLE
Added spec with `x-ignorable:true` to check Evaluation operations

### DIFF
--- a/tools/tests/tester/MergedOpenApiSpec.test.ts
+++ b/tools/tests/tester/MergedOpenApiSpec.test.ts
@@ -21,6 +21,7 @@ describe('merged API spec', () => {
 
     test('paths', () => {
       expect(spec.paths()).toEqual({
+        '/_cluster/nodes/hot_threads': ['get'],
         '/_nodes/{id}': ['get', 'post'],
         '/_superseded/nodes/{id}': ['get'],
         '/cluster_manager': ['get', 'post'],

--- a/tools/tests/tester/TestResults.test.ts
+++ b/tools/tests/tester/TestResults.test.ts
@@ -15,7 +15,8 @@ import fs from 'fs'
 describe('TestResults', () => {
   const spec = new MergedOpenApiSpec('tools/tests/tester/fixtures/specs/complete')
 
-  const evaluations = [{
+  const evaluations = [
+    {
     result: Result.PASSED,
     display_path: 'PUT /{index}',
     full_path: 'full_path',
@@ -31,6 +32,26 @@ describe('TestResults', () => {
         result: Result.PASSED
       },
       path: 'PUT /{index}'
+    }],
+    epilogues: [],
+    prologues: []
+  },
+  {
+    result: Result.PASSED,
+    display_path: 'GET /_cluster/nodes/hot_threads',
+    full_path: '/_cluster/nodes/hot_threads',
+    description: 'description',
+    message: 'message',
+    chapters: [{
+      title: 'title',
+      operation: {
+        method: 'GET',
+        path: '/_cluster/nodes/hot_threads'
+      },
+      overall: {
+        result: Result.PASSED
+      },
+      path: 'GET /_cluster/nodes/hot_threads'
     }],
     epilogues: [],
     prologues: []
@@ -87,7 +108,8 @@ describe('TestResults', () => {
         { method: 'GET', path: '/nodes' }
       ],
       stories: [
-        'full_path'
+        'full_path',
+        '/_cluster/nodes/hot_threads'
       ]
     })
     fs.unlinkSync(filename)

--- a/tools/tests/tester/TestResults.test.ts
+++ b/tools/tests/tester/TestResults.test.ts
@@ -17,45 +17,45 @@ describe('TestResults', () => {
 
   const evaluations = [
     {
-    result: Result.PASSED,
-    display_path: 'PUT /{index}',
-    full_path: 'full_path',
-    description: 'description',
-    message: 'message',
-    chapters: [{
-      title: 'title',
-      operation: {
-        method: 'PUT',
-        path: '/{index}'
-      },
-      overall: {
-        result: Result.PASSED
-      },
-      path: 'PUT /{index}'
-    }],
-    epilogues: [],
-    prologues: []
-  },
-  {
-    result: Result.PASSED,
-    display_path: 'GET /_cluster/nodes/hot_threads',
-    full_path: '/_cluster/nodes/hot_threads',
-    description: 'description',
-    message: 'message',
-    chapters: [{
-      title: 'title',
-      operation: {
-        method: 'GET',
-        path: '/_cluster/nodes/hot_threads'
-      },
-      overall: {
-        result: Result.PASSED
-      },
-      path: 'GET /_cluster/nodes/hot_threads'
-    }],
-    epilogues: [],
-    prologues: []
-  }]
+      result: Result.PASSED,
+      display_path: 'PUT /{index}',
+      full_path: 'full_path',
+      description: 'description',
+      message: 'message',
+      chapters: [{
+        title: 'title',
+        operation: {
+          method: 'PUT',
+          path: '/{index}'
+        },
+        overall: {
+          result: Result.PASSED
+        },
+        path: 'PUT /{index}'
+      }],
+      epilogues: [],
+      prologues: []
+    },
+    {
+      result: Result.PASSED,
+      display_path: 'GET /_cluster/nodes/hot_threads',
+      full_path: '/_cluster/nodes/hot_threads',
+      description: 'description',
+      message: 'message',
+      chapters: [{
+        title: 'title',
+        operation: {
+          method: 'GET',
+          path: '/_cluster/nodes/hot_threads'
+        },
+        overall: {
+          result: Result.PASSED
+        },
+        path: 'GET /_cluster/nodes/hot_threads'
+      }],
+      epilogues: [],
+      prologues: []
+    }]
 
   const test_results = new TestResults(spec, { evaluations })
 

--- a/tools/tests/tester/fixtures/specs/complete/namespaces/nodes.yaml
+++ b/tools/tests/tester/fixtures/specs/complete/namespaces/nodes.yaml
@@ -36,6 +36,21 @@ paths:
           $ref: '#/components/responses/nodes.info@201'
         '200':
           $ref: '#/components/responses/nodes.info@200'
+  /_cluster/nodes/hot_threads:
+    get:
+      operationId: nodes.hot_threads.0
+      x-operation-group: nodes.hot_threads
+      x-ignorable: true
+      deprecated: true
+      x-deprecation-message: The hot accepts /_cluster/nodes as prefix for backwards compatibility reasons
+      x-version-added: '1.0'
+      x-version-deprecated: '1.0'
+      description: Returns information about hot threads on each node in the cluster.
+      externalDocs:
+        url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-hot-threads/
+      responses:
+        '200':
+          $ref: '#/components/responses/nodes.hot_threads@200'
 components:
   requestBodies:
     nodes.info:
@@ -88,3 +103,6 @@ components:
         application/json:
           schema:
             type: object
+    nodes.hot_threads@200:
+      content:
+        text/plain: {}


### PR DESCRIPTION
### Description
I'm adding a spec with the parameter `x-ignorable:true` to see if it will appear in `operations` and `evaluated_operations` on the existing tests.
debt from #759 

### Issues Resolved
[#748]
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
