### PR TITLE
Change `ml.get_tools` to have two different operation groups: `ml.get_all_tools` and `ml.get_tool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Changed `indices.data_streams_stats:DataStreamsStatsItem` to instead be `indices._common:DataStreamStats` ([#725](https://github.com/opensearch-project/opensearch-api-specification/pull/725)) 
 - Changed naming of `snapshot._common`'s `Status`, `ShardsStats`, `ShardsStatsStage`, `ShardsStatsSummary` and `ShardsStatsSummaryItem` schemas to be prefixed with `Snapshot` ([#730](https://github.com/opensearch-project/opensearch-api-specification/pull/730))
 - Changed `ml.get_memory` and `ml.get_message` to split out `get_all` variants ([#796](https://github.com/opensearch-project/opensearch-api-specification/pull/796))
+- Changed `ml.get_tools` to have two different operation groups `ml.get_all_tools` and `ml.get_tool` ([#799](https://github.com/opensearch-project/opensearch-api-specification/pull/799))
 
 ## [0.1.0] - 2024-10-25
 

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -760,24 +760,24 @@ paths:
           $ref: '#/components/responses/ml.get_stats@200'
   /_plugins/_ml/tools:
     get:
-      operationId: ml.get_tools.0
-      x-operation-group: ml.get_tools
+      operationId: ml.get_all_tools.0
+      x-operation-group: ml.get_all_tools
       x-version-added: '2.12'
       description: Get tools.
       responses:
         '200':
-          $ref: '#/components/responses/ml.get_tools@200'
+          $ref: '#/components/responses/ml.get_all_tools@200'
   /_plugins/_ml/tools/{tool_name}:
     get:
-      operationId: ml.get_tools.1
-      x-operation-group: ml.get_tools
+      operationId: ml.get_tool.0
+      x-operation-group: ml.get_tool
       x-version-added: '2.12'
       description: Get tools.
       parameters:
-        - $ref: '#/components/parameters/ml.get_tools::path.tool_name'
+        - $ref: '#/components/parameters/ml.get_tool::path.tool_name'
       responses:
         '200':
-          $ref: '#/components/responses/ml.get_tools@200'
+          $ref: '#/components/responses/ml.get_tool@200'
 components:
   requestBodies:
     ml.register_model_group:
@@ -1806,15 +1806,18 @@ components:
         application/json:
           schema:
             $ref: '../schemas/ml._common.yaml#/components/schemas/GetStatsResponse'
-    ml.get_tools@200:
+    ml.get_all_tools@200:
       content:
         application/json:
           schema:
-            oneOf:
-              - type: array
-                items:
-                  $ref: '../schemas/ml._common.yaml#/components/schemas/GetToolsResponse'
-              - $ref: '../schemas/ml._common.yaml#/components/schemas/GetToolsResponse'
+            type: array
+            items:
+              $ref: '../schemas/ml._common.yaml#/components/schemas/GetToolsResponse'
+    ml.get_tool@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/GetToolsResponse'
   parameters:
     ml.get_all_memories::query.max_results:
       name: max_results
@@ -2122,7 +2125,7 @@ components:
       required: true
       schema:
         type: string
-    ml.get_tools::path.tool_name:
+    ml.get_tool::path.tool_name:
       name: tool_name
       in: path
       required: true

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -1812,12 +1812,12 @@ components:
           schema:
             type: array
             items:
-              $ref: '../schemas/ml._common.yaml#/components/schemas/GetToolsResponse'
+              $ref: '../schemas/ml._common.yaml#/components/schemas/Tool'
     ml.get_tool@200:
       content:
         application/json:
           schema:
-            $ref: '../schemas/ml._common.yaml#/components/schemas/GetToolsResponse'
+            $ref: '../schemas/ml._common.yaml#/components/schemas/Tool'
   parameters:
     ml.get_all_memories::query.max_results:
       name: max_results

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -1494,7 +1494,7 @@ components:
           type: string
           description: The field name.
       additionalProperties: true
-    GetToolsResponse:
+    Tool:
       type: object
       properties:
         name:


### PR DESCRIPTION
### Description
Changed `ml.get_tools` to have two different operation groups: `ml.get_all_tools` and `ml.get_tool`.

### Issues Resolved
Resolve https://github.com/opensearch-project/opensearch-api-specification/pull/797#discussion_r1919286243

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
