### PR TITLE
Fixed REST status codes for RBAC and provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed Aggregation schemas ([#801](https://github.com/opensearch-project/opensearch-api-specification/pull/801))
 - Fixed FilterQueryRequestProcessor to use correct query type ([#821](https://github.com/opensearch-project/opensearch-api-specification/pull/821))
 - Fixed `knn.train_model`'s request body `method` field to accept an object rather than a string ([#814](https://github.com/opensearch-project/opensearch-api-specification/pull/814))
+- Fixed REST status codes for RBAC and provisioning for Flow Framework plugin
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed Aggregation schemas ([#801](https://github.com/opensearch-project/opensearch-api-specification/pull/801))
 - Fixed FilterQueryRequestProcessor to use correct query type ([#821](https://github.com/opensearch-project/opensearch-api-specification/pull/821))
 - Fixed `knn.train_model`'s request body `method` field to accept an object rather than a string ([#814](https://github.com/opensearch-project/opensearch-api-specification/pull/814))
-- Fixed REST status codes for RBAC and provisioning for Flow Framework plugin
+- Fixed REST status codes for RBAC and provisioning for Flow Framework plugin ([#842](https://github.com/opensearch-project/opensearch-api-specification/pull/842))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/json_schemas/test_story.schema.yaml
+++ b/json_schemas/test_story.schema.yaml
@@ -192,12 +192,12 @@ definitions:
       status:
         oneOf:
           - type: integer
-            description: The expected HTTP status code.
+            description: The expected HTTP status code. Default to 200.
+            default: 200
           - type: array
-            description: List of acceptable HTTP status codes.
             items:
               type: integer
-            minItems: 1
+            description: Array of success HTTP status codes.
       content_type:
         type: string
         default: application/json

--- a/json_schemas/test_story.schema.yaml
+++ b/json_schemas/test_story.schema.yaml
@@ -190,15 +190,21 @@ definitions:
     type: object
     properties:
       status:
-        type: integer
-        description: The expected HTTP status code. Default to 200.
-        default: 200
+        oneOf:
+          - type: integer
+            description: The expected HTTP status code.
+          - type: array
+            description: List of acceptable HTTP status codes.
+            items:
+              type: integer
+            minItems: 1
       content_type:
         type: string
         default: application/json
       payload:
         $ref: '#/definitions/Payload'
-    required: [status]
+    required:
+      - status
     additionalProperties: false
 
   ActualResponse:

--- a/tests/default/flow_framework/workflow/provision.yaml
+++ b/tests/default/flow_framework/workflow/provision.yaml
@@ -32,4 +32,4 @@ chapters:
       payload:
         openai_key: '1234556'
     response:
-      status: 202
+      status: [200, 202]

--- a/tests/default/flow_framework/workflow/provision.yaml
+++ b/tests/default/flow_framework/workflow/provision.yaml
@@ -33,3 +33,4 @@ chapters:
         openai_key: '1234556'
     response:
       status: [200, 202]
+      content_type: application/json

--- a/tests/default/flow_framework/workflow/provision.yaml
+++ b/tests/default/flow_framework/workflow/provision.yaml
@@ -32,4 +32,4 @@ chapters:
       payload:
         openai_key: '1234556'
     response:
-      status: 200
+      status: 202

--- a/tests/default/flow_framework/workflow/template.yaml
+++ b/tests/default/flow_framework/workflow/template.yaml
@@ -135,7 +135,7 @@ chapters:
     parameters:
       workflow_id: ${workflow.workflow_id}
     response:
-      status: 200
+      status: 202
   - synopsis: Update workflow fail with `provision` and `update_fields` set to `true`.
     path: /_plugins/_flow_framework/workflow/{workflow_id}
     method: PUT

--- a/tests/default/flow_framework/workflow/template.yaml
+++ b/tests/default/flow_framework/workflow/template.yaml
@@ -136,6 +136,7 @@ chapters:
       workflow_id: ${workflow.workflow_id}
     response:
       status: [200, 202]
+      content_type: application/json
   - synopsis: Update workflow fail with `provision` and `update_fields` set to `true`.
     path: /_plugins/_flow_framework/workflow/{workflow_id}
     method: PUT

--- a/tests/default/flow_framework/workflow/template.yaml
+++ b/tests/default/flow_framework/workflow/template.yaml
@@ -135,7 +135,7 @@ chapters:
     parameters:
       workflow_id: ${workflow.workflow_id}
     response:
-      status: 202
+      status: [200, 202]
   - synopsis: Update workflow fail with `provision` and `update_fields` set to `true`.
     path: /_plugins/_flow_framework/workflow/{workflow_id}
     method: PUT

--- a/tools/src/tester/ChapterEvaluator.ts
+++ b/tools/src/tester/ChapterEvaluator.ts
@@ -132,14 +132,19 @@ export default class ChapterEvaluator {
 
   #evaluate_status(chapter: ParsedChapter, response: ActualResponse): Evaluation {
     const expected_status = chapter.response?.status ?? 200
-    if (response.status === expected_status && response.error === undefined) return { result: Result.PASSED }
+
+    const is_status_match = Array.isArray(expected_status)
+      ? expected_status.includes(response.status)
+      : response.status === expected_status
+
+    if (is_status_match && response.error === undefined) return { result: Result.PASSED }
 
     let result: Evaluation = {
       result: Result.ERROR,
       message: _.join(_.compact([
-        expected_status == response.status ?
+        is_status_match ?
           `Received ${response.status ?? 'none'}: ${response.content_type ?? 'unknown'}.` :
-          `Expected status ${expected_status}, but received ${response.status ?? 'none'}: ${response.content_type ?? 'unknown'}.`,
+          `Expected status ${Array.isArray(expected_status) ? expected_status.join(' or ') : expected_status}, but received ${response.status ?? 'none'}: ${response.content_type ?? 'unknown'}.`,
         response.message
       ]), ' ')
     }

--- a/tools/src/tester/types/story.types.ts
+++ b/tools/src/tester/types/story.types.ts
@@ -186,10 +186,7 @@ export interface Retry {
  * via the `definition` "ExpectedResponse".
  */
 export interface ExpectedResponse {
-  /**
-   * The expected HTTP status code. Default to 200.
-   */
-  status: number;
+  status: number | number[];
   content_type?: string;
   payload?: Payload;
 }

--- a/tools/tests/tester/ChapterEvaluator.test.ts
+++ b/tools/tests/tester/ChapterEvaluator.test.ts
@@ -73,6 +73,37 @@ describe('ChapterEvaluator', () => {
       )
     })
 
+    test('a successful response for array of status codes', async () => {
+      mock.onAny().reply(200, '{"acknowledged":true}', { "content-type": "application/json" })
+
+      expect(
+        await chapter_evaluator.evaluate({
+          synopsis: 'Perform a PUT /{index} with multiple possible status codes.',
+          path: '/{index}',
+          method: 'PUT',
+          parameters: {
+            index: 'test'
+          },
+          request: {
+            payload: {}
+          },
+          response: {
+            status: [200, 202]  // Expecting either 200 or 202
+          }
+        }, false, story_outputs)).toEqual(
+        {
+          title: 'Perform a PUT /{index} with multiple possible status codes.',
+          path: 'PUT /{index}',
+          operation: { method: 'PUT', path: '/{index}' },
+          request: { parameters: { index: { result: 'PASSED' } }, request: { result: 'PASSED' } },
+          response: { output_values: { result: 'SKIPPED' }, payload_body: { result: 'PASSED' }, payload_schema: { result: 'PASSED' }, status: { result: 'PASSED' } },
+          overall: {
+            result: Result.PASSED
+          }
+        }
+      )
+    })
+
     test('retries', async () => {
       var count = 0
 


### PR DESCRIPTION
### Description
Depends on https://github.com/opensearch-project/flow-framework/pull/1083
- Added support for an array of status codes
- Fixed REST status codes for RBAC and provisioning

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
