### PR TITLE
Async search editorial

### DIFF
--- a/spec/namespaces/asynchronous_search.yaml
+++ b/spec/namespaces/asynchronous_search.yaml
@@ -52,7 +52,7 @@ paths:
       operationId: asynchronous_search.stats.0
       x-operation-group: asynchronous_search.stats
       x-version-added: '1.0'
-      description: Monitors any asynchronous searches that are `running`, `completed`, `persisted`.
+      description: Monitors any asynchronous searches that are `running`, `completed`, or `persisted`.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/async/index/#monitor-stats
       responses:
@@ -64,13 +64,13 @@ components:
     asynchronous_search.search::query.wait_for_completion_timeout:
       name: wait_for_completion_timeout
       in: query
-      description: The amount of time that you plan to wait for the results. You can poll the remaining results based on an ID. The maximum value is 300 seconds. Default is `1s`.
+      description: The amount of time to wait for the results. You can poll the remaining results based on an ID. The maximum value is 300 seconds. Default is `1s`.
       schema:
         type: string
     asynchronous_search.search::query.keep_on_completion:
       name: keep_on_completion
       in: query
-      description: Whether you want to save the results in the cluster after the search is complete. You can examine the stored results at a later time.
+      description: Whether to save the results in the cluster after the search is complete. You can examine the stored results at a later time.
       schema:
         type: boolean
     asynchronous_search.search::query.keep_alive:
@@ -79,7 +79,7 @@ components:
       description: |- 
         The amount of time that the result is saved in the cluster. For example, `2d` means that the results are stored in the cluster for 48 hours. 
         The saved search results are deleted after this period or if the search is canceled. Note that this includes the query execution time. 
-        If the query overruns this time, the process cancels this query automatically.
+        If the query exceeds this amount of time, the process cancels this query automatically.
       schema:
         type: string
     asynchronous_search.search::query.index:


### PR DESCRIPTION
Adds comments from #781 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
