### PR TITLE
Fix Bulk API schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed `knn.train_model`'s request body `method` field to accept an object rather than a string ([#814](https://github.com/opensearch-project/opensearch-api-specification/pull/814))
 - Fixed REST status codes for RBAC and provisioning for Flow Framework plugin ([#842](https://github.com/opensearch-project/opensearch-api-specification/pull/842), [#852](https://github.com/opensearch-project/opensearch-api-specification/pull/852))
 - Fixed swapped schema references in nodes info API buffer fields ([#808](https://github.com/opensearch-project/opensearch-api-specification/pull/808))
+- Fixed Bulk API schemas ([#843](https://github.com/opensearch-project/opensearch-api-specification/pull/843))
 
 ### Changed
 - Changed `tasks._common:TaskInfo` and `tasks._common:TaskGroup` to be composed of a `tasks._common:TaskInfoBase` ([#683](https://github.com/opensearch-project/opensearch-api-specification/pull/683))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -3412,7 +3412,7 @@ components:
       name: routing
       description: Custom value used to route operations to a specific shard.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/RoutingInQueryString'
+        $ref: '../schemas/_common.yaml#/components/schemas/Routing'
       style: form
     bulk::query.timeout:
       in: query

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -969,6 +969,9 @@ components:
           type: object
           description: The source of the document.
           additionalProperties: true
+      additionalProperties: 
+        type: object 
+        title: metadata_fields 
       required:
         - found
     Names:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -938,10 +938,13 @@ components:
         - type: string
           const: all
           description: Wait for all shards to be active.
+        - type: string
+          not: 
+            type: string
+            const: all
+          description: A numeric value greater than or equal to 0
         - type: 'null'
           description: null represents the default value (which defaults to one shard copy).
-        - $ref: '#/components/schemas/uint'
-          description: A numeric value greater than or equal to 0
     InlineGetDictUserDefined:
       type: object
       description: The inline get operation results for user-defined dictionaries.

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -549,18 +549,9 @@ components:
               required:
                 - source
     ScriptLanguage:
-      oneOf:
-        - title: builtin
-          $ref: '#/components/schemas/BuiltinScriptLanguage'
-        - title: custom
-          type: string
-    BuiltinScriptLanguage:
       type: string
-      enum:
-        - expression
-        - java
-        - mustache
-        - painless
+      description: |-
+        Built in scripts include: 'expression', 'java', 'mustache', and 'painless', but custom script languages can be provided as well.
     ScriptBase:
       type: object
       properties:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -362,6 +362,25 @@ components:
         - failed
         - successful
         - total
+    ShardInfo:
+      type: object
+      properties:
+        failed:
+          $ref: '#/components/schemas/uint'
+        successful:
+          $ref: '#/components/schemas/uint'
+        total:
+          $ref: '#/components/schemas/uint'
+        failures:
+          type: array
+          items:
+            $ref: '#/components/schemas/ShardFailure'
+        primary:
+          $ref: '#/components/schemas/uint'
+      required:
+        - failed
+        - successful
+        - total
     uint:
       type: integer
     ShardFailure:
@@ -402,6 +421,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ErrorCause'
+        headers:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/StringOrStringArray'
       required:
         - type
       additionalProperties:
@@ -526,7 +549,7 @@ components:
               required:
                 - source
     ScriptLanguage:
-      anyOf:
+      oneOf:
         - title: builtin
           $ref: '#/components/schemas/BuiltinScriptLanguage'
         - title: custom
@@ -919,9 +942,10 @@ components:
         - type: string
           const: all
           description: Wait for all shards to be active.
-        - type: string
-          const: index-setting
-          description: Wait for the number of shards specified in the index settings.
+        - type: 'null'
+          description: null represents the default value (which defaults to one shard copy).
+        - $ref: '#/components/schemas/uint'
+          description: A numeric value greater than or equal to 0
     InlineGetDictUserDefined:
       type: object
       description: The inline get operation results for user-defined dictionaries.
@@ -946,6 +970,9 @@ components:
           type: object
           description: The source of the document.
           additionalProperties: true
+      additionalProperties: 
+        title: metadata_fields
+        description: Any additional information about the document.
       required:
         - found
     Names:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -375,8 +375,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ShardFailure'
-        primary:
-          $ref: '#/components/schemas/uint'
       required:
         - failed
         - successful
@@ -421,10 +419,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ErrorCause'
-        headers:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/StringOrStringArray'
       required:
         - type
       additionalProperties:
@@ -549,9 +543,20 @@ components:
               required:
                 - source
     ScriptLanguage:
+      oneOf:
+        - title: builtin
+          $ref: '#/components/schemas/BuiltinScriptLanguage'
+        - title: custom
+          type: string
+          not:
+            $ref: '#/components/schemas/BuiltinScriptLanguage'
+    BuiltinScriptLanguage:
       type: string
-      description: |-
-        Built in scripts include: 'expression', 'java', 'mustache', and 'painless', but custom script languages can be provided as well.
+      enum:
+        - expression
+        - java
+        - mustache
+        - painless
     ScriptBase:
       type: object
       properties:
@@ -961,9 +966,6 @@ components:
           type: object
           description: The source of the document.
           additionalProperties: true
-      additionalProperties: 
-        title: metadata_fields
-        description: Any additional information about the document.
       required:
         - found
     Names:

--- a/spec/schemas/_core.bulk.yaml
+++ b/spec/schemas/_core.bulk.yaml
@@ -20,20 +20,26 @@ components:
       minProperties: 1
       maxProperties: 1
     IndexOperation:
-      $ref: '#/components/schemas/WriteOperation'
+      allOf:
+        - $ref: '#/components/schemas/WriteOperation'
+        - type: object
+          properties:
+            if_primary_term:
+              type: integer
+              format: int64
+            if_seq_no:
+              $ref: '_common.yaml#/components/schemas/SequenceNumber'
+            op_type:
+              $ref: '_common.yaml#/components/schemas/OpType'
+            version:
+              $ref: '_common.yaml#/components/schemas/VersionNumber'
+            version_type:
+              $ref: '_common.yaml#/components/schemas/VersionType'
     WriteOperation:
       allOf:
         - $ref: '#/components/schemas/OperationBase'
         - type: object
           properties:
-            dynamic_templates:
-              description: |-
-                A map from the full name of fields to the name of dynamic templates.
-                If a name matches a dynamic template, then that template will be applied regardless of other match predicates defined in the template.
-                If a field is already defined in the mapping, then this parameter won't be used.
-              type: object
-              additionalProperties:
-                type: string
             pipeline:
               description: |-
                 The pipeline ID for preprocessing documents.
@@ -52,15 +58,6 @@ components:
           $ref: '_common.yaml#/components/schemas/IndexName'
         routing:
           $ref: '_common.yaml#/components/schemas/Routing'
-        if_primary_term:
-          type: integer
-          format: int64
-        if_seq_no:
-          $ref: '_common.yaml#/components/schemas/SequenceNumber'
-        version:
-          $ref: '_common.yaml#/components/schemas/VersionNumber'
-        version_type:
-          $ref: '_common.yaml#/components/schemas/VersionType'
     CreateOperation:
       $ref: '#/components/schemas/WriteOperation'
     UpdateOperation:
@@ -68,6 +65,11 @@ components:
         - $ref: '#/components/schemas/OperationBase'
         - type: object
           properties:
+            if_primary_term:
+              type: integer
+              format: int64
+            if_seq_no:
+              $ref: '_common.yaml#/components/schemas/SequenceNumber'
             require_alias:
               description: When `true`, the request's actions must target an index alias.
               type: boolean
@@ -75,7 +77,19 @@ components:
               type: integer
               format: int32
     DeleteOperation:
-      $ref: '#/components/schemas/OperationBase'
+      allOf:
+        - $ref: '#/components/schemas/OperationBase'
+        - type: object
+          properties:
+            if_primary_term:
+              type: integer
+              format: int64
+            if_seq_no:
+              $ref: '_common.yaml#/components/schemas/SequenceNumber'
+            version:
+              $ref: '_common.yaml#/components/schemas/VersionNumber'
+            version_type:
+              $ref: '_common.yaml#/components/schemas/VersionType'
     UpdateAction:
       type: object
       properties:
@@ -135,7 +149,7 @@ components:
         _seq_no:
           $ref: '_common.yaml#/components/schemas/SequenceNumber'
         _shards:
-          $ref: '_common.yaml#/components/schemas/ShardStatistics'
+          $ref: '_common.yaml#/components/schemas/ShardInfo'
         _version:
           $ref: '_common.yaml#/components/schemas/VersionNumber'
         forced_refresh:


### PR DESCRIPTION
### Description
While working on [GRPC Bulk endpoint](https://github.com/opensearch-project/OpenSearch/pull/17727), discovered a few discrepancies in the Bulk protos with the source code

1. WaitForActiveShardOptions does not support `index-settings`. It is `all`, `null`, or an integer greater than 0 according to [ActiveShardCount#parseString](https://github.com/opensearch-project/OpenSearch/blob/1937f5f06271cd70522c4d7391140b01070a16db/server/src/main/java/org/opensearch/action/support/ActiveShardCount.java#L117-L138).
2. [routing](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/bulk/BulkRequest.java#L403) field is a String, not array of String
3. [CreateOperation](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/index/IndexRequest.java#L201-L222) does not support version_type, and versioning-related fields. makes sense as CreateOperation is for creating a document for the very first time.
4. [UpdateOperation](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/update/UpdateRequest.java#L544-L551) does not support version_types and will always use VersionType.INTERNAL
5. `dynamic_templates` is not supported for IndexOperation and CreateOperation 
6. Spec is missing [ShardInfo](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/support/replication/ReplicationResponse.java#L96) type to be used in the BulkResponse. The existing ShardStatistics struct is only used for Search responses. 
7. Missing [metaFields](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/get/GetResult.java#L300-L307) in InlineGetDictUserDefined field. 
8. ErrorCause should have an additional field called  [header](https://github.com/opensearch-project/OpenSearch/blob/1937f5f06271cd70522c4d7391140b01070a16db/libs/core/src/main/java/org/opensearch/OpenSearchException.java#L421), which is a `Map<String, List<String> | String>`  
9. ScriptLanguage should be a oneOf not anyOf.

### Issues Resolved
General spec fixes, contributing to accuracy of the Bulk Protobufs:
https://github.com/opensearch-project/OpenSearch/issues/16784
https://github.com/opensearch-project/opensearch-protobufs/issues/28

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
