### PR TITLE
Add description for `level` parameter in cluster health.

### DIFF
--- a/spec/schemas/cluster.health.yaml
+++ b/spec/schemas/cluster.health.yaml
@@ -138,6 +138,7 @@ components:
         - status
         - unassigned_shards
     Level:
+      description: Controls the amount of detail included in the cluster health response.
       type: string
       enum:
         - awareness_attributes


### PR DESCRIPTION
This adds a description for the `level` parameter in the cluster health API. This helps it appear in the table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
