### PR TITLE
Fix typo in cluster level description

### DIFF
--- a/spec/namespaces/cluster.yaml
+++ b/spec/namespaces/cluster.yaml
@@ -1174,7 +1174,7 @@ components:
       name: name
       description: |-
         The name of the component template to create.
-        OpenSearch includes the following built-in component templates: `logs-mappings`; 'logs-settings`; `metrics-mappings`; `metrics-settings`;`synthetics-mapping`; `synthetics-settings`.
+        OpenSearch includes the following built-in component templates: `logs-mappings`; `logs-settings`; `metrics-mappings`; `metrics-settings`; `synthetics-mapping`; `synthetics-settings`.
         OpenSearch uses these templates to configure backing indexes for its data streams.
         If you want to overwrite one of these templates, set the replacement template `version` to a higher value than the current version.
         If you want to disable all built-in component and index templates, set `stack.templates.enabled` to `false` using the Cluster Update Settings API.


### PR DESCRIPTION
This PR fixes a typo in the description for the cluster level parameter that caused a formatting error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
