### PR TITLE
Test using common schema descriptions for repeated query parameters

### DIFF
--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -3613,10 +3613,6 @@ components:
     count::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: |-
-        Type of index that wildcard patterns can match.
-        If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-        Supports comma-separated values, such as `open,hidden`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form

--- a/spec/namespaces/asynchronous_search.yaml
+++ b/spec/namespaces/asynchronous_search.yaml
@@ -52,7 +52,7 @@ paths:
       operationId: asynchronous_search.stats.0
       x-operation-group: asynchronous_search.stats
       x-version-added: '1.0'
-      description: Monitor any asynchronous searches that are `running`, `completed`, `persisted`.
+      description: Monitors any asynchronous searches that are `running`, `completed`, `persisted`.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/async/index/#monitor-stats
       responses:
@@ -66,7 +66,6 @@ components:
       in: query
       description: |- 
         The amount of time that you plan to wait for the results. 
-        You can see whatever results you get within this time just like in a normal search. 
         You can poll the remaining results based on an ID. The maximum value is 300 seconds. Default is `1s`.
       schema:
         type: string

--- a/spec/namespaces/asynchronous_search.yaml
+++ b/spec/namespaces/asynchronous_search.yaml
@@ -64,9 +64,7 @@ components:
     asynchronous_search.search::query.wait_for_completion_timeout:
       name: wait_for_completion_timeout
       in: query
-      description: |- 
-        The amount of time that you plan to wait for the results. 
-        You can poll the remaining results based on an ID. The maximum value is 300 seconds. Default is `1s`.
+      description: The amount of time that you plan to wait for the results. You can poll the remaining results based on an ID. The maximum value is 300 seconds. Default is `1s`.
       schema:
         type: string
     asynchronous_search.search::query.keep_on_completion:

--- a/spec/namespaces/asynchronous_search.yaml
+++ b/spec/namespaces/asynchronous_search.yaml
@@ -9,7 +9,7 @@ paths:
       operationId: asynchronous_search.search.0
       x-operation-group: asynchronous_search.search
       x-version-added: '1.0'
-      description: Perform an asynchronous search.
+      description: Performs an asynchronous search.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/async/index/#rest-api
       parameters:
@@ -27,7 +27,7 @@ paths:
       operationId: asynchronous_search.get.0
       x-operation-group: asynchronous_search.get
       x-version-added: '1.0'
-      description: Get partial responses from asynchronous search.
+      description: Gets partial responses from an asynchronous search.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/async/index/#get-partial-results
       parameters:
@@ -39,7 +39,7 @@ paths:
       operationId: asynchronous_search.delete.0
       x-operation-group: asynchronous_search.delete
       x-version-added: '1.0'
-      description: Delete asynchronous search.
+      description: Deletes any responses from an asynchronous search.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/async/index/#delete-searches-and-results
       parameters:
@@ -52,7 +52,7 @@ paths:
       operationId: asynchronous_search.stats.0
       x-operation-group: asynchronous_search.stats
       x-version-added: '1.0'
-      description: Monitoring of asynchronous searches that are running, completed, and/or persisted.
+      description: Monitor any asynchronous searches that are `running`, `completed`, `persisted`.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/async/index/#monitor-stats
       responses:
@@ -64,19 +64,25 @@ components:
     asynchronous_search.search::query.wait_for_completion_timeout:
       name: wait_for_completion_timeout
       in: query
-      description: The amount of time that you plan to wait for the results. You can poll the remaining results based on an ID. The maximum value is `300s`. Default is `1s`.
+      description: |- 
+        The amount of time that you plan to wait for the results. 
+        You can see whatever results you get within this time just like in a normal search. 
+        You can poll the remaining results based on an ID. The maximum value is 300 seconds. Default is `1s`.
       schema:
         type: string
     asynchronous_search.search::query.keep_on_completion:
       name: keep_on_completion
       in: query
-      description: Whether you want to save the results in the cluster after the search is complete. 
+      description: Whether you want to save the results in the cluster after the search is complete. You can examine the stored results at a later time.
       schema:
         type: boolean
     asynchronous_search.search::query.keep_alive:
       name: keep_alive
       in: query
-      description: The amount of time that the result is saved in the cluster. For example, `2d` means that the results are stored in the cluster for 48 hours. The saved search results are deleted after this period or if the search is canceled. Note that this includes the query execution time. If the query overruns this time, the process cancels this query automatically.
+      description: |- 
+        The amount of time that the result is saved in the cluster. For example, `2d` means that the results are stored in the cluster for 48 hours. 
+        The saved search results are deleted after this period or if the search is canceled. Note that this includes the query execution time. 
+        If the query overruns this time, the process cancels this query automatically.
       schema:
         type: string
     asynchronous_search.search::query.index:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -419,6 +419,7 @@ components:
           items:
             $ref: '#/components/schemas/Field'
     ExpandWildcards:
+      description: Specifies the type of index that wildcard expressions can match. Supports comma-separated values.
       oneOf:
         - $ref: '#/components/schemas/ExpandWildcard'
         - type: array


### PR DESCRIPTION
### Description

As part of issue #783, this PR tests whether removing a description from a query parameter in `namespaces` will use the description found in the common schema. This would make the descriptions for common query parameters, such as `expand_wildcards`, more consistent when automating API documentation.

This does pass linting. Going this route for descriptions will require steering new contributors towards using descriptions from the common schema, though one could argue they should be doing so already.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
