### PR TITLE
Add target_index_settings to rollup specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `time_in_execution` and `time_in_execution_millis` to `PendingTask` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))
 - Added `phase_results_processor` to `NodeInfoSearchPipelines` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))
 - Added new neural search stats and response filtering parameters (`include_individual_nodes`, `include_all_nodes`, `include_info`) to neural stats API ([#921](https://github.com/opensearch-project/opensearch-api-specification/pull/921))
+- Added `target_index_settings` to `Index Rollups API` from `index-management` plugin ([#822](https://github.com/opensearch-project/opensearch-api-specification/pull/822))
 
 ### Removed
 

--- a/spec/schemas/rollups._common.yaml
+++ b/spec/schemas/rollups._common.yaml
@@ -53,6 +53,8 @@ components:
         target_index:
           type: string
           description: The target index where rollup results are stored.
+        target_index_settings:
+          $ref: 'indices._common.yaml#/components/schemas/IndexSettings'
         metadata_id:
           type: ['null', string]
           description: The metadata ID associated with the rollup job.

--- a/spec/schemas/rollups._common.yaml
+++ b/spec/schemas/rollups._common.yaml
@@ -54,6 +54,7 @@ components:
           type: string
           description: The target index where rollup results are stored.
         target_index_settings:
+          x-version-added: 3.0.0
           $ref: 'indices._common.yaml#/components/schemas/IndexSettings'
         metadata_id:
           type: ['null', string]

--- a/tests/default/rollup/jobs.yaml
+++ b/tests/default/rollup/jobs.yaml
@@ -117,7 +117,7 @@ chapters:
             index:
               number_of_shards: '2'
               number_of_replicas: '0'
-              codec: 'zlib'
+              codec: zlib
   - synopsis: Get an index rollup job with target_index_settings.
     version: '>= 3.0'
     path: /_plugins/_rollup/jobs/{id}
@@ -134,7 +134,7 @@ chapters:
             index:
               number_of_shards: '2'
               number_of_replicas: '0'
-              codec: 'zlib'
+              codec: zlib
   - synopsis: Delete an index rollup job.
     path: /_plugins/_rollup/jobs/{id}
     method: DELETE

--- a/tests/default/rollup/jobs.yaml
+++ b/tests/default/rollup/jobs.yaml
@@ -34,6 +34,55 @@ chapters:
           enabled: true
           description: Rollup books.
           schedule:
+            interval:
+              period: 1
+              unit: Minutes
+          source_index: books
+          target_index: books_by_order_date
+          page_size: 1
+          delay: 0
+          continuous: false
+          dimensions:
+            - date_histogram:
+                source_field: order_date
+                fixed_interval: 1h
+            - terms:
+                source_field: title
+          metrics:
+            - source_field: pages
+              metrics:
+                - sum: {}
+                - avg: {}
+    response:
+      status: 201
+      payload:
+        _id: books
+        rollup:
+          rollup_id: books
+          enabled: true
+  - synopsis: Get an index rollup job.
+    path: /_plugins/_rollup/jobs/{id}
+    method: GET
+    parameters:
+      id: books
+    response:
+      status: 200
+      payload:
+        _id: books
+        rollup:
+          rollup_id: books
+  - synopsis: Create an index rollup job with target_index_settings.
+    version: '>= 3.0'
+    path: /_plugins/_rollup/jobs/{id}
+    method: PUT
+    parameters:
+      id: books
+    request:
+      payload:
+        rollup:
+          enabled: true
+          description: Rollup books.
+          schedule:
             interval: 
               period: 1
               unit: Minutes
@@ -69,7 +118,8 @@ chapters:
               number_of_shards: '2'
               number_of_replicas: '0'
               codec: 'zlib'
-  - synopsis: Get an index rollup job.
+  - synopsis: Get an index rollup job with target_index_settings.
+    version: '>= 3.0'
     path: /_plugins/_rollup/jobs/{id}
     method: GET
     parameters:

--- a/tests/default/rollup/jobs.yaml
+++ b/tests/default/rollup/jobs.yaml
@@ -39,6 +39,10 @@ chapters:
               unit: Minutes
           source_index: books
           target_index: books_by_order_date
+          target_index_settings:
+            index.number_of_shards: 2
+            index.number_of_replicas: 0
+            index.codec: zlib
           page_size: 1
           delay: 0
           continuous: false
@@ -60,6 +64,11 @@ chapters:
         rollup:
           rollup_id: books
           enabled: true
+          target_index_settings:
+            index:
+              number_of_shards: '2'
+              number_of_replicas: '0'
+              codec: 'zlib'
   - synopsis: Get an index rollup job.
     path: /_plugins/_rollup/jobs/{id}
     method: GET
@@ -71,6 +80,11 @@ chapters:
         _id: books
         rollup:
           rollup_id: books
+          target_index_settings:
+            index:
+              number_of_shards: '2'
+              number_of_replicas: '0'
+              codec: 'zlib'
   - synopsis: Delete an index rollup job.
     path: /_plugins/_rollup/jobs/{id}
     method: DELETE

--- a/tests/default/rollup/jobs.yaml
+++ b/tests/default/rollup/jobs.yaml
@@ -71,12 +71,17 @@ chapters:
         _id: books
         rollup:
           rollup_id: books
+  - synopsis: Delete an index rollup job.
+    path: /_plugins/_rollup/jobs/{id}
+    method: DELETE
+    parameters:
+      id: books
   - synopsis: Create an index rollup job with target_index_settings.
     version: '>= 3.0'
     path: /_plugins/_rollup/jobs/{id}
     method: PUT
     parameters:
-      id: books
+      id: books_with_settings
     request:
       payload:
         rollup:
@@ -109,9 +114,9 @@ chapters:
     response:
       status: 201
       payload:
-        _id: books
+        _id: books_with_settings
         rollup:
-          rollup_id: books
+          rollup_id: books_with_settings
           enabled: true
           target_index_settings:
             index:
@@ -123,20 +128,21 @@ chapters:
     path: /_plugins/_rollup/jobs/{id}
     method: GET
     parameters:
-      id: books
+      id: books_with_settings
     response:
       status: 200
       payload:
-        _id: books
+        _id: books_with_settings
         rollup:
-          rollup_id: books
+          rollup_id: books_with_settings
           target_index_settings:
             index:
               number_of_shards: '2'
               number_of_replicas: '0'
               codec: zlib
-  - synopsis: Delete an index rollup job.
+  - synopsis: Delete an index rollup job with target_index_settings.
+    version: '>= 3.0'
     path: /_plugins/_rollup/jobs/{id}
     method: DELETE
     parameters:
-      id: books
+      id: books_with_settings


### PR DESCRIPTION
### Description
Allow to create index with specified settings during rollup

### Issues Resolved
https://github.com/opensearch-project/index-management/issues/1376

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
