### PR TITLE
Fix flaky snapshot test.

### DIFF
--- a/tests/snapshot/snapshot/status.yaml
+++ b/tests/snapshot/snapshot/status.yaml
@@ -40,21 +40,11 @@ chapters:
   - synopsis: Get status of all running snapshots.
     path: /_snapshot/_status
     method: GET
-    response:
-      status: 200
-      payload:
-        snapshots:
-          - snapshot: my-test-snapshot
   - synopsis: Get status of all running snapshots in specific repository.
     path: /_snapshot/{repository}/_status
     method: GET
     parameters:
       repository: my-fs-repository
-    response:
-      status: 200
-      payload:
-        snapshots:
-          - snapshot: my-test-snapshot
   - synopsis: Get status of specific snapshot in specific repository.
     path: /_snapshot/{repository}/{snapshot}/_status
     method: GET


### PR DESCRIPTION
### Description

Fix for a flaky snapshot test. The snapshot completes too fast so `/_snapshot/{repository}/_status` isn't returning anything.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/issues/756.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
