### PR TITLE
Evaluate payload body in prologues and epilogues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added the ability to skip an individual chapter test ([#765](https://github.com/opensearch-project/opensearch-api-specification/pull/765))
 - Added uploading of test spec logs ([#767](https://github.com/opensearch-project/opensearch-api-specification/pull/767))
 - Added `POST /_plugins/_ml/memory`, `POST /_plugins/_ml/memory/_search`, `{memory_id}/_search`, `{memory_id}/messages`, `PUT /_plugins/_ml/memory/{memory_id}`, `message/{message_id}`,  `GET /_plugins/_ml/memory`, `GET /_plugins/_ml/memory/{memory_id}`, `_search`, `message/{message_id}`, `{memory_id}/messages`, `{memory_id}/_search`, `message/{message_id}/traces`,  and `DELETE /_plugins/_ml/memory/{memory_id}` ([#771](https://github.com/opensearch-project/opensearch-api-specification/pull/771))
+- Added support for evaluating response payloads in prologues and epilogues ([#772](https://github.com/opensearch-project/opensearch-api-specification/pull/772))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/tools/src/tester/ResponsePayloadEvaluator.ts
+++ b/tools/src/tester/ResponsePayloadEvaluator.ts
@@ -1,0 +1,39 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+import _ from "lodash"
+import { Evaluation, Result } from './types/eval.types'
+import { Logger } from "../Logger"
+import { to_json } from "../helpers"
+import { ActualResponse, Payload } from "./types/story.types"
+import { atomizeChangeset, diff, Operation } from "json-diff-ts"
+
+export default class ResponsePayloadEvaluator {
+  private readonly logger: Logger
+
+  constructor(logger: Logger) {
+    this.logger = logger
+  }
+
+  evaluate(response: ActualResponse, expected_payload?: Payload): Evaluation {
+    if (expected_payload == null) return { result: Result.PASSED }
+    const payload = response.payload
+    this.logger.info(`${to_json(payload)}`)
+    const delta = atomizeChangeset(diff(expected_payload, payload))
+    const messages: string[] = _.compact(delta.map((value, _index, _array) => {
+      switch (value.type) {
+        case Operation.UPDATE:
+          return `expected ${value.path.replace('$.', '')}='${value.oldValue}', got '${value.value}'`
+        case Operation.REMOVE:
+          return `missing ${value.path.replace('$.', '')}='${value.value}'`
+      }
+    }))
+    return messages.length > 0 ? { result: Result.FAILED, message: _.join(messages, ', ') } : { result: Result.PASSED }
+  }
+}

--- a/tools/src/tester/types/story.types.ts
+++ b/tools/src/tester/types/story.types.ts
@@ -64,23 +64,6 @@ export type Version = string;
  */
 export type DistributionsList = string[];
 /**
- * Number of times to retry on error.
- *
- *
- * This interface was referenced by `Story`'s JSON-Schema
- * via the `definition` "Retry".
- */
-export type Retry = {
-  /**
-   * Number of retries.
-   */
-  count: number;
-  /**
-   * Number of milliseconds to wait before retrying.
-   */
-  wait?: number;
-};
-/**
  * This interface was referenced by `Story`'s JSON-Schema
  * via the `definition` "Chapter".
  */
@@ -90,6 +73,9 @@ export type Chapter = ChapterRequest & {
    * A brief description of the chapter.
    */
   synopsis: string;
+  /**
+   * An explanation is provided to clarify why it has been skipped.
+   */
   pending?: string;
   response?: ExpectedResponse;
   warnings?: Warnings;
@@ -131,6 +117,7 @@ export interface ChapterRequest {
   version?: Version;
   distributions?: Distributions;
   retry?: Retry;
+  response?: ExpectedResponse;
 }
 /**
  * This interface was referenced by `Story`'s JSON-Schema
@@ -176,6 +163,23 @@ export interface DetailedOutput {
 export interface Distributions {
   included?: DistributionsList;
   excluded?: DistributionsList;
+}
+/**
+ * Number of times to retry on error.
+ *
+ *
+ * This interface was referenced by `Story`'s JSON-Schema
+ * via the `definition` "Retry".
+ */
+export interface Retry {
+  /**
+   * Number of retries.
+   */
+  count: number;
+  /**
+   * Number of milliseconds to wait before retrying.
+   */
+  wait?: number;
 }
 /**
  * This interface was referenced by `Story`'s JSON-Schema

--- a/tools/tests/tester/ResponsePayloadEvaluator.test.ts
+++ b/tools/tests/tester/ResponsePayloadEvaluator.test.ts
@@ -1,0 +1,39 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+
+import { Result } from "tester/types/eval.types";
+import ResponsePayloadEvaluator from "tester/ResponsePayloadEvaluator";
+import { Logger } from "Logger";
+import { ActualResponse } from "tester/types/story.types";
+
+function create_response(payload: any): ActualResponse {
+  return {
+    status: 200,
+    content_type: 'application/json',
+    payload
+  }
+}
+
+describe('ResponsePayloadEvaluator', () => {
+  const evaluator = new ResponsePayloadEvaluator(new Logger())
+
+  describe('evaluate', () => {
+    test('succeeds without an expected payload', () => {
+      expect(evaluator.evaluate(create_response({}), undefined)).toEqual({ result: Result.PASSED })
+    })
+
+    test('fails with a non-matching payload', () => {
+      expect(evaluator.evaluate(create_response({}), { x: 1 })).toEqual({ result: Result.FAILED, message: "missing x='1'" })
+    })
+
+    test('succeeds with a matching payload', () => {
+      expect(evaluator.evaluate(create_response({ x: 1 }), { x: 1 })).toEqual({ result: Result.PASSED })
+    })
+  })
+})

--- a/tools/tests/tester/SupplementalChapterEvaluator.test.ts
+++ b/tools/tests/tester/SupplementalChapterEvaluator.test.ts
@@ -86,5 +86,53 @@ describe('SupplementalChapterEvaluator', () => {
       expect(result.overall.result).toEqual(Result.ERROR)
       expect(count).toEqual(5)
     })
+
+    test('a valid response payload', async () => {
+      mock.onAny().reply(200, '{"acknowledged":true}', { "content-type": "application/json" })
+
+      expect(
+        await supplemental_chapter_evaluator.evaluate({
+          path: '/test',
+          method: 'PUT',
+          request: {
+            payload: {}
+          },
+          response: {
+            status: 200,
+            payload: {
+              acknowledged: true
+            }
+          }
+        }, story_outputs)).toEqual({
+        title: 'PUT /test',
+        overall: {
+          result: Result.PASSED
+        }
+      })
+    })
+
+    test('an invalid response payload', async () => {
+      mock.onAny().reply(200, '{"acknowledged":false}', { "content-type": "application/json" })
+
+      expect(
+        await supplemental_chapter_evaluator.evaluate({
+          path: '/test',
+          method: 'PUT',
+          request: {
+            payload: {}
+          },
+          response: {
+            status: 200,
+            payload: {
+              acknowledged: true
+            }
+          }
+        }, story_outputs)).toEqual({
+        title: 'PUT /test',
+        overall: {
+          result: Result.FAILED
+        }
+      })
+    })
   })
 })


### PR DESCRIPTION
### Description

Coming from https://github.com/opensearch-project/opensearch-api-specification/pull/733, evaluate response payloads in prologues so we can wait for a certain output.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-api-specification/issues/619.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
