### PR TITLE
Add time field to getStats schema in _common.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `GET`, `POST /_plugins/_ml/tasks/_search`, `GET /_plugins/_ml/tools`, `tools/{tool_name}` ([#797](https://github.com/opensearch-project/opensearch-api-specification/pull/797))
 - Added `POST /_plugins/_ml/agents/{agent_id}/_execute`, `GET /_plugins/_ml/agents/{agent_id}`, `GET`, `POST /_plugins/_ml/agents/_search` ([#798](https://github.com/opensearch-project/opensearch-api-specification/pull/798))
 - Added a warning for test file names that don't match the API being tested ([#793](https://github.com/opensearch-project/opensearch-api-specification/pull/793))
+- Added `time` field to the `GetStats` schema in `_common.yml` ([#803](https://github.com/opensearch-project/opensearch-api-specification/pull/803))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -1714,6 +1714,7 @@ components:
           format: int64
         getTime:
           $ref: '#/components/schemas/Duration'
+          deprecated: true
         time:
           $ref: '#/components/schemas/Duration'
         time_in_millis:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -1715,8 +1715,10 @@ components:
         getTime:
           $ref: '#/components/schemas/Duration'
           deprecated: true
+          x-version-deprecated: '2.19'
         time:
           $ref: '#/components/schemas/Duration'
+          x-version-added: '2.19'
         time_in_millis:
           $ref: '#/components/schemas/DurationValueUnitMillis'
         exists_total:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -1714,6 +1714,8 @@ components:
           format: int64
         getTime:
           $ref: '#/components/schemas/Duration'
+        time:
+          $ref: '#/components/schemas/Duration'
         time_in_millis:
           $ref: '#/components/schemas/DurationValueUnitMillis'
         exists_total:


### PR DESCRIPTION
### Description
Added the `time` field to the `GetStats` schema in `_common.yml`.

### Issues Resolved
Related to opensearch-project/OpenSearch#16894

### Related PR
https://github.com/opensearch-project/OpenSearch/pull/17009

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
