### PR TITLE
Point CAT API descriptions to shared schema when applicable.

### DIFF
--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -1063,8 +1063,7 @@ components:
   parameters:
     cat.aliases::path.name:
       in: path
-      name: name
-      description: A comma-separated list of aliases to retrieve. Supports wildcards (`*`).  To retrieve all aliases, omit this parameter or use `*` or `_all`.
+      name: name 
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Names'
@@ -1072,7 +1071,6 @@ components:
     cat.aliases::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: Expands wildcard expressions to concrete indexes. Combine multiple values with commas. Supported values are `all`, `open`, `closed`, `hidden`, and `none`. 
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
@@ -1544,7 +1542,6 @@ components:
     cat.indices::query.expand_wildcards:
       in: query
       name: expand_wildcards
-      description: The type of index that wildcard patterns can match.  Supported values are `all`, `open`, `closed`, `hidden`, and `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
       style: form
@@ -2288,7 +2285,6 @@ components:
     cat.segment_replication::query.expand_wildcards:
       name: expand_wildcards
       in: query
-      description: The type of index that wildcard patterns can match. Supported values are `all`, `open`, `closed`, `hidden`, and `none`.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
     cat.segment_replication::query.format:
@@ -2470,10 +2466,6 @@ components:
     cat.shards::path.index:
       in: path
       name: index
-      description: |-
-        A comma-separated list of data streams, indexes, and aliases used to limit the request.
-        Supports wildcards (`*`).
-        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Indices'
@@ -2549,7 +2541,6 @@ components:
     cat.shards::query.time:
       name: time
       in: query
-      description: Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/TimeUnit'
     cat.shards::query.v:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -404,6 +404,10 @@ components:
         - type: string
         - $ref: '#/components/schemas/EpochTimeUnitMillis'
     Indices:
+      description: |-
+        A comma-separated list of data streams, indexes, and aliases used to limit the request.
+        Supports wildcards (`*`).
+        To target all data streams and indexes, omit this parameter or use `*` or `_all`.
       oneOf:
         - $ref: '#/components/schemas/IndexName'
         - type: array
@@ -806,6 +810,7 @@ components:
       required:
         - found
     Names:
+      description: A comma-separated list of aliases to retrieve. Supports wildcards (`*`).  To retrieve all aliases, omit this parameter or use `*` or `_all`.
       oneOf:
         - $ref: '#/components/schemas/Name'
         - type: array
@@ -888,6 +893,7 @@ components:
       description: Time of day, expressed as HH:MM:SS.
       type: string
     TimeUnit:
+      description: Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
       oneOf:
         - title: nanoseconds
           type: string


### PR DESCRIPTION
### Description

This PR removes descriptions for CAT APIs when the API can use the description from the shared common schema. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
