### PR TITLE
[Part 2] Add common schema API descriptions

### DIFF
--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -947,7 +947,7 @@ components:
           $ref: '#/components/schemas/Routing'
         _source:
           type: object
-          escription: The source of the document.
+          description: The source of the document.
           additionalProperties: true
       required:
         - found

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -1225,10 +1225,10 @@ components:
       oneOf:
         - type: string
           const: df
-          description: The document frequency lambda.
+          description: The document frequency Lambda.
         - type: string
           const: ttf
-          description: The total term frequency lambda.
+          description: The total term frequency Lambda.
     byte:
       type: number
       description: The byte value.

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -1102,6 +1102,7 @@ components:
             $ref: '#/components/schemas/ScrollId'
     TransportAddress:
       type: string
+      description: The transport address of a node.
     StringOrStringArray:
       oneOf:
         - type: string
@@ -1151,51 +1152,92 @@ components:
         - $ref: '#/components/schemas/EpochTimeUnitMillis'
         - type: string
     DFIIndependenceMeasure:
-      type: string
-      enum:
-        - chisquared
-        - saturated
-        - standardized
+      oneOf:
+        - type: string
+          const: chisquared
+          description: The chi-squared measure of independence.
+        - type: string
+          const: saturated
+          description: The saturated measure of independence.
+        - type: string
+          const: standardized
+          description: The standardized measure of independence.
     DFRAfterEffect:
-      type: string
-      enum:
-        - b
-        - l
-        - no
+      oneOf:
+        - type: string
+          const: b
+          description: The basic after effect.
+        - type: string
+          const: l
+          description: The Laplace after effect.
+        - type: string
+          const: no
+          description: No after effect.
     DFRBasicModel:
-      type: string
-      enum:
-        - be
-        - d
-        - g
-        - if
-        - in
-        - ine
-        - p
+      oneOf:
+        - type: string
+          const: be
+          description: The Bose-Einstein model.
+        - type: string
+          const: d
+          description: The divergence from independence model.
+        - type: string
+          const: g
+          description: The geometric model.
+        - type: string
+          const: if
+          description: The inverse frequency model.
+        - type: string
+          const: in
+          description: The inverse document frequency model.
+        - type: string
+          const: ine
+          description: The inverse expected document frequency model.
+        - type: string
+          const: p
+          description: The Poisson model.
     TermFrequencyNormalization:
-      type: string
-      enum:
-        - h1
-        - h2
-        - h3
-        - no
-        - z
+      oneOf:
+        - type: string
+          const: h1
+          description: The first normalization of Hazm.
+        - type: string
+          const: h2
+          description: The second normalization of Hazm.
+        - type: string
+          const: h3
+          description: The third normalization of Hazm.
+        - type: string
+          const: no
+          description: No normalization.
+        - type: string
+          const: z
+          description: The Zipfian normalization.
     IBDistribution:
-      type: string
-      enum:
-        - ll
-        - spl
+      oneOf:
+        - type: string
+          const: ll
+          description: The log-logistic distribution.
+        - type: string
+          const: spl
+          description: The smoothed power-law distribution.
     IBLambda:
-      type: string
-      enum:
-        - df
-        - ttf
+      oneOf:
+        - type: string
+          const: df
+          description: The document frequency lambda.
+        - type: string
+          const: ttf
+          description: The total term frequency lambda.
     byte:
       type: number
+      description: The byte value.
     short:
       type: number
+      description: The short integer value.
     ulong:
       type: number
+      description: The unsigned long integer value.
     Level:
       description: Specifies the level of detail of the returned information.
       type: string
@@ -1233,24 +1275,30 @@ components:
           description: The total amount, in bytes, of memory used for completion across all shards assigned to the selected nodes.
           $ref: '#/components/schemas/ByteCount'
         size:
+          description: The human-readable size of memory used for completion.
           $ref: '#/components/schemas/HumanReadableByteCount'
         fields:
           type: object
+          description: The per-field completion statistics.
           additionalProperties:
             $ref: '#/components/schemas/FieldSizeUsage'
       required:
         - size_in_bytes
     FieldSizeUsage:
       type: object
+      description: The memory usage statistics for a field.
       properties:
         size:
           $ref: '#/components/schemas/HumanReadableByteCount'
+          description: The human-readable size of memory used.
         size_in_bytes:
           $ref: '#/components/schemas/ByteCount'
+          description: The size of memory used in bytes.
       required:
         - size_in_bytes
     DocStats:
       type: object
+      description: The document-level statistics.
       properties:
         count:
           description: |-
@@ -1268,32 +1316,41 @@ components:
       required:
         - count
     FielddataStats:
+      description: The statistics about field data memory usage.
       type: object
       properties:
         evictions:
           type: integer
           format: int64
+          description: The number of times field data was evicted from memory.
         memory_size:
           $ref: '#/components/schemas/HumanReadableByteCount'
+          description: The human-readable amount of memory used for field data.
         memory_size_in_bytes:
           $ref: '#/components/schemas/ByteCount'
+          description: The amount of memory used for field data in bytes.
         fields:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/FieldMemoryUsage'
+            description: The per-field field data statistics.
       required:
         - memory_size_in_bytes
     FieldMemoryUsage:
       type: object
+      description: The memory usage statistics for a field.
       properties:
         memory_size:
           $ref: '#/components/schemas/HumanReadableByteCount'
+          description: The human-readable amount of memory used.
         memory_size_in_bytes:
           $ref: '#/components/schemas/ByteCount'
+          description: The amount of memory used in bytes.
       required:
         - memory_size_in_bytes
     QueryCacheStats:
       type: object
+      description: The statistics about query cache usage.
       properties:
         cache_count:
           description: |-
@@ -1315,6 +1372,7 @@ components:
           format: int64
         memory_size:
           $ref: '#/components/schemas/HumanReadableByteCount'
+          description: The human-readable amount of memory used for the query cache.
         memory_size_in_bytes:
           description: The total amount, in bytes, of memory used for the query cache across all shards assigned to the selected nodes.
           $ref: '#/components/schemas/ByteCount'
@@ -1336,10 +1394,10 @@ components:
         - total_count
     RemoteStoreStats:
       type: object
-      description: Statistics related to remote segment store operations.
+      description: The statistics related to remote segment store operations.
       properties:
         upload:
-          $ref: '#/components/schemas/RemoteStoreUploadStats'
+          $ref: '#/components/schemas/RemoteStoreUploadStats'     
         download:
           $ref: '#/components/schemas/RemoteStoreDownloadStats'
       required:
@@ -1347,6 +1405,7 @@ components:
         - upload
     RemoteStoreTranslogStats:
       type: object
+      description: The statistics related to remote translog operations.
       properties:
         upload:
           $ref: '#/components/schemas/RemoteStoreTranslogUploadStats'
@@ -1354,7 +1413,7 @@ components:
         - upload
     RemoteStoreTranslogUploadStats:
       type: object
-      description: Statistics related to uploads to the remote translog store.
+      description: The statistics related to uploads to the remote translog store.
       properties:
         total_uploads:
           $ref: '#/components/schemas/RemoteStoreTranslogUploadTotalUploadsStats'
@@ -1411,7 +1470,7 @@ components:
         - succeeded_bytes
     RemoteStoreUploadStats:
       type: object
-      description: Statistics related to uploads to the remote segment store.
+      description: Any statistics related to uploads to the remote segment store.
       properties:
         max_refresh_time_lag:
           description: The maximum duration that the remote refresh is behind the local refresh.
@@ -1493,7 +1552,7 @@ components:
         - total_bytes
     RemoteStoreDownloadStats:
       type: object
-      description: Statistics related to downloads to the remote segment store. 
+      description: Any statistics related to downloads to the remote segment store. 
       properties:
         total_download_size:
           description: The total amount of data downloaded from the remote segment store. 
@@ -1513,32 +1572,41 @@ components:
         - x-version-added: 2.10.0
           x-version-removed: 2.12.0
           type: object
+          description: The segment replication statistics for versions 2.10.0 to 2.12.0.
           properties:
             max_bytes_behind:
               $ref: '#/components/schemas/HumanReadableByteCount'
+              description: The maximum number of bytes the replica is behind the primary.
             max_replication_lag:
               $ref: '#/components/schemas/Duration'
+              description: The maximum replication lag between primary and replica shards.
             total_bytes_behind:
               $ref: '#/components/schemas/HumanReadableByteCount'
+              description: The total number of bytes all replicas are behind their primaries.
           required:
             - max_bytes_behind
             - max_replication_lag
             - total_bytes_behind
         - x-version-added: 2.12.0
           type: object
+          description: The segment replication statistics for version 2.12.0 and later.
           properties:
             max_bytes_behind:
               $ref: '#/components/schemas/ByteCount'
+              description: The maximum number of bytes the replica is behind the primary.
             max_replication_lag:
               $ref: '#/components/schemas/DurationValueUnitMillis'
+              description: The maximum replication lag between primary and replica shards in milliseconds.
             total_bytes_behind:
               $ref: '#/components/schemas/ByteCount'
+              description: The total number of bytes all replicas are behind their primaries.
           required:
             - max_bytes_behind
             - max_replication_lag
             - total_bytes_behind
     SegmentsStats:
       type: object
+      description: The statistics about segments.
       properties:
         count:
           description: The total number of segments across all shards assigned to the selected nodes.
@@ -1546,6 +1614,7 @@ components:
           format: int32
         doc_values_memory:
           $ref: '#/components/schemas/HumanReadableByteCount'
+          description: The human-readable amount of memory used for doc values.
         doc_values_memory_in_bytes:
           description: The total amount, in bytes, of memory used for document values across all shards assigned to the selected nodes.
           $ref: '#/components/schemas/ByteCount'
@@ -1563,8 +1632,10 @@ components:
           $ref: '#/components/schemas/ByteCount'
         index_writer_memory:
           $ref: '#/components/schemas/HumanReadableByteCount'
+          description: The human-readable amount of memory used by index writers.
         index_writer_max_memory_in_bytes:
           $ref: '#/components/schemas/ByteCount'
+          description: The maximum amount of memory, in bytes, used by index writers.
         index_writer_memory_in_bytes:
           description: The total amount, in bytes, of memory used by all index writers across all shards assigned to the selected nodes.
           $ref: '#/components/schemas/ByteCount'

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -255,6 +255,7 @@ components:
     SequenceNumber:
       type: integer
       format: int64
+      description: The sequence number of the document.
     VersionNumber:
       type: integer
       format: int64
@@ -422,6 +423,7 @@ components:
       type: string
     Routing:
       type: string
+      description: The routing value for the document.
     RoutingInQueryString:
       $ref: '#/components/schemas/StringOrStringArray'
     DateTime:
@@ -703,34 +705,51 @@ components:
           $ref: '#/components/schemas/SortOrder'
     SortOrder:
       type: string
+      description: The direction of the sort order.
       enum:
         - asc
         - desc
     GeoDistanceSort:
       type: object
+      description: The options for sorting by geo distance.
       properties:
         mode:
           $ref: '#/components/schemas/SortMode'
+          description: The mode for sorting on array or multi-valued fields.
         distance_type:
           $ref: '#/components/schemas/GeoDistanceType'
+          description: The algorithm to use for distance calculation.
         ignore_unmapped:
           type: boolean
+          description: Whether to ignore unmapped fields and not sort based on them.
         order:
           $ref: '#/components/schemas/SortOrder'
+          description: The direction of the sort order.
         unit:
           $ref: '#/components/schemas/DistanceUnit'
+          description: The unit of distance measurement.
       additionalProperties:
         type: array
+        description: The geo points to use for distance calculation.
         items:
           $ref: '#/components/schemas/GeoLocation'
     SortMode:
-      type: string
-      enum:
-        - avg
-        - max
-        - median
-        - min
-        - sum
+      oneOf:
+        - type: string
+          const: avg
+          description: Use the average of all values.
+        - type: string
+          const: max
+          description: Use the maximum value.
+        - type: string
+          const: median
+          description: Use the median value.
+        - type: string
+          const: min
+          description: Use the minimum value.
+        - type: string
+          const: sum
+          description: Use the sum of all values.
     DistanceUnit:
       oneOf:
         - title: centimeters
@@ -767,119 +786,168 @@ components:
           $ref: '#/components/schemas/SortOrder'
         script:
           $ref: '#/components/schemas/Script'
+          description: The script to use for sorting.
         type:
           $ref: '#/components/schemas/ScriptSortType'
+          description: The type of the script sort value.
         mode:
           $ref: '#/components/schemas/SortMode'
+          description: The mode for sorting on array or multi-valued fields.
         nested:
           $ref: '#/components/schemas/NestedSortValue'
+          description: The nested path and filter for nested sorting.
       required:
         - script
     ScriptSortType:
-      type: string
-      enum:
-        - number
-        - string
-        - version
+      oneOf:
+        - type: string
+          const: number
+          description: The script returns a numeric value.
+        - type: string
+          const: string
+          description: The script returns a string value.
+        - type: string
+          const: version
+          description: The script returns a version value.
     NestedSortValue:
       type: object
       properties:
         filter:
           $ref: '_common.query_dsl.yaml#/components/schemas/QueryContainer'
+          description: The filter to apply to nested objects.
         max_children:
           type: integer
           format: int32
+          description: The maximum number of children to consider for sorting.
         nested:
           $ref: '#/components/schemas/NestedSortValue'
+          description: How to sort hierarchical nested objects.
         path:
           $ref: '#/components/schemas/Field'
+          description: The path to the nested objects.
       required:
         - path
     RelationName:
       type: string
+      description: The name of a relation in a join field.
     Ids:
       oneOf:
         - $ref: '#/components/schemas/Id'
+          description: A single document ID.
         - type: array
           items:
             $ref: '#/components/schemas/Id'
+            description: An array of document IDs.
     VersionType:
-      type: string
-      enum:
-        - external
-        - external_gte
-        - force
-        - internal
+      oneOf:
+        - type: string
+          const: external
+          description: The version number must be higher than the current version.
+        - type: string
+          const: external_gte
+          description: The version number must be higher than or equal to the current version.
+        - type: string
+          const: force
+          description: The version number is forced to be the given value.
+        - type: string
+          const: internal
+          description: The version number is managed internally by OpenSearch.
     TimeZone:
       type: string
+      description: The time zone identifier.
     DateFormat:
       type: string
+      description: The date format pattern.
     GeoHashPrecision:
       description: The level of geohash precision, which can be expressed as a geohash length between 1 and 12 or as a distance measure, such as "1km" or "10m".
       oneOf:
         - title: geohash_length
           type: integer
           format: int32
+          description: The geohash precision as a geohash length.
         - title: distance
           type: string
+          description: The geohash precision as a distance measure.
     GeoTilePrecision:
       type: number
+      description: The precision level for geo tile calculations.
     EmptyObject:
       type: object
+      description: An empty object with no properties.
     SlicedScroll:
       type: object
+      description: The configuration for a sliced scroll request.
       properties:
         field:
           $ref: '#/components/schemas/Field'
+          description: The field to slice on.
         id:
           type: integer
           format: int32
+          description: The ID of the slice.
         max:
           type: integer
           format: int32
+          description: The maximum number of slices.
       required:
         - id
         - max
     NodeName:
       type: string
+      description: The name of the node.
     Refresh:
       oneOf:
         - type: boolean
+          description: Whether to refresh the affected shards immediately.
         - type: string
-          enum:
-            - 'false'
-            - 'true'
-            - wait_for
+          const: 'false'
+          description: Do not refresh the affected shards.
+        - type: string
+          const: 'true'
+          description: Refresh the affected shards immediately.
+        - type: string
+          const: wait_for
+          description: Wait for the changes to become visible before replying.
     WaitForActiveShards:
       description: Waits until the specified number of shards is active before returning a response. Use `all` for all shards.
       oneOf:
         - title: count
           type: integer
+          description: The number of active shards to wait for.
         - title: option
           $ref: '#/components/schemas/WaitForActiveShardOptions'
+          description: Determines how many shards to wait for.
     WaitForActiveShardOptions:
-      type: string
-      enum:
-        - all
-        - index-setting
+     oneOf:
+       - type: string
+         const: all
+         description: Wait for all shards to be active.
+       - type: string
+         const: index-setting
+         description: Wait for the number of shards specified in the index settings.
     InlineGetDictUserDefined:
       type: object
+      description: The inline get operation results for user-defined dictionaries.
       properties:
         fields:
           type: object
+          description: The fields retrieved from the document.
           additionalProperties:
             type: object
         found:
           type: boolean
+          description: Whether the document was found.
         _seq_no:
           $ref: '#/components/schemas/SequenceNumber'
         _primary_term:
           type: integer
           format: int32
+          description: The primary term of the document.
         _routing:
           $ref: '#/components/schemas/Routing'
         _source:
           type: object
+          escription: The source of the document.
           additionalProperties: true
       required:
         - found
@@ -899,9 +967,11 @@ components:
             $ref: '#/components/schemas/NodeId'
     NodeId:
       type: string
+      description: The unique identifier of a node.
     HumanReadableByteCount:
       type: string
       pattern: '(?:(-1)|(0)|\d+(\.\d+)?(b|kb|k|mb|m|gb|g|tb|t|pb|p))'
+      description: The unique identifier of a node.
     ByteUnit:
       # eslint-disable yml/sort-sequence-values -- The order of `kb` & `k` etc. is important for preferring the more correct variant.
       oneOf:
@@ -937,16 +1007,21 @@ components:
     ByteCount:
       type: integer
       format: int64
+      description: The size in bytes.
     PercentageNumber:
       type: number
       format: double
+      description: The percentage value as a number.     
     PercentageString:
       type: string
       pattern: '\d+(\.\d+)?'
+      description: The percentage value as a string.
     Host:
       type: string
+      description: The hostname or IP address.
     Ip:
       type: string
+      description: The IP address.
     StringifiedEpochTimeUnitSeconds:
       description: |-
         Certain APIs may return values, including numbers such as epoch timestamps, as strings. This setting captures
@@ -1016,10 +1091,13 @@ components:
         # eslint-enable yml/sort-sequence-values
     Uuid:
       type: string
+      description: The universally unique identifier.
     ScrollIds:
       oneOf:
         - $ref: '#/components/schemas/ScrollId'
+          description: A single scroll identifier.
         - type: array
+          description: A list of scroll identifiers.
           items:
             $ref: '#/components/schemas/ScrollId'
     TransportAddress:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -918,13 +918,13 @@ components:
           $ref: '#/components/schemas/WaitForActiveShardOptions'
           description: Determines how many shards to wait for.
     WaitForActiveShardOptions:
-     oneOf:
-       - type: string
-         const: all
-         description: Wait for all shards to be active.
-       - type: string
-         const: index-setting
-         description: Wait for the number of shards specified in the index settings.
+      oneOf:
+        - type: string
+          const: all
+          description: Wait for all shards to be active.
+        - type: string
+          const: index-setting
+          description: Wait for the number of shards specified in the index settings.
     InlineGetDictUserDefined:
       type: object
       description: The inline get operation results for user-defined dictionaries.


### PR DESCRIPTION
Add's more common schema API descriptions, including for `enums`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
