### PR TITLE
Changed type of ActionRollover properties min_index_age and min_primary_shard_size from number to string

### DIFF
--- a/spec/schemas/ism._common.yaml
+++ b/spec/schemas/ism._common.yaml
@@ -48,18 +48,18 @@ components:
             - type: 'null'
             - type: array
               items:
-                $ref: '#/components/schemas/IsmTemplate'              
+                $ref: '#/components/schemas/IsmTemplate'
     PolicyWithMetadata:
       type: object
       allOf:
         - $ref: '#/components/schemas/Metadata'
-        - $ref: '#/components/schemas/PolicyEnvelope'      
+        - $ref: '#/components/schemas/PolicyEnvelope'
     States:
       type: object
       description: |-
-        A list of actions to perform, and transitions to enter a new state. 
-        Once a managed index enters a state it will sequentially execute the actions 
-        in the same order listed in the policy. Once all actions have been successfully completed 
+        A list of actions to perform, and transitions to enter a new state.
+        Once a managed index enters a state it will sequentially execute the actions
+        in the same order listed in the policy. Once all actions have been successfully completed
         state transitions will be checked until a true condition is eventually met.
         If you define multiple transitions in a state, the first one in the list that is true will be used.
       properties:
@@ -177,11 +177,11 @@ components:
         min_size:
           type: number
         min_index_age:
-          type: number
+          type: string
         min_doc_count:
           type: number
         min_primary_shard_size:
-          type: number
+          type: string
         copy_alias:
           type: boolean
     ActionNotification:


### PR DESCRIPTION
Changed type of ActionRollover properties min_index_age and min_primary_shard_size from number to string
 Signed-off-by: Robin Doermann <robin.doermann@gmail.com>

### Description
Fixes error caused by including units in the values for these properties.

### Issues Resolved
Closes #856 and #1001 from opensearch-js

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
