### PR TITLE
Support 'aggs' (aggregations) within bucket aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+- Added `aggs` alias for nested aggregations ([#818](https://github.com/opensearch-project/opensearch-api-specification/pull/818))
 - Added API specs for query groups lifecycle APIs ([#649](https://github.com/opensearch-project/opensearch-api-specification/pull/649))
 - Added Python and Ruby spec validators ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))
 - Added verbose output of the story being evaluated ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))

--- a/spec/schemas/_common.aggregations.yaml
+++ b/spec/schemas/_common.aggregations.yaml
@@ -1440,7 +1440,7 @@ components:
             - properties
             - type
     AggregationContainer:
-      allOf:
+      allOf: 
         - type: object
           properties:
             aggregations:
@@ -1450,152 +1450,367 @@ components:
               type: object
               additionalProperties:
                 $ref: '#/components/schemas/AggregationContainer'
+            aggs:
+              description: |-
+                Sub-aggregations for this aggregation.
+                Only applies to bucket aggregations.
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/AggregationContainer'
             meta:
               $ref: '_common.yaml#/components/schemas/Metadata'
         - type: object
-          properties:
-            adjacency_matrix:
-              $ref: '#/components/schemas/AdjacencyMatrixAggregation'
-            auto_date_histogram:
-              $ref: '#/components/schemas/AutoDateHistogramAggregation'
-            avg:
-              $ref: '#/components/schemas/AverageAggregation'
-            avg_bucket:
-              $ref: '#/components/schemas/AverageBucketAggregation'
-            boxplot:
-              $ref: '#/components/schemas/BoxplotAggregation'
-            bucket_script:
-              $ref: '#/components/schemas/BucketScriptAggregation'
-            bucket_selector:
-              $ref: '#/components/schemas/BucketSelectorAggregation'
-            bucket_sort:
-              $ref: '#/components/schemas/BucketSortAggregation'
-            cardinality:
-              $ref: '#/components/schemas/CardinalityAggregation'
-            children:
-              $ref: '#/components/schemas/ChildrenAggregation'
-            composite:
-              $ref: '#/components/schemas/CompositeAggregation'
-            cumulative_cardinality:
-              $ref: '#/components/schemas/CumulativeCardinalityAggregation'
-            cumulative_sum:
-              $ref: '#/components/schemas/CumulativeSumAggregation'
-            date_histogram:
-              $ref: '#/components/schemas/DateHistogramAggregation'
-            date_range:
-              $ref: '#/components/schemas/DateRangeAggregation'
-            derivative:
-              $ref: '#/components/schemas/DerivativeAggregation'
-            diversified_sampler:
-              $ref: '#/components/schemas/DiversifiedSamplerAggregation'
-            extended_stats:
-              $ref: '#/components/schemas/ExtendedStatsAggregation'
-            extended_stats_bucket:
-              $ref: '#/components/schemas/ExtendedStatsBucketAggregation'
-            filter:
-              $ref: '_common.query_dsl.yaml#/components/schemas/QueryContainer'
-            filters:
-              $ref: '#/components/schemas/FiltersAggregation'
-            geo_bounds:
-              $ref: '#/components/schemas/GeoBoundsAggregation'
-            geo_centroid:
-              $ref: '#/components/schemas/GeoCentroidAggregation'
-            geo_distance:
-              $ref: '#/components/schemas/GeoDistanceAggregation'
-            geohash_grid:
-              $ref: '#/components/schemas/GeoHashGridAggregation'
-            geo_line:
-              $ref: '#/components/schemas/GeoLineAggregation'
-            geotile_grid:
-              $ref: '#/components/schemas/GeoTileGridAggregation'
-            global:
-              $ref: '#/components/schemas/GlobalAggregation'
-            histogram:
-              $ref: '#/components/schemas/HistogramAggregation'
-            ip_range:
-              $ref: '#/components/schemas/IpRangeAggregation'
-            inference:
-              $ref: '#/components/schemas/InferenceAggregation'
-            line:
-              $ref: '#/components/schemas/GeoLineAggregation'
-            matrix_stats:
-              $ref: '#/components/schemas/MatrixStatsAggregation'
-            max:
-              $ref: '#/components/schemas/MaxAggregation'
-            max_bucket:
-              $ref: '#/components/schemas/MaxBucketAggregation'
-            median_absolute_deviation:
-              $ref: '#/components/schemas/MedianAbsoluteDeviationAggregation'
-            min:
-              $ref: '#/components/schemas/MinAggregation'
-            min_bucket:
-              $ref: '#/components/schemas/MinBucketAggregation'
-            missing:
-              $ref: '#/components/schemas/MissingAggregation'
-            moving_avg:
-              $ref: '#/components/schemas/MovingAverageAggregation'
-            moving_percentiles:
-              $ref: '#/components/schemas/MovingPercentilesAggregation'
-            moving_fn:
-              $ref: '#/components/schemas/MovingFunctionAggregation'
-            multi_terms:
-              $ref: '#/components/schemas/MultiTermsAggregation'
-            nested:
-              $ref: '#/components/schemas/NestedAggregation'
-            normalize:
-              $ref: '#/components/schemas/NormalizeAggregation'
-            parent:
-              $ref: '#/components/schemas/ParentAggregation'
-            percentile_ranks:
-              $ref: '#/components/schemas/PercentileRanksAggregation'
-            percentiles:
-              $ref: '#/components/schemas/PercentilesAggregation'
-            percentiles_bucket:
-              $ref: '#/components/schemas/PercentilesBucketAggregation'
-            range:
-              $ref: '#/components/schemas/RangeAggregation'
-            rare_terms:
-              $ref: '#/components/schemas/RareTermsAggregation'
-            rate:
-              $ref: '#/components/schemas/RateAggregation'
-            reverse_nested:
-              $ref: '#/components/schemas/ReverseNestedAggregation'
-            sampler:
-              $ref: '#/components/schemas/SamplerAggregation'
-            scripted_metric:
-              $ref: '#/components/schemas/ScriptedMetricAggregation'
-            serial_diff:
-              $ref: '#/components/schemas/SerialDifferencingAggregation'
-            significant_terms:
-              $ref: '#/components/schemas/SignificantTermsAggregation'
-            significant_text:
-              $ref: '#/components/schemas/SignificantTextAggregation'
-            stats:
-              $ref: '#/components/schemas/StatsAggregation'
-            stats_bucket:
-              $ref: '#/components/schemas/StatsBucketAggregation'
-            string_stats:
-              $ref: '#/components/schemas/StringStatsAggregation'
-            sum:
-              $ref: '#/components/schemas/SumAggregation'
-            sum_bucket:
-              $ref: '#/components/schemas/SumBucketAggregation'
-            terms:
-              $ref: '#/components/schemas/TermsAggregation'
-            top_hits:
-              $ref: '#/components/schemas/TopHitsAggregation'
-            t_test:
-              $ref: '#/components/schemas/TTestAggregation'
-            top_metrics:
-              $ref: '#/components/schemas/TopMetricsAggregation'
-            value_count:
-              $ref: '#/components/schemas/ValueCountAggregation'
-            weighted_avg:
-              $ref: '#/components/schemas/WeightedAverageAggregation'
-            variable_width_histogram:
-              $ref: '#/components/schemas/VariableWidthHistogramAggregation'
-          minProperties: 1
-          maxProperties: 1
+          oneOf: 
+            - properties: 
+                adjacency_matrix:
+                  $ref: '#/components/schemas/AdjacencyMatrixAggregation'
+              required: [adjacency_matrix]
+              unevaluatedProperties: true
+            - properties: 
+                auto_date_histogram:
+                  $ref: '#/components/schemas/AutoDateHistogramAggregation'
+              required: [auto_date_histogram]
+              unevaluatedProperties: true
+            - properties: 
+                avg:
+                  $ref: '#/components/schemas/AverageAggregation'
+              required: [avg]
+              unevaluatedProperties: true
+            - properties: 
+                avg_bucket:
+                  $ref: '#/components/schemas/AverageBucketAggregation'
+              required: [avg_bucket]
+              unevaluatedProperties: true
+            - properties: 
+                boxplot:
+                  $ref: '#/components/schemas/BoxplotAggregation'
+              required: [boxplot]
+              unevaluatedProperties: true
+            - properties: 
+                bucket_script:
+                  $ref: '#/components/schemas/BucketScriptAggregation'
+              required: [bucket_script]
+              unevaluatedProperties: true
+            - properties: 
+                bucket_selector:
+                  $ref: '#/components/schemas/BucketSelectorAggregation'
+              required: [bucket_selector]
+              unevaluatedProperties: true
+            - properties: 
+                bucket_sort:
+                  $ref: '#/components/schemas/BucketSortAggregation'
+              required: [bucket_sort]
+              unevaluatedProperties: true
+            - properties: 
+                cardinality:
+                  $ref: '#/components/schemas/CardinalityAggregation'
+              required: [cardinality]
+              unevaluatedProperties: true
+            - properties: 
+                children:
+                  $ref: '#/components/schemas/ChildrenAggregation'
+              required: [children]
+              unevaluatedProperties: true
+            - properties: 
+                composite:
+                  $ref: '#/components/schemas/CompositeAggregation'
+              required: [composite]
+              unevaluatedProperties: true
+            - properties: 
+                cumulative_cardinality:
+                  $ref: '#/components/schemas/CumulativeCardinalityAggregation'
+              required: [cumulative_cardinality]
+              unevaluatedProperties: true
+            - properties: 
+                cumulative_sum:
+                  $ref: '#/components/schemas/CumulativeSumAggregation'
+              required: [cumulative_sum]
+              unevaluatedProperties: true
+            - properties: 
+                date_histogram:
+                  $ref: '#/components/schemas/DateHistogramAggregation'
+              required: [date_histogram]
+              unevaluatedProperties: true
+            - properties: 
+                date_range:
+                  $ref: '#/components/schemas/DateRangeAggregation'
+              required: [date_range]
+              unevaluatedProperties: true
+            - properties: 
+                derivative:
+                  $ref: '#/components/schemas/DerivativeAggregation'
+              required: [derivative]
+              unevaluatedProperties: true
+            - properties: 
+                diversified_sampler:
+                  $ref: '#/components/schemas/DiversifiedSamplerAggregation'
+              required: [diversified_sampler]
+              unevaluatedProperties: true
+            - properties: 
+                extended_stats:
+                  $ref: '#/components/schemas/ExtendedStatsAggregation'
+              required: [extended_stats]
+              unevaluatedProperties: true
+            - properties: 
+                extended_stats_bucket:
+                  $ref: '#/components/schemas/ExtendedStatsBucketAggregation'
+              required: [extended_stats_bucket]
+              unevaluatedProperties: true
+            - properties: 
+                filter:
+                  $ref: '_common.query_dsl.yaml#/components/schemas/QueryContainer'
+              required: [filter]
+              unevaluatedProperties: true
+            - properties: 
+                filters:
+                  $ref: '#/components/schemas/FiltersAggregation'
+              required: [filters]
+              unevaluatedProperties: true
+            - properties: 
+                geo_bounds:
+                  $ref: '#/components/schemas/GeoBoundsAggregation'
+              required: [geo_bounds]
+              unevaluatedProperties: true
+            - properties: 
+                geo_centroid:
+                  $ref: '#/components/schemas/GeoCentroidAggregation'
+              required: [geo_centroid]
+              unevaluatedProperties: true
+            - properties: 
+                geo_distance:
+                  $ref: '#/components/schemas/GeoDistanceAggregation'
+              required: [geo_distance]
+              unevaluatedProperties: true
+            - properties: 
+                geohash_grid:
+                  $ref: '#/components/schemas/GeoHashGridAggregation'
+              required: [geohash_grid]
+              unevaluatedProperties: true
+            - properties: 
+                geo_line:
+                  $ref: '#/components/schemas/GeoLineAggregation'
+              required: [geo_line]
+              unevaluatedProperties: true
+            - properties: 
+                geotile_grid:
+                  $ref: '#/components/schemas/GeoTileGridAggregation'
+              required: [geotile_grid]
+              unevaluatedProperties: true
+            - properties: 
+                global:
+                  $ref: '#/components/schemas/GlobalAggregation'
+              required: [global]
+              unevaluatedProperties: true
+            - properties: 
+                histogram:
+                  $ref: '#/components/schemas/HistogramAggregation'
+              required: [histogram]
+              unevaluatedProperties: true
+            - properties: 
+                ip_range:
+                  $ref: '#/components/schemas/IpRangeAggregation'
+              required: [ip_range]
+              unevaluatedProperties: true
+            - properties: 
+                inference:
+                  $ref: '#/components/schemas/InferenceAggregation'
+              required: [inference]
+              unevaluatedProperties: true
+            - properties: 
+                line:
+                  $ref: '#/components/schemas/GeoLineAggregation'
+              required: [line]
+              unevaluatedProperties: true
+            - properties: 
+                matrix_stats:
+                  $ref: '#/components/schemas/MatrixStatsAggregation'
+              required: [matrix_stats]
+              unevaluatedProperties: true
+            - properties: 
+                max:
+                  $ref: '#/components/schemas/MaxAggregation'
+              required: [max]
+              unevaluatedProperties: true
+            - properties: 
+                max_bucket:
+                  $ref: '#/components/schemas/MaxBucketAggregation'
+              required: [max_bucket]
+              unevaluatedProperties: true
+            - properties: 
+                median_absolute_deviation:
+                  $ref: '#/components/schemas/MedianAbsoluteDeviationAggregation'
+              required: [median_absolute_deviation]
+              unevaluatedProperties: true
+            - properties: 
+                min:
+                  $ref: '#/components/schemas/MinAggregation'
+              required: [min]
+              unevaluatedProperties: true
+            - properties: 
+                min_bucket:
+                  $ref: '#/components/schemas/MinBucketAggregation'
+              required: [min_bucket]
+              unevaluatedProperties: true
+            - properties: 
+                missing:
+                  $ref: '#/components/schemas/MissingAggregation'
+              required: [missing]
+              unevaluatedProperties: true
+            - properties: 
+                moving_avg:
+                  $ref: '#/components/schemas/MovingAverageAggregation'
+              required: [moving_avg]
+              unevaluatedProperties: true
+            - properties: 
+                moving_percentiles:
+                  $ref: '#/components/schemas/MovingPercentilesAggregation'
+              required: [moving_percentiles]
+              unevaluatedProperties: true
+            - properties: 
+                moving_fn:
+                  $ref: '#/components/schemas/MovingFunctionAggregation'
+              required: [moving_fn]
+              unevaluatedProperties: true
+            - properties: 
+                multi_terms:
+                  $ref: '#/components/schemas/MultiTermsAggregation'
+              required: [multi_terms]
+              unevaluatedProperties: true
+            - properties: 
+                nested:
+                  $ref: '#/components/schemas/NestedAggregation'
+              required: [nested]
+              unevaluatedProperties: true
+            - properties: 
+                normalize:
+                  $ref: '#/components/schemas/NormalizeAggregation'
+              required: [normalize]
+              unevaluatedProperties: true
+            - properties: 
+                parent:
+                  $ref: '#/components/schemas/ParentAggregation'
+              required: [parent]
+              unevaluatedProperties: true
+            - properties: 
+                percentile_ranks:
+                  $ref: '#/components/schemas/PercentileRanksAggregation'
+              required: [percentile_ranks]
+              unevaluatedProperties: true
+            - properties: 
+                percentiles:
+                  $ref: '#/components/schemas/PercentilesAggregation'
+              required: [percentiles]
+              unevaluatedProperties: true
+            - properties: 
+                percentiles_bucket:
+                  $ref: '#/components/schemas/PercentilesBucketAggregation'
+              required: [percentiles_bucket]
+              unevaluatedProperties: true
+            - properties: 
+                range:
+                  $ref: '#/components/schemas/RangeAggregation'
+              required: [range]
+              unevaluatedProperties: true
+            - properties: 
+                rare_terms:
+                  $ref: '#/components/schemas/RareTermsAggregation'
+              required: [rare_terms]
+              unevaluatedProperties: true
+            - properties: 
+                rate:
+                  $ref: '#/components/schemas/RateAggregation'
+              required: [rate]
+              unevaluatedProperties: true
+            - properties: 
+                reverse_nested:
+                  $ref: '#/components/schemas/ReverseNestedAggregation'
+              required: [reverse_nested]
+              unevaluatedProperties: true
+            - properties: 
+                sampler:
+                  $ref: '#/components/schemas/SamplerAggregation'
+              required: [sampler]
+              unevaluatedProperties: true
+            - properties: 
+                scripted_metric:
+                  $ref: '#/components/schemas/ScriptedMetricAggregation'
+              required: [scripted_metric]
+              unevaluatedProperties: true
+            - properties: 
+                serial_diff:
+                  $ref: '#/components/schemas/SerialDifferencingAggregation'
+              required: [serial_diff]
+              unevaluatedProperties: true
+            - properties: 
+                significant_terms:
+                  $ref: '#/components/schemas/SignificantTermsAggregation'
+              required: [significant_terms]
+              unevaluatedProperties: true
+            - properties: 
+                significant_text:
+                  $ref: '#/components/schemas/SignificantTextAggregation'
+              required: [significant_text]
+              unevaluatedProperties: true
+            - properties: 
+                stats:
+                  $ref: '#/components/schemas/StatsAggregation'
+              required: [stats]
+              unevaluatedProperties: true
+            - properties: 
+                stats_bucket:
+                  $ref: '#/components/schemas/StatsBucketAggregation'
+              required: [stats_bucket]
+              unevaluatedProperties: true
+            - properties: 
+                string_stats:
+                  $ref: '#/components/schemas/StringStatsAggregation'
+              required: [string_stats]
+              unevaluatedProperties: true
+            - properties: 
+                sum:
+                  $ref: '#/components/schemas/SumAggregation'
+              required: [sum]
+              unevaluatedProperties: true
+            - properties: 
+                sum_bucket:
+                  $ref: '#/components/schemas/SumBucketAggregation'
+              required: [sum_bucket]
+              unevaluatedProperties: true
+            - properties: 
+                terms:
+                  $ref: '#/components/schemas/TermsAggregation'
+              required: [terms]
+              unevaluatedProperties: true
+            - properties: 
+                top_hits:
+                  $ref: '#/components/schemas/TopHitsAggregation'
+              required: [top_hits]
+              unevaluatedProperties: true
+            - properties: 
+                t_test:
+                  $ref: '#/components/schemas/TTestAggregation'
+              required: [t_test]
+              unevaluatedProperties: true
+            - properties: 
+                top_metrics:
+                  $ref: '#/components/schemas/TopMetricsAggregation'
+              required: [top_metrics]
+              unevaluatedProperties: true
+            - properties: 
+                value_count:
+                  $ref: '#/components/schemas/ValueCountAggregation'
+              required: [value_count]
+              unevaluatedProperties: true
+            - properties: 
+                weighted_avg:
+                  $ref: '#/components/schemas/WeightedAverageAggregation'
+              required: [weighted_avg]
+              unevaluatedProperties: true
+            - properties: 
+                variable_width_histogram:
+                  $ref: '#/components/schemas/VariableWidthHistogramAggregation'
+              required: [variable_width_histogram]
+              unevaluatedProperties: true     
     AdjacencyMatrixAggregation:
       allOf:
         - $ref: '#/components/schemas/BucketAggregationBase'

--- a/spec/schemas/_common.aggregations.yaml
+++ b/spec/schemas/_common.aggregations.yaml
@@ -779,6 +779,8 @@ components:
               type: number
           required:
             - doc_count
+          additionalProperties:
+            $ref: '#/components/schemas/Aggregate'
     NestedAggregate:
       allOf:
         - $ref: '#/components/schemas/AggregateBase'

--- a/tests/default/_core/search/aggregations/bucket.yaml
+++ b/tests/default/_core/search/aggregations/bucket.yaml
@@ -12,11 +12,11 @@ prologues:
       content_type: application/x-ndjson
       payload:
         - {create: {_index: movies}}
-        - {title: Pearl Harbour, directorId: 445212, cost: 2000, isCostHidden: true}
+        - {title: Pearl Harbour, director_id: 445212, cost: 2000, cost_hidden: true}
         - {create: {_index: movies}}
-        - {title: The Doctor, directorId: 445212, cost: 5000, isCostHidden: false}
+        - {title: The Doctor, director_id: 445212, cost: 5000, cost_hidden: false}
         - {create: {_index: movies}}
-        - {title: Home Sweet Home, directorId: 55123, cost: 36000, isCostHidden: true}
+        - {title: Home Sweet Home, director_id: 55123, cost: 36000, cost_hidden: true}
 chapters:
   - synopsis: Aggregate within bucket aggregation
     path: /{index}/_search
@@ -30,11 +30,11 @@ chapters:
           moviesWithHiddenCost:
             filter:
               term:
-                isCostHidden: true
+                cost_hidden: true
             aggs:
               numOfDirectors:
                 cardinality:
-                  field: directorId
+                  field: director_id
     response:
       status: 200
       payload:

--- a/tests/default/_core/search/aggregations/bucket.yaml
+++ b/tests/default/_core/search/aggregations/bucket.yaml
@@ -11,37 +11,37 @@ prologues:
     request:
       content_type: application/x-ndjson
       payload:
-        - { create: { _index: jobads } }
-        - { title: Nurse, hirerId: 445212, salaryType: monthly, salary: 2000, isSalaryHidden: true }
-        - { create: { _index: jobads } }
-        - { title: Doctor, hirerId: 445212, salaryType: monthly, salary: 5000, isSalaryHidden: false }
-        - { create: { _index: jobads } }
-        - { title: Engineer, hirerId: 55123, salaryType: annual, salary: 36000, isSalaryHidden: true }
+        - {create: {_index: movies}}
+        - {title: Pearl Harbour, directorId: 445212, cost: 2000, isCostHidden: true}
+        - {create: {_index: movies}}
+        - {title: The Doctor, directorId: 445212, cost: 5000, isCostHidden: false}
+        - {create: {_index: movies}}
+        - {title: Home Sweet Home, directorId: 55123, cost: 36000, isCostHidden: true}
 chapters:
   - synopsis: Aggregate within bucket aggregation
     path: /{index}/_search
     parameters:
-      index: jobads
+      index: movies
     method: POST
     request:
       payload:
         size: 0
         aggs:
-          jobAdsWithHiddenSalary:
+          moviesWithHiddenCost:
             filter:
               term:
-                isSalaryHidden: true
+                isCostHidden: true
             aggs:
-              numOfHirers:
+              numOfDirectors:
                 cardinality:
-                  field: hirerId
+                  field: directorId
     response:
       status: 200
       payload:
         aggregations:
-          jobAdsWithHiddenSalary:
+          moviesWithHiddenCost:
             doc_count: 2
-            numOfHirers:
+            numOfDirectors:
               value: 2
 epilogues:
   - path: /jobads

--- a/tests/default/_core/search/aggregations/bucket.yaml
+++ b/tests/default/_core/search/aggregations/bucket.yaml
@@ -1,0 +1,49 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test aggregation within bucket aggregation.
+warnings:
+  invalid-path-detected: false
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - { create: { _index: jobads } }
+        - { title: Nurse, hirerId: 445212, salaryType: monthly, salary: 2000, isSalaryHidden: true }
+        - { create: { _index: jobads } }
+        - { title: Doctor, hirerId: 445212, salaryType: monthly, salary: 5000, isSalaryHidden: false }
+        - { create: { _index: jobads } }
+        - { title: Engineer, hirerId: 55123, salaryType: annual, salary: 36000, isSalaryHidden: true }
+chapters:
+  - synopsis: Aggregate within bucket aggregation
+    path: /{index}/_search
+    parameters:
+      index: jobads
+    method: POST
+    request:
+      payload:
+        size: 0
+        aggs:
+          jobAdsWithHiddenSalary:
+            filter:
+              term:
+                isSalaryHidden: true
+            aggs:
+              numOfHirers:
+                cardinality:
+                  field: hirerId
+    response:
+      status: 200
+      payload:
+        aggregations:
+          jobAdsWithHiddenSalary:
+            doc_count: 2
+            numOfHirers:
+              value: 2
+epilogues:
+  - path: /jobads
+    method: DELETE
+    status: [200, 404]

--- a/tests/default/_core/search/aggregations/bucket.yaml
+++ b/tests/default/_core/search/aggregations/bucket.yaml
@@ -18,7 +18,7 @@ prologues:
         - {create: {_index: movies}}
         - {title: Home Sweet Home, director_id: 55123, cost: 36000, cost_hidden: true}
 chapters:
-  - synopsis: Aggregate within bucket aggregation
+  - synopsis: Aggregate within bucket aggregation.
     path: /{index}/_search
     parameters:
       index: movies

--- a/tests/default/_core/search/aggregations/bucket.yaml
+++ b/tests/default/_core/search/aggregations/bucket.yaml
@@ -44,6 +44,6 @@ chapters:
             numOfDirectors:
               value: 2
 epilogues:
-  - path: /jobads
+  - path: /movies
     method: DELETE
     status: [200, 404]


### PR DESCRIPTION
### Description

Adds an alias `aggs` similar to https://github.com/opensearch-project/opensearch-js/issues/956 within `aggregations/aggs` itself. 

Also added support so the response can recognise aggregations within bucket aggregations like so

```
aggregations:
  jobAdsWithHiddenSalary:
    doc_count: 2
    numOfHirers:
      value: 2
```

### Issues Resolved

https://github.com/opensearch-project/opensearch-js/issues/977

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
