### PR TITLE
Add version for ML Predict, Train APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `GET`, `POST /_plugins/_ml/tasks/_search`, `GET /_plugins/_ml/tools`, `tools/{tool_name}` ([#797](https://github.com/opensearch-project/opensearch-api-specification/pull/797))
 - Added `POST /_plugins/_ml/agents/{agent_id}/_execute`, `GET /_plugins/_ml/agents/{agent_id}`, `GET`, `POST /_plugins/_ml/agents/_search` ([#798](https://github.com/opensearch-project/opensearch-api-specification/pull/798))
 - Added a warning for test file names that don't match the API being tested ([#793](https://github.com/opensearch-project/opensearch-api-specification/pull/793))
+- Added version for `POST /_plugins/_ml/_train/{algorithm_name}`, `_predict/{algorithm_name}/{model_id}`, and `_train_predict/{algorithm_name}` ([#763](https://github.com/opensearch-project/opensearch-api-specification/pull/763))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -333,6 +333,7 @@ paths:
     post:
       operationId: ml.predict.0
       x-operation-group: ml.predict
+      x-version-added: '1.3'
       description: Predicts new data with trained model.
       parameters:
         - $ref: '#/components/parameters/ml.predict::path.algorithm_name'
@@ -346,6 +347,7 @@ paths:
     post:
       operationId: ml.train.0
       x-operation-group: ml.train
+      x-version-added: '1.3'
       description: Trains a model synchronously.
       parameters:
         - $ref: '#/components/parameters/ml.train::path.algorithm_name'
@@ -358,6 +360,7 @@ paths:
     post:
       operationId: ml.train_predict.0
       x-operation-group: ml.train_predict
+      x-version-added: '1.3'
       description: Trains a model and predicts against the same training dataset.
       parameters:
         - $ref: '#/components/parameters/ml.train_predict::path.algorithm_name'

--- a/tests/plugins/ml/ml/predict.yaml
+++ b/tests/plugins/ml/ml/predict.yaml
@@ -1,6 +1,7 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test the prediction of new data with trained model.
+version: '>= 1.3'
 prologues:
   - path: /_bulk
     method: POST

--- a/tests/plugins/ml/ml/train.yaml
+++ b/tests/plugins/ml/ml/train.yaml
@@ -1,6 +1,7 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test the training of a model synchronously.
+version: '>= 1.3'
 prologues:
   - path: /_bulk
     method: POST

--- a/tests/plugins/ml/ml/train_predict.yaml
+++ b/tests/plugins/ml/ml/train_predict.yaml
@@ -1,6 +1,7 @@
 $schema: ../../../../json_schemas/test_story.schema.yaml
 
 description: Test training a model, then immediately predict against the same training dataset.
+version: '>= 1.3'
 prologues:
   - path: /_bulk
     method: POST


### PR DESCRIPTION
### Description
Added version for ML train, predict, train and predict APIs.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-py/issues/867.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
