### PR TITLE
Add ML Memory APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `GET /_plugins/_ml/connectors/{connector_id}`, `_search`, `POST /_plugins/_ml/connectors/_search`, and `PUT /_plugins/_ml/connectors/{connector_id}` ([#764](https://github.com/opensearch-project/opensearch-api-specification/pull/764))
 - Added the ability to skip an individual chapter test ([#765](https://github.com/opensearch-project/opensearch-api-specification/pull/765))
 - Added uploading of test spec logs ([#767](https://github.com/opensearch-project/opensearch-api-specification/pull/767))
-- Added `POST /_plugins/_ml/memory`, `PUT /_plugins/_ml/memory/{memory_id}`, `GET /_plugins/_ml/memory`, `GET /_plugins/_ml/memory/{memory_id}`, `_search`, `POST /_plugins/_ml/memory/_search`, and `DELETE /_plugins/_ml/memory/{memory_id}` ([#771](https://github.com/opensearch-project/opensearch-api-specification/pull/771))
+- Added `POST /_plugins/_ml/memory`, `POST /_plugins/_ml/memory/_search`, `{memory_id}/_search`, `{memory_id}/messages`, `PUT /_plugins/_ml/memory/{memory_id}`, `message/{message_id}`,  `GET /_plugins/_ml/memory`, `GET /_plugins/_ml/memory/{memory_id}`, `_search`, `message/{message_id}`, `{memory_id}/messages`, `{memory_id}/_search`, `message/{message_id}/traces`,  and `DELETE /_plugins/_ml/memory/{memory_id}` ([#771](https://github.com/opensearch-project/opensearch-api-specification/pull/771))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `GET /_plugins/_ml/connectors/{connector_id}`, `_search`, `POST /_plugins/_ml/connectors/_search`, and `PUT /_plugins/_ml/connectors/{connector_id}` ([#764](https://github.com/opensearch-project/opensearch-api-specification/pull/764))
 - Added the ability to skip an individual chapter test ([#765](https://github.com/opensearch-project/opensearch-api-specification/pull/765))
 - Added uploading of test spec logs ([#767](https://github.com/opensearch-project/opensearch-api-specification/pull/767))
+- Added `POST /_plugins/_ml/memory`, `PUT /_plugins/_ml/memory/{memory_id}`, `GET /_plugins/_ml/memory`, `GET /_plugins/_ml/memory/{memory_id}`, `_search`, `POST /_plugins/_ml/memory/_search`, and `DELETE /_plugins/_ml/memory/{memory_id}` ([#771](https://github.com/opensearch-project/opensearch-api-specification/pull/771))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -255,6 +255,83 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ml.delete_agent@200'
+  /_plugins/_ml/memory:
+    get:
+      operationId: ml.get_memory.0
+      x-operation-group: ml.get_memory
+      x-version-added: '2.12'
+      description: Get a memory.
+      requestBody:
+        $ref: '#/components/requestBodies/ml.get_memory'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.get_memory@200'
+    post:
+      operationId: ml.create_memory.0
+      x-operation-group: ml.create_memory
+      x-version-added: '2.12'
+      description: Create a memory.
+      requestBody:
+        $ref: '#/components/requestBodies/ml.create_memory'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.create_memory@200'
+  /_plugins/_ml/memory/{memory_id}:
+    get:
+      operationId: ml.get_memory.1
+      x-operation-group: ml.get_memory
+      x-version-added: '2.12'
+      description: Get a memory.
+      requestBody:
+        $ref: '#/components/requestBodies/ml.get_memory'
+      parameters:
+        - $ref: '#/components/parameters/ml.get_memory::path.memory_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.get_memory@200'
+    put:
+      operationId: ml.update_memory.0
+      x-operation-group: ml.update_memory
+      x-version-added: '2.12'
+      description: Update a memory.
+      parameters:
+        - $ref: '#/components/parameters/ml.update_memory::path.memory_id'
+      requestBody:
+        $ref: '#/components/requestBodies/ml.update_memory'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.update_memory@200'
+    delete:
+      operationId: ml.delete_memory.0
+      x-operation-group: ml.delete_memory
+      x-version-added: '2.12'
+      description: Delete a memory.
+      parameters:
+        - $ref: '#/components/parameters/ml.delete_memory::path.memory_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.delete_memory@200'
+  /_plugins/_ml/memory/_search:
+    get:
+      operationId: ml.search_memory.0
+      x-operation-group: ml.search_memory
+      x-version-added: '2.12'
+      description: Search memory.
+      requestBody:
+        $ref: '#/components/requestBodies/ml.search_memory'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.search_memory@200'
+    post:
+      operationId: ml.search_memory.1
+      x-operation-group: ml.search_memory
+      x-version-added: '2.12'
+      description: Search memory.
+      requestBody:
+        $ref: '#/components/requestBodies/ml.search_memory'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.search_memory@200'
 components:
   requestBodies:
     ml.register_model_group:
@@ -547,6 +624,53 @@ components:
             required:
               - name
               - type
+    ml.get_memory:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              max_results:
+                type: integer
+                format: int64
+                description: The maximum number of results to return.
+              next_token:
+                type: integer
+                format: int64
+                description: The index of the first memory in the sorted list of memories to return.
+    ml.create_memory:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                $ref: '../schemas/_common.yaml#/components/schemas/Name'
+    ml.update_memory:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                $ref: '../schemas/_common.yaml#/components/schemas/Name'
+    ml.search_memory:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              query:
+                $ref: '../schemas/ml._common.yaml#/components/schemas/Query'
+              size:
+                type: integer
+                format: int64
+                description: The number of memories to return.
+              sort:
+                type: array
+                items:
+                  $ref: '../schemas/ml._common.yaml#/components/schemas/SortMemory'
+                description: The sort order.
   responses:
     ml.register_model_group@200:
       content:
@@ -682,6 +806,40 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
+    ml.get_memory@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/GetMemoryResponse'
+    ml.create_memory@200:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              memory_id:
+                type: string
+    ml.update_memory@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
+    ml.delete_memory@200:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+                description: Whether the memory was deleted successfully.
+            required:
+              - success
+    ml.search_memory@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/SearchMemoryResponse'
   parameters:
     ml.get_model_group::path.model_group_id:
       name: model_group_id
@@ -775,6 +933,24 @@ components:
         type: string
     ml.get_task::path.task_id:
       name: task_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.get_memory::path.memory_id:
+      name: memory_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.update_memory::path.memory_id:
+      name: memory_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.delete_memory::path.memory_id:
+      name: memory_id
       in: path
       required: true
       schema:

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -332,6 +332,88 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ml.search_memory@200'
+  /_plugins/_ml/memory/{memory_id}/messages:
+    get:
+      operationId: ml.get_message.0
+      x-operation-group: ml.get_message
+      x-version-added: '2.12'
+      description: Get a message.
+      parameters:
+        - $ref: '#/components/parameters/ml.get_message::path.memory_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.get_message@200'
+    post:
+      operationId: ml.create_message.0
+      x-operation-group: ml.create_message
+      x-version-added: '2.12'
+      description: Create a message.
+      parameters:
+        - $ref: '#/components/parameters/ml.create_message::path.memory_id'
+      requestBody:
+        $ref: '#/components/requestBodies/ml.create_message'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.create_message@200'
+  /_plugins/_ml/memory/message/{message_id}:
+    get:
+      operationId: ml.get_message.1
+      x-operation-group: ml.get_message
+      x-version-added: '2.12'
+      description: Get a message.
+      parameters:
+        - $ref: '#/components/parameters/ml.get_message::path.message_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.get_message@200'
+    put:
+      operationId: ml.update_message.0
+      x-operation-group: ml.update_message
+      x-version-added: '2.12'
+      description: Update a message.
+      parameters:
+        - $ref: '#/components/parameters/ml.update_message::path.message_id'
+      requestBody:
+        $ref: '#/components/requestBodies/ml.update_message'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.update_message@200'
+  /_plugins/_ml/memory/{memory_id}/_search:
+    get:
+      operationId: ml.search_message.0
+      x-operation-group: ml.search_message
+      x-version-added: '2.12'
+      description: Search messages.
+      parameters:
+        - $ref: '#/components/parameters/ml.search_message::path.memory_id'
+      requestBody:
+        $ref: '#/components/requestBodies/ml.search_message'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.search_message@200'
+    post:
+      operationId: ml.search_message.1
+      x-operation-group: ml.search_message
+      x-version-added: '2.12'
+      description: Search messages.
+      parameters:
+        - $ref: '#/components/parameters/ml.search_message::path.memory_id'
+      requestBody:
+        $ref: '#/components/requestBodies/ml.search_message'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.search_message@200'
+  /_plugins/_ml/memory/message/{message_id}/traces:
+    get:
+      operationId: ml.get_message_traces.0
+      x-operation-group: ml.get_message_traces
+      x-version-added: '2.12'
+      description: Get a message traces.
+      parameters:
+        - $ref: '#/components/parameters/ml.get_message_traces::path.message_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.get_message_traces@200'
 components:
   requestBodies:
     ml.register_model_group:
@@ -671,6 +753,63 @@ components:
                 items:
                   $ref: '../schemas/ml._common.yaml#/components/schemas/SortMemory'
                 description: The sort order.
+    ml.create_message:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              input:
+                type: string
+                description: The question in the message.
+              prompt_template:
+                type: string
+                description: The prompt template.
+              response:
+                type: string
+                description: The answer to the question.
+              origin:
+                type: string
+                description: The system name that generated the response.
+              additional_info:
+                $ref: '../schemas/ml._common.yaml#/components/schemas/AdditionalInfo'
+    ml.update_message:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              input:
+                type: string
+                description: The question in the message.
+              prompt_template:
+                type: string
+                description: The prompt template.
+              response:
+                type: string
+                description: The answer to the question.
+              origin:
+                type: string
+                description: The system name that generated the response.
+              additional_info:
+                $ref: '../schemas/ml._common.yaml#/components/schemas/AdditionalInfo'
+    ml.search_message:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              query:
+                $ref: '../schemas/ml._common.yaml#/components/schemas/Query'
+              size:
+                type: integer
+                format: int64
+                description: The number of messages to return.
+              sort:
+                type: array
+                items:
+                  $ref: '../schemas/ml._common.yaml#/components/schemas/SortMessage'
+                description: The sort order.
   responses:
     ml.register_model_group@200:
       content:
@@ -818,7 +957,9 @@ components:
             type: object
             properties:
               memory_id:
-                type: string
+                $ref: '../schemas/_common.yaml#/components/schemas/Name'
+            required:
+              - memory_id
     ml.update_memory@200:
       content:
         application/json:
@@ -840,6 +981,36 @@ components:
         application/json:
           schema:
             $ref: '../schemas/ml._common.yaml#/components/schemas/SearchMemoryResponse'
+    ml.create_message@200:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message_id:
+                $ref: '../schemas/_common.yaml#/components/schemas/Name'
+            required:
+              - message_id
+    ml.get_message@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/GetMessageResponse'
+    ml.update_message@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
+    ml.search_message@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/SearchMessageResponse'
+    ml.get_message_traces@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/GetMessageTracesResponse'
   parameters:
     ml.get_model_group::path.model_group_id:
       name: model_group_id
@@ -951,6 +1122,42 @@ components:
         type: string
     ml.delete_memory::path.memory_id:
       name: memory_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.create_message::path.memory_id:
+      name: memory_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.get_message::path.memory_id:
+      name: memory_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.get_message::path.message_id:
+      name: message_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.update_message::path.message_id:
+      name: message_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.search_message::path.memory_id:
+      name: memory_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.get_message_traces::path.message_id:
+      name: message_id
       in: path
       required: true
       schema:

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -33,8 +33,7 @@ components:
           items:
             $ref: '#/components/schemas/SearchHitsHit'
         max_score:
-          type: number
-          format: float
+          type: ['null', number]
           description: The maximum score.
       required:
         - hits
@@ -224,6 +223,26 @@ components:
         user:
           type: string
           description: The username of the user.
+        input:
+          type: ['null', string]
+          description: The question in the message.
+        memory_id:
+          $ref: '_common.yaml#/components/schemas/Name'
+        trace_number:
+          type: ['null', string]
+          description: The trace number.
+        response:
+          type: ['null', string]
+          description: The answer to the question.
+        origin:
+          type: ['null', string]
+          description: The system name that generated the response.
+        parent_message_id:
+          type: ['null', string]
+          description: The parent message ID.
+        prompt_template:
+          type: ['null', string]
+          description: The prompt template.
     ModelConfig:
       type: object
       properties:
@@ -382,6 +401,8 @@ components:
       properties:
         bool:
           $ref: '#/components/schemas/BoolQuery'
+        match:
+          $ref: '#/components/schemas/Match'
         match_all:
           $ref: '#/components/schemas/MatchAllQuery'
         term:
@@ -605,6 +626,30 @@ components:
           $ref: '#/components/schemas/SortOrder'
         _seq_no:
           $ref: '#/components/schemas/SortOrder'
+    SortMessage:
+      type: object
+      description: The sort message query.
+      properties:
+        additional_info:
+          $ref: '#/components/schemas/SortOrder'
+        create_time:
+          $ref: '#/components/schemas/SortOrder'
+        memory_id:
+          $ref: '#/components/schemas/SortOrder'
+        origin:
+          $ref: '#/components/schemas/SortOrder'
+        parent_message_id:
+          $ref: '#/components/schemas/SortOrder'
+        trace_number:
+          $ref: '#/components/schemas/SortOrder'
+        _id:
+          $ref: '#/components/schemas/SortOrder'
+        _index:
+          $ref: '#/components/schemas/SortOrder'
+        _score:
+          $ref: '#/components/schemas/SortOrder'
+        _seq_no:
+          $ref: '#/components/schemas/SortOrder'
     SortOrder:
       type: object
       description: The order of the sort.
@@ -622,6 +667,7 @@ components:
         description:
           type: string
           description: The description.
+      additionalProperties: true
     TrainParameters:
       type: object
       properties:
@@ -870,6 +916,7 @@ components:
       type: object
       description: Additional information query.
       properties: {}
+      additionalProperties: true
     ToolItems:
       type: object
       properties:
@@ -933,3 +980,53 @@ components:
               description: The index of the first memory in the sorted list of memories.
     SearchMemoryResponse:
       $ref: '#/components/schemas/SearchResponse'
+    Message:
+      type: object
+      properties:
+        memory_id:
+          $ref: '_common.yaml#/components/schemas/Name'
+        message_id:
+          $ref: '_common.yaml#/components/schemas/Name'
+        create_time:
+          type: string
+          format: date-time
+          description: The create time.
+        input:
+          type: ['null', string]
+          description: The question in the message.
+        prompt_template:
+          type: ['null', string]
+          description: The prompt template.
+        response:
+          type: ['null', string]
+          description: The answer to the question.
+        origin:
+          type: ['null', string]
+          description: The system name that generated the response.
+        additional_info:
+          $ref: '#/components/schemas/AdditionalInfo'
+        parent_message_id:
+          type: ['null', string]
+          description: The parent message ID.
+        trace_number:
+          type: integer
+          format: int64
+          description: The trace number.
+    GetMessageResponse:
+      oneOf:
+        - $ref: '#/components/schemas/Message'
+        - type: object
+          properties:
+            messages:
+              type: array
+              items:
+                $ref: '#/components/schemas/Message'
+    SearchMessageResponse:
+      $ref: '#/components/schemas/SearchResponse'
+    GetMessageTracesResponse:
+      type: object
+      properties:
+        traces:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -74,6 +74,12 @@ components:
           $ref: '#/components/schemas/Source'
         model_id:
           $ref: '_common.yaml#/components/schemas/Name'
+        sort:
+          type: array
+          items:
+            type: number
+            format: float
+          description: The sort values.
       required:
         - _score
     Source:
@@ -149,8 +155,7 @@ components:
           format: int64
           description: The auto redeploy retry times.
         name:
-          type: string
-          description: The model name.
+          $ref: '_common.yaml#/components/schemas/Name'
         connector_id:
           type: string
           description: The connector ID.
@@ -203,6 +208,22 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Action'
+        updated_time:
+          type: string
+          format: date-time
+          description: The updated time.
+        create_time:
+          type: string
+          format: date-time
+          description: The create time.
+        application_type:
+          type: ['null', string]
+          description: The application type.
+        additional_info:
+          $ref: '#/components/schemas/AdditionalInfo'
+        user:
+          type: string
+          description: The username of the user.
     ModelConfig:
       type: object
       properties:
@@ -445,6 +466,8 @@ components:
             $ref: '_common.yaml#/components/schemas/Id'
         model_id:
           $ref: '_common.yaml#/components/schemas/Name'
+        name:
+          $ref: '#/components/schemas/OwnerNameKeyword'
         owner.name.keyword:
           $ref: '#/components/schemas/OwnerNameKeyword'
     Algorithm:
@@ -559,6 +582,28 @@ components:
         _seq_no:
           $ref: '#/components/schemas/SortOrder'
         _score:
+          $ref: '#/components/schemas/SortOrder'
+    SortMemory:
+      type: object
+      description: The sort memory query.
+      properties:
+        additional_info:
+          $ref: '#/components/schemas/SortOrder'
+        application_time:
+          $ref: '#/components/schemas/SortOrder'
+        create_time:
+          $ref: '#/components/schemas/SortOrder'
+        updated_time:
+          $ref: '#/components/schemas/SortOrder'
+        user:
+          $ref: '#/components/schemas/SortOrder'
+        _id:
+          $ref: '#/components/schemas/SortOrder'
+        _index:
+          $ref: '#/components/schemas/SortOrder'
+        _score:
+          $ref: '#/components/schemas/SortOrder'
+        _seq_no:
           $ref: '#/components/schemas/SortOrder'
     SortOrder:
       type: object
@@ -804,6 +849,27 @@ components:
       properties:
         type:
           type: string
+        memory_id:
+          $ref: '_common.yaml#/components/schemas/Name'
+        create_time:
+          type: string
+          format: date-time
+          description: The create time.
+        updated_time:
+          type: string
+          format: date-time
+          description: The updated time.
+        name:
+          $ref: '_common.yaml#/components/schemas/Name'
+        user:
+          type: string
+          description: The username of the user.
+        additional_info:
+          $ref: '#/components/schemas/AdditionalInfo'
+    AdditionalInfo:
+      type: object
+      description: Additional information query.
+      properties: {}
     ToolItems:
       type: object
       properties:
@@ -851,4 +917,19 @@ components:
           format: int64
           description: The last updated time.
     SearchConnectorsResponse:
+      $ref: '#/components/schemas/SearchResponse'
+    GetMemoryResponse:
+      oneOf:
+        - $ref: '#/components/schemas/Memory'
+        - type: object
+          properties:
+            memories:
+              type: array
+              items:
+                $ref: '#/components/schemas/Memory'
+            next_token:
+              type: integer
+              format: int64
+              description: The index of the first memory in the sorted list of memories.
+    SearchMemoryResponse:
       $ref: '#/components/schemas/SearchResponse'

--- a/tests/plugins/ml/ml/memory/create.yaml
+++ b/tests/plugins/ml/ml/memory/create.yaml
@@ -1,0 +1,22 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the creation of a memory.
+version: '>= 2.12'
+epilogues:
+  - path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      memory_id: ${create_memory.memory_id}
+chapters:
+  - synopsis: Create a memory.
+    id: create_memory
+    path: /_plugins/_ml/memory
+    method: POST
+    request:
+      payload:
+        name: Test memory
+    response:
+      status: 200
+    output:
+      memory_id: payload.memory_id

--- a/tests/plugins/ml/ml/memory/delete.yaml
+++ b/tests/plugins/ml/ml/memory/delete.yaml
@@ -1,0 +1,27 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the deletion of a memory.
+version: '>= 2.12'
+prologues:
+  - path: /_plugins/_ml/memory
+    id: create_memory
+    method: POST
+    request:
+      payload:
+        name: Test memory
+    output:
+      memory_id: payload.memory_id
+epilogues:
+  - path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      memory_id: ${create_memory.memory_id}
+chapters:
+  - synopsis: Delete a memory.
+    path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    response:
+      status: 200

--- a/tests/plugins/ml/ml/memory/get.yaml
+++ b/tests/plugins/ml/ml/memory/get.yaml
@@ -1,0 +1,35 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the retrieval of a memory by ID and all memories.
+version: '>= 2.12'
+prologues:
+  - path: /_plugins/_ml/memory
+    id: create_memory
+    method: POST
+    request:
+      payload:
+        name: Test memory
+    output:
+      memory_id: payload.memory_id
+epilogues:
+  - path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      memory_id: ${create_memory.memory_id}
+chapters:
+  - synopsis: Get a memory by ID.
+    path: /_plugins/_ml/memory/{memory_id}
+    method: GET
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    response:
+      status: 200
+  - synopsis: Get all memories.
+    path: /_plugins/_ml/memory
+    method: GET
+    request:
+      payload:
+        max_results: 10
+    response:
+      status: 200

--- a/tests/plugins/ml/ml/memory/search.yaml
+++ b/tests/plugins/ml/ml/memory/search.yaml
@@ -1,0 +1,41 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the search of memories.
+version: '>= 2.12'
+prologues:
+  - path: /_plugins/_ml/memory
+    id: create_memory
+    method: POST
+    request:
+      payload:
+        name: Test memory
+    output:
+      memory_id: payload.memory_id
+epilogues:
+  - path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      memory_id: ${create_memory.memory_id}
+chapters:
+  - synopsis: Search memory.
+    path: /_plugins/_ml/memory/_search
+    method: GET
+    request:
+      payload:
+        query:
+          match_all: {}
+        size: 1000
+    response:
+      status: 200
+  - synopsis: Search memory by name.
+    path: /_plugins/_ml/memory/_search
+    method: POST
+    request:
+      payload:
+        query:
+          term:
+            name:
+              value: conversation
+    response:
+      status: 200

--- a/tests/plugins/ml/ml/memory/update.yaml
+++ b/tests/plugins/ml/ml/memory/update.yaml
@@ -1,0 +1,30 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test updating of a memory.
+version: '>= 2.12'
+prologues:
+  - path: /_plugins/_ml/memory
+    id: create_memory
+    method: POST
+    request:
+      payload:
+        name: Test memory
+    output:
+      memory_id: payload.memory_id
+epilogues:
+  - path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      memory_id: ${create_memory.memory_id}
+chapters:
+  - synopsis: Update a memory.
+    path: /_plugins/_ml/memory/{memory_id}
+    method: PUT
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    request:
+      payload:
+        name: Test memory updated
+    response:
+      status: 200

--- a/tests/plugins/ml/ml/message/create.yaml
+++ b/tests/plugins/ml/ml/message/create.yaml
@@ -1,6 +1,6 @@
 $schema: ../../../../../json_schemas/test_story.schema.yaml
 
-description: Test updating a memory.
+description: Test the creation of a message.
 version: '>= 2.12'
 prologues:
   - path: /_plugins/_ml/memory
@@ -18,13 +18,18 @@ epilogues:
     parameters:
       memory_id: ${create_memory.memory_id}
 chapters:
-  - synopsis: Update a memory.
-    path: /_plugins/_ml/memory/{memory_id}
-    method: PUT
+  - synopsis: Create a message.
+    path: /_plugins/_ml/memory/{memory_id}/messages
+    method: POST
     parameters:
       memory_id: ${create_memory.memory_id}
     request:
       payload:
-        name: Test memory updated
+        input: What is the best selling novel of all time?
+        prompt_template: Hello OpenAI, can you answer this question?
+        response: Hello, this is OpenAI. Here is the answer to your question.
+        origin: MyFirstOpenAIWrapper
+        additional_info:
+          suggestion: api.openai.com
     response:
       status: 200

--- a/tests/plugins/ml/ml/message/get.yaml
+++ b/tests/plugins/ml/ml/message/get.yaml
@@ -1,0 +1,50 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the retrieval of a message by ID and all messages.
+version: '>= 2.12'
+warnings:
+  multiple-paths-detected: false
+prologues:
+  - path: /_plugins/_ml/memory
+    id: create_memory
+    method: POST
+    request:
+      payload:
+        name: Test memory
+    output:
+      memory_id: payload.memory_id
+  - path: /_plugins/_ml/memory/{memory_id}/messages
+    id: create_message
+    method: POST
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    request:
+      payload:
+        input: What is the best selling novel of all time?
+        prompt_template: Hello OpenAI, can you answer this question?
+        response: Hello, this is OpenAI. Here is the answer to your question.
+        additional_info:
+          suggestion: api.openai.com
+    output:
+      message_id: payload.message_id
+epilogues:
+  - path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      memory_id: ${create_memory.memory_id}
+chapters:
+  - synopsis: Get a message by ID.
+    path: /_plugins/_ml/memory/message/{message_id}
+    method: GET
+    parameters:
+      message_id: ${create_message.message_id}
+    response:
+      status: 200
+  - synopsis: Get all messages.
+    path: /_plugins/_ml/memory/{memory_id}/messages
+    method: GET
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    response:
+      status: 200

--- a/tests/plugins/ml/ml/message/get_traces.yaml
+++ b/tests/plugins/ml/ml/message/get_traces.yaml
@@ -1,0 +1,41 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the retrieval of message trace.
+version: '>= 2.12'
+prologues:
+  - path: /_plugins/_ml/memory
+    id: create_memory
+    method: POST
+    request:
+      payload:
+        name: Test memory
+    output:
+      memory_id: payload.memory_id
+  - path: /_plugins/_ml/memory/{memory_id}/messages
+    id: create_message
+    method: POST
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    request:
+      payload:
+        input: What is the best selling novel of all time?
+        prompt_template: Hello OpenAI, can you answer this question?
+        response: Hello, this is OpenAI. Here is the answer to your question.
+        additional_info:
+          suggestion: api.openai.com
+    output:
+      message_id: payload.message_id
+epilogues:
+  - path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      memory_id: ${create_memory.memory_id}
+chapters:
+  - synopsis: Get a message trace.
+    path: /_plugins/_ml/memory/message/{message_id}/traces
+    method: GET
+    parameters:
+      message_id: ${create_message.message_id}
+    response:
+      status: 200

--- a/tests/plugins/ml/ml/message/search.yaml
+++ b/tests/plugins/ml/ml/message/search.yaml
@@ -1,0 +1,58 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the search of messages.
+version: '>= 2.12'
+prologues:
+  - path: /_plugins/_ml/memory
+    id: create_memory
+    method: POST
+    request:
+      payload:
+        name: Test memory
+    output:
+      memory_id: payload.memory_id
+  - path: /_plugins/_ml/memory/{memory_id}/messages
+    id: create_message
+    method: POST
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    request:
+      payload:
+        input: What is the best selling novel of all time?
+        prompt_template: Hello OpenAI, can you answer this question?
+        response: Hello, this is OpenAI. Here is the answer to your question.
+        additional_info:
+          suggestion: api.openai.com
+    output:
+      message_id: payload.message_id
+epilogues:
+  - path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      memory_id: ${create_memory.memory_id}
+chapters:
+  - synopsis: Search message.
+    path: /_plugins/_ml/memory/{memory_id}/_search
+    method: GET
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    request:
+      payload:
+        query:
+          match_all: {}
+        size: 1000
+    response:
+      status: 200
+  - synopsis: Search message by matching input.
+    path: /_plugins/_ml/memory/{memory_id}/_search
+    method: POST
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    request:
+      payload:
+        query:
+          match:
+            input: novel
+    response:
+      status: 200

--- a/tests/plugins/ml/ml/message/update.yaml
+++ b/tests/plugins/ml/ml/message/update.yaml
@@ -1,0 +1,46 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test updating a message.
+version: '>= 2.12'
+prologues:
+  - path: /_plugins/_ml/memory
+    id: create_memory
+    method: POST
+    request:
+      payload:
+        name: Test memory
+    output:
+      memory_id: payload.memory_id
+  - path: /_plugins/_ml/memory/{memory_id}/messages
+    id: create_message
+    method: POST
+    parameters:
+      memory_id: ${create_memory.memory_id}
+    request:
+      payload:
+        input: What is the best selling novel of all time?
+        prompt_template: Hello OpenAI, can you answer this question?
+        response: Hello, this is OpenAI. Here is the answer to your question.
+        origin: MyFirstOpenAIWrapper
+        additional_info:
+          suggestion: api.openai.com
+    output:
+      message_id: payload.message_id
+epilogues:
+  - path: /_plugins/_ml/memory/{memory_id}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      memory_id: ${create_memory.memory_id}
+chapters:
+  - synopsis: Update a message.
+    path: /_plugins/_ml/memory/message/{message_id}
+    method: PUT
+    parameters:
+      message_id: ${create_message.message_id}
+    request:
+      payload:
+        additional_info:
+          feedback: positive
+    response:
+      status: 200


### PR DESCRIPTION
### Description
Added missing ML Memory APIs.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-py/issues/867.

### ML Memory APIs to add
- [x] POST /_plugins/_ml/memory
- [x] PUT /_plugins/_ml/memory/{memory_id}
- [x] GET /_plugins/_ml/memory
- [x] GET /_plugins/_ml/memory/{memory_id}
- [x] GET /_plugins/_ml/memory/_search
- [x] POST /_plugins/_ml/memory/_search
- [x] DELETE /_plugins/_ml/memory/{memory_id}
- [x] POST /_plugins/_ml/memory/{memory_id}/messages
- [x] PUT /_plugins/_ml/memory/message/{message_id}
- [x] GET /_plugins/_ml/memory/message/{message_id}
- [x] GET /_plugins/_ml/memory/{memory_id}/messages
- [x] GET /_plugins/_ml/memory/{memory_id}/_search
- [x] POST /_plugins/_ml/memory/{memory_id}/_search
- [x] GET /_plugins/_ml/memory/message/{message_id}/traces

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
