### PR TITLE
Remove empty spaces in links when producing text masks for vale.

### DIFF
--- a/tools/src/prepare-for-vale/KeepDescriptions.ts
+++ b/tools/src/prepare-for-vale/KeepDescriptions.ts
@@ -24,7 +24,6 @@ export default class KeepDescriptions {
   }
 
   process(): void {
-    this.root_folder
     const files = fg.globSync([`${this.root_folder}/**/*.{yaml,yml}`], { dot: true })
     files.forEach((path) => {
       this.logger.log(path)
@@ -38,14 +37,14 @@ export default class KeepDescriptions {
 
     var inside_text = false
     contents.split(/\r?\n/).forEach((line) => {
-      if (line.match(/^[\s]+((description|x-deprecation-message): \|)/)) {
+      if (line.match(/^\s+((description|x-deprecation-message): \|)/)) {
         inside_text = true
-      } else if (line.match(/^[\s]+((description|x-deprecation-message):)[\s]+/)) {
+      } else if (line.match(/^\s+((description|x-deprecation-message):)[\s]+/)) {
         let cleaned_line = this.prune(line, /(description|x-deprecation-message):/, ' ')
         cleaned_line = this.prune_vars(cleaned_line)
         cleaned_line = this.remove_links(cleaned_line)
         fs.writeSync(writer, cleaned_line)
-      } else if (inside_text && line.match(/^[\s]*[\w\\$]*:/)) {
+      } else if (inside_text && line.match(/^\s*[\w\\$]*:/)) {
         inside_text = false
       } else if (inside_text) {
         let cleaned_line = this.remove_links(line)
@@ -59,7 +58,7 @@ export default class KeepDescriptions {
   }
 
   prune_vars(line: string): string {
-    return this.prune(line, /([`])(?:(?=(\\?))\2.)*?\1/g, '*')
+    return this.prune(line, /(`)(?:(?=(\\?))\2.)*?\1/g, '*')
   }
 
   prune(line: string, regex: RegExp, char: string): string {
@@ -69,9 +68,6 @@ export default class KeepDescriptions {
   }
 
   remove_links(line: string): string {
-    return line.replace(/\[([^\]]+)\]\([^)]+\)/g, (match, p1) => {
-      const spaces = ' '.repeat(match.length - p1.length - 1)
-      return ' ' + p1 + spaces
-    })
+    return line.replace(/\[([^\]]+)]\([^)]+\)/g, '$1')
   }
 }

--- a/tools/tests/prepare-for-vale/fixtures/spec.txt
+++ b/tools/tests/prepare-for-vale/fixtures/spec.txt
@@ -9,15 +9,15 @@
 
 
 
-                       For a successful response, this value is always true. On failure, an exception is returned instead  Supported units                                                          .
+                       For a successful response, this value is always true. On failure, an exception is returned instead Supported units.
 
 
 
-        The item level REST category class codes during indexing  link with a title                                 .
+        The item level REST category class codes during indexing link with a title.
 
 
 
-        Here is  link one                          and  link two                          .
+        Here is link one and link two.
         Line two
 
 


### PR DESCRIPTION
The extra space characters are causing Vale to [fail](https://github.com/opensearch-project/opensearch-api-specification/actions/runs/13550673566/job/37873283914?pr=824). This change makes the text masks for links appear like how the links are displayed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
