### PR TITLE
Fix Memory CB flaky error in ML APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed ingest API schemas ([#766](https://github.com/opensearch-project/opensearch-api-specification/pull/766))
 - Fixed CAT API schemas ([#769](https://github.com/opensearch-project/opensearch-api-specification/pull/769))
 - Fixed core API schemas ([#777](https://github.com/opensearch-project/opensearch-api-specification/pull/777))
-- Fixed Memory Circuit Breaker flaky test in ML Model APIs ([#782](https://github.com/opensearch-project/opensearch-api-specification/pull/782))
+- Fixed Memory Circuit Breaker flaky error in ML APIs ([#788](https://github.com/opensearch-project/opensearch-api-specification/pull/788))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/tests/plugins/ml/ml/controller/create.yaml
+++ b/tests/plugins/ml/ml/controller/create.yaml
@@ -8,7 +8,7 @@ prologues:
     request:
       payload:
         persistent:
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
   - path: /_plugins/_ml/models/_register
     id: register_model
     method: POST

--- a/tests/plugins/ml/ml/controller/delete.yaml
+++ b/tests/plugins/ml/ml/controller/delete.yaml
@@ -8,7 +8,7 @@ prologues:
     request:
       payload:
         persistent:
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
   - path: /_plugins/_ml/models/_register
     id: register_model
     method: POST

--- a/tests/plugins/ml/ml/controller/get.yaml
+++ b/tests/plugins/ml/ml/controller/get.yaml
@@ -8,7 +8,7 @@ prologues:
     request:
       payload:
         persistent:
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
   - path: /_plugins/_ml/models/_register
     id: register_model
     method: POST

--- a/tests/plugins/ml/ml/controller/update.yaml
+++ b/tests/plugins/ml/ml/controller/update.yaml
@@ -8,7 +8,7 @@ prologues:
     request:
       payload:
         persistent:
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
   - path: /_plugins/_ml/models/_register
     id: register_model
     method: POST

--- a/tests/plugins/ml/ml/models/load.yaml
+++ b/tests/plugins/ml/ml/models/load.yaml
@@ -7,7 +7,7 @@ prologues:
     request:
       payload:
         persistent:
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
   - path: /_plugins/_ml/models/_register
     id: register_model
     method: POST

--- a/tests/plugins/ml/ml/models/predict.yaml
+++ b/tests/plugins/ml/ml/models/predict.yaml
@@ -10,7 +10,7 @@ prologues:
         persistent:
           plugins.ml_commons.only_run_on_ml_node: false
           plugins.ml_commons.model_access_control_enabled: true
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
   - path: /_plugins/_ml/model_groups/_register
     id: create_model_group
     method: POST

--- a/tests/plugins/ml/ml/models/search.yaml
+++ b/tests/plugins/ml/ml/models/search.yaml
@@ -8,7 +8,7 @@ prologues:
     request:
       payload:
         persistent:
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
   - path: /_plugins/_ml/models/_register
     id: register_model
     method: POST

--- a/tests/plugins/ml/ml/models/undeploy.yaml
+++ b/tests/plugins/ml/ml/models/undeploy.yaml
@@ -9,7 +9,7 @@ prologues:
       payload:
         persistent:
           plugins.ml_commons.allow_custom_deployment_plan: true
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
   - path: /_plugins/_ml/models/_register
     id: register_model
     method: POST

--- a/tests/plugins/ml/ml/models/unload.yaml
+++ b/tests/plugins/ml/ml/models/unload.yaml
@@ -8,7 +8,7 @@ prologues:
       payload:
         persistent:
           plugins.ml_commons.allow_custom_deployment_plan: true
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
   - path: /_plugins/_ml/models/_register
     id: register_model
     method: POST

--- a/tests/plugins/ml/ml/models/upload.yaml
+++ b/tests/plugins/ml/ml/models/upload.yaml
@@ -7,7 +7,7 @@ prologues:
     request:
       payload:
         persistent:
-          plugins.ml_commons.native_memory_threshold: 100
+          plugins.ml_commons.jvm_heap_memory_threshold: 100
 epilogues:
   - path: /_plugins/_ml/tasks/{task_id}
     id: get_completed_task


### PR DESCRIPTION
### Description
Replaced native memory threshold settings with JVM heap memory threshold settings to fix Memory Circuit Breaker error in ML API tests.

### Issues Resolved
Resolve https://github.com/opensearch-project/opensearch-api-specification/issues/776

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
