### PR TITLE
Added `aggs` property as an alias to `aggregations` in requestBody of `search`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `GET /_plugins/_ml/connectors/{connector_id}`, `_search`, `POST /_plugins/_ml/connectors/_search`, and `PUT /_plugins/_ml/connectors/{connector_id}` ([#764](https://github.com/opensearch-project/opensearch-api-specification/pull/764))
 - Added the ability to skip an individual chapter test ([#765](https://github.com/opensearch-project/opensearch-api-specification/pull/765))
 - Added uploading of test spec logs ([#767](https://github.com/opensearch-project/opensearch-api-specification/pull/767))
+- Added `aggs` property as an alias to `aggregations` in requestBody of `search` [#774](https://github.com/opensearch-project/opensearch-api-specification/issues/774)
 - Added `POST /_plugins/_ml/memory`, `POST /_plugins/_ml/memory/_search`, `{memory_id}/_search`, `{memory_id}/messages`, `PUT /_plugins/_ml/memory/{memory_id}`, `message/{message_id}`,  `GET /_plugins/_ml/memory`, `GET /_plugins/_ml/memory/{memory_id}`, `_search`, `message/{message_id}`, `{memory_id}/messages`, `{memory_id}/_search`, `message/{message_id}/traces`,  and `DELETE /_plugins/_ml/memory/{memory_id}` ([#771](https://github.com/opensearch-project/opensearch-api-specification/pull/771))
 - Added support for evaluating response payloads in prologues and epilogues ([#772](https://github.com/opensearch-project/opensearch-api-specification/pull/772))
 

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2538,6 +2538,11 @@ components:
                 type: object
                 additionalProperties:
                   $ref: '../schemas/_common.aggregations.yaml#/components/schemas/AggregationContainer'
+              aggs:
+                description: Defines the aggregations that are run as part of the search request.
+                type: object
+                additionalProperties:
+                  $ref: '../schemas/_common.aggregations.yaml#/components/schemas/AggregationContainer'
               collapse:
                 $ref: '../schemas/_core.search.yaml#/components/schemas/FieldCollapse'
               explain:

--- a/tests/default/_core/search/aggregations/avg.yaml
+++ b/tests/default/_core/search/aggregations/avg.yaml
@@ -22,7 +22,7 @@ chapters:
     request:
       payload:
         size: 0
-        aggregations:
+        aggs:
           duration_avg:
             avg:
               field: duration

--- a/tests/default/_core/search/aggregations/historgram.yaml
+++ b/tests/default/_core/search/aggregations/historgram.yaml
@@ -24,7 +24,7 @@ chapters:
     request:
       payload:
         size: 0
-        aggregations:
+        aggs:
           movies:
             histogram:
               field: year

--- a/tests/default/_core/search/aggregations/max.yaml
+++ b/tests/default/_core/search/aggregations/max.yaml
@@ -22,7 +22,7 @@ chapters:
     request:
       payload:
         size: 0
-        aggregations:
+        aggs:
           duration_max:
             max:
               field: duration

--- a/tests/default/_core/search/aggregations/min.yaml
+++ b/tests/default/_core/search/aggregations/min.yaml
@@ -22,7 +22,7 @@ chapters:
     request:
       payload:
         size: 0
-        aggregations:
+        aggs:
           duration_min:
             min:
               field: duration


### PR DESCRIPTION
Note that we have 8 tests that use `aggregations`. I converted 4 to `aggs` since they are alias of each other.

closes #774 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
