### PR TITLE
Remove unnecessary allOf 

### DIFF
--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -186,8 +186,7 @@ components:
         - x
         - y
     EpochTimeUnitMillis:
-      allOf:
-        - $ref: '#/components/schemas/UnitMillis'
+      $ref: '#/components/schemas/UnitMillis'
     UnitMillis:
       description: The time unit for milliseconds.
       type: integer
@@ -309,8 +308,7 @@ components:
         - skipped
         - successful
     DurationValueUnitMillis:
-      allOf:
-        - $ref: '#/components/schemas/UnitMillis'
+      $ref: '#/components/schemas/UnitMillis'
     ShardStatistics:
       type: object
       properties:
@@ -376,15 +374,13 @@ components:
         title: metadata
         description: Any additional information about the error.
     DurationValueUnitNanos:
-      allOf:
-        - $ref: '#/components/schemas/UnitNanos'
+      $ref: '#/components/schemas/UnitNanos'
     UnitNanos:
       description: Time unit for nanoseconds.
       type: integer
       format: int64
     DurationValueUnitMicros:
-      allOf:
-        - $ref: '#/components/schemas/UnitMicros'
+      $ref: '#/components/schemas/UnitMicros'
     UnitMicros:
       description: Time unit for microseconds.
       type: integer
@@ -889,8 +885,7 @@ components:
         - $ref: '#/components/schemas/EpochTimeUnitSeconds'
         - type: string
     EpochTimeUnitSeconds:
-      allOf:
-        - $ref: '#/components/schemas/UnitSeconds'
+      $ref: '#/components/schemas/UnitSeconds'
     UnitSeconds:
       description: Time unit for seconds.
       type: integer


### PR DESCRIPTION
### Description
From [OpenAPI 3.1.0](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md), allOf subschema should be valid object rather than primitive type. 
`allOf takes an array of object definitions that are validated independently but together compose a single object.
`
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
