### PR TITLE
Fix Search API schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `pagination_depth` to `HybridQuery` ([#848](https://github.com/opensearch-project/opensearch-api-specification/pull/848))
 - Added `warm` to `ClusterNodeCount` ([#852](https://github.com/opensearch-project/opensearch-api-specification/pull/852))
 - Added `total_primary_shards_per_node` to `IndexRoutingAllocation` ([#852](https://github.com/opensearch-project/opensearch-api-specification/pull/852))
-- Added `verbose_pipeline` to SearchRequest ([#860](https://github.com/opensearch-project/opensearch-api-specification/pull/860))
+- Added `verbose_pipeline`, to SearchRequest ([#860](https://github.com/opensearch-project/opensearch-api-specification/pull/860))
+- Added `store` and `value_type` to TermsQuery  ([#860](https://github.com/opensearch-project/opensearch-api-specification/pull/860))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `pagination_depth` to `HybridQuery` ([#848](https://github.com/opensearch-project/opensearch-api-specification/pull/848))
 - Added `warm` to `ClusterNodeCount` ([#852](https://github.com/opensearch-project/opensearch-api-specification/pull/852))
 - Added `total_primary_shards_per_node` to `IndexRoutingAllocation` ([#852](https://github.com/opensearch-project/opensearch-api-specification/pull/852))
+- Added `verbose_pipeline` to SearchRequest ([#860](https://github.com/opensearch-project/opensearch-api-specification/pull/860))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))
@@ -85,6 +86,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed `HealthStatusCapatilized` and merged it with `HealthStatus` ([#725](https://github.com/opensearch-project/opensearch-api-specification/pull/725))
 - Removed `id` from `required` in `indices.termvectors@200` ([#734](https://github.com/opensearch-project/opensearch-api-specification/pull/734))
 - Removed duplicate `string` from `MultiTermQueryRewrite` ([#862](https://github.com/opensearch-project/opensearch-api-specification/pull/862/))
+- Removed unneeded `ExplanationDetail` from `Explanation` ([#860](https://github.com/opensearch-project/opensearch-api-specification/pull/860))
 
 ### Fixed
 - Spec passes OpenAPI 3.1.0 validations ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -53,7 +53,7 @@ Set up an OpenSearch cluster with Docker:
 ```bash
 export OPENSEARCH_PASSWORD=<<your_password>>
 cd tests/default
-docker-compose up -d
+docker compose up -d
 ```
 #### Run Tests
 

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -53,7 +53,7 @@ Set up an OpenSearch cluster with Docker:
 ```bash
 export OPENSEARCH_PASSWORD=<<your_password>>
 cd tests/default
-docker compose up -d
+docker-compose up -d
 ```
 #### Run Tests
 

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -5820,6 +5820,7 @@ components:
         type: boolean
       style: form
     search::query.verbose_pipeline:
+      x-version-added: '3.0'
       in: query
       name: verbose_pipeline
       description: |- 

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -746,6 +746,7 @@ paths:
         - $ref: '#/components/parameters/search::query.track_scores'
         - $ref: '#/components/parameters/search::query.track_total_hits'
         - $ref: '#/components/parameters/search::query.typed_keys'
+        - $ref: '#/components/parameters/search::query.verbose_pipeline'
         - $ref: '#/components/parameters/search::query.version'
       requestBody:
         $ref: '#/components/requestBodies/search'
@@ -809,6 +810,7 @@ paths:
         - $ref: '#/components/parameters/search::query.track_scores'
         - $ref: '#/components/parameters/search::query.track_total_hits'
         - $ref: '#/components/parameters/search::query.typed_keys'
+        - $ref: '#/components/parameters/search::query.verbose_pipeline'
         - $ref: '#/components/parameters/search::query.version'
       requestBody:
         $ref: '#/components/requestBodies/search'
@@ -1845,6 +1847,7 @@ paths:
         - $ref: '#/components/parameters/search::query.track_scores'
         - $ref: '#/components/parameters/search::query.track_total_hits'
         - $ref: '#/components/parameters/search::query.typed_keys'
+        - $ref: '#/components/parameters/search::query.verbose_pipeline'
         - $ref: '#/components/parameters/search::query.version'
       requestBody:
         $ref: '#/components/requestBodies/search'
@@ -1909,6 +1912,7 @@ paths:
         - $ref: '#/components/parameters/search::query.track_scores'
         - $ref: '#/components/parameters/search::query.track_total_hits'
         - $ref: '#/components/parameters/search::query.typed_keys'
+        - $ref: '#/components/parameters/search::query.verbose_pipeline'
         - $ref: '#/components/parameters/search::query.version'
       requestBody:
         $ref: '#/components/requestBodies/search'
@@ -2955,7 +2959,7 @@ components:
               matched:
                 type: boolean
               explanation:
-                $ref: '../schemas/_core.explain.yaml#/components/schemas/ExplanationDetail'
+                $ref: '../schemas/_core.explain.yaml#/components/schemas/Explanation'
               get:
                 $ref: '../schemas/_common.yaml#/components/schemas/InlineGet'
             required:
@@ -5812,6 +5816,19 @@ components:
       in: query
       name: typed_keys
       description: If `true`, aggregation and suggester names are be prefixed by their respective types in the response.
+      schema:
+        type: boolean
+      style: form
+    search::query.verbose_pipeline:
+      in: query
+      name: verbose_pipeline
+      description: |- 
+        Enables or disables verbose mode for the search pipeline.
+        When verbose mode is enabled, detailed information about each processor
+        in the search pipeline is included in the search response. This includes
+        the processor name, execution status, input, output, and time taken for processing.
+        This parameter is primarily intended for debugging purposes, allowing users
+        to track how data flows and transforms through the search pipeline.
       schema:
         type: boolean
       style: form

--- a/spec/namespaces/query.yaml
+++ b/spec/namespaces/query.yaml
@@ -9,7 +9,7 @@ paths:
       operationId: query.datasources_list.0
       x-operation-group: query.datasources_list
       x-version-added: '2.7'
-      description: Retrieves a list of all available datasources.
+      description: Retrieves a list of all available data sources.
       responses:
         '200':
           $ref: '#/components/responses/query.datasources_list@200'

--- a/spec/namespaces/sql.yaml
+++ b/spec/namespaces/sql.yaml
@@ -24,7 +24,7 @@ paths:
       operationId: sql.query.0
       x-operation-group: sql.query
       x-version-added: '1.0'
-      description: Executes SQL or PPL queries against OpenSearch indices.
+      description: Executes SQL or PPL queries against OpenSearch indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/sql/sql-ppl-api/
       parameters:

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -316,6 +316,16 @@ components:
           format: float
         _name:
           type: string
+    ValueType:
+      type: object
+      properties:
+        value_type:
+          description: |-
+            Specifies the types of values used for filtering. Valid values are default and bitmap. If omitted, the value defaults to default.
+          type: string
+          enum:
+            - bitmap
+            - default
     BoostingQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
@@ -2114,6 +2124,7 @@ components:
     TermsQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
+        - $ref: '#/components/schemas/ValueType'
         - type: object
           properties:
             _name: {}
@@ -2144,6 +2155,12 @@ components:
           $ref: '_common.yaml#/components/schemas/Field'
         routing:
           $ref: '_common.yaml#/components/schemas/Routing'
+        store:
+          type: boolean
+      required:
+        - id
+        - index
+        - path
     TermsSetQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -321,7 +321,7 @@ components:
       properties:
         value_type:
           description: |-
-            Specifies the types of values used for filtering. Valid values are default and bitmap. If omitted, the value defaults to default.
+             Specifies the types of values used for filtering. Valid values are `default` and `bitmap`. Default is `default`.
           type: string
           enum:
             - bitmap

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -321,7 +321,7 @@ components:
       properties:
         value_type:
           description: |-
-             Specifies the types of values used for filtering. Valid values are `default` and `bitmap`. Default is `default`.
+            Specifies the types of values used for filtering. Valid values are `default` and `bitmap`. Default is `default`.
           type: string
           enum:
             - bitmap

--- a/spec/schemas/_core.explain.yaml
+++ b/spec/schemas/_core.explain.yaml
@@ -16,7 +16,7 @@ components:
           items:
             $ref: '#/components/schemas/Explanation'
         value:
-          oneOf:
+          anyOf:
             - type: integer
               format: int32
             - type: integer

--- a/spec/schemas/_core.explain.yaml
+++ b/spec/schemas/_core.explain.yaml
@@ -14,7 +14,7 @@ components:
         details:
           type: array
           items:
-            $ref: '#/components/schemas/ExplanationDetail'
+            $ref: '#/components/schemas/Explanation'
         value:
           oneOf:
             - type: integer
@@ -28,26 +28,4 @@ components:
       required:
         - description
         - details
-        - value
-    ExplanationDetail:
-      type: object
-      properties:
-        description:
-          type: string
-        details:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExplanationDetail'
-        value:
-          anyOf:
-            - type: integer
-              format: int32
-            - type: integer
-              format: int64
-            - type: number
-              format: float
-            - type: number
-              format: double
-      required:
-        - description
         - value

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -111,6 +111,32 @@ components:
           $ref: '#/components/schemas/HitsMetadata'
       required:
         - hits
+    ProcessorExecutionDetail:
+      type: object
+      properties:
+        processor_name:
+          type: string
+        duration_millis:
+          type: integer
+          format: int64
+        input_data:
+          oneOf:
+            - type: object 
+            - type: array
+              items: 
+                type: object
+        output_data: 
+          oneOf:
+            - type: object 
+            - type: array
+              items: 
+                type: object
+        status: 
+          type: string
+        tag:
+          type: string 
+        error:
+          type: string
     NestedIdentity:
       type: object
       properties:
@@ -1254,6 +1280,11 @@ components:
           $ref: '_common.yaml#/components/schemas/PhaseTook'
         hits:
           $ref: '#/components/schemas/HitsMetadata'
+        processor_results: 
+          x-version-added: '3.0'
+          type: array
+          items: 
+            $ref: '#/components/schemas/ProcessorExecutionDetail'
         aggregations:
           type: object
           additionalProperties:

--- a/tests/default/_core/search/pipeline/verbose_pipeline.yaml
+++ b/tests/default/_core/search/pipeline/verbose_pipeline.yaml
@@ -1,0 +1,98 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the verbose_pipeline parameter with search pipelines.
+warnings:
+  invalid-path-detected: false
+version: '>= 2.16'
+prologues:
+  # Create test data
+  - path: /test_index/_doc/1
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      payload:
+        field1: test value
+        field2: 123
+        
+epilogues:
+  # Clean up
+  - path: /_search/pipeline/test_pipeline
+    method: DELETE
+    status: [200, 404]
+  - path: /test_index
+    method: DELETE
+    status: [200, 404]
+    
+chapters:
+  # Create a pipeline with multiple processors
+  - synopsis: Create search pipeline with multiple processors.
+    path: /_search/pipeline/{id}
+    method: PUT
+    parameters:
+      id: test_pipeline
+    request:
+      payload:
+        request_processors:
+          - filter_query:
+              tag: filter_processor
+              description: Filter processor for testing
+              query:
+                match_all: {}
+        response_processors:
+          - sort:
+              field: field2
+              order: asc
+              target_field: sorted_field
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+      
+  # Test with verbose_pipeline: false (default)
+  - synopsis: Search with default verbose_pipeline (false) should not return processor_results.
+    path: /{index}/_search
+    method: GET
+    parameters:
+      index: test_index
+      search_pipeline: test_pipeline
+      verbose_pipeline: false
+    response:
+      status: 200
+      payload:
+        hits:
+          total:
+            value: 1
+          hits:
+            - _index: test_index
+              _source:
+                field1: test value
+                field2: 123
+        
+  # Test with verbose_pipeline: true
+  - synopsis: Search with verbose_pipeline enabled should return processor_results.
+    warnings:
+      multiple-paths-detected: false
+    path: /{index}/_search
+    method: GET
+    parameters:
+      index: test_index
+      search_pipeline: test_pipeline
+      verbose_pipeline: true
+    response:
+      status: 200
+      payload:
+        hits:
+          total:
+            value: 1
+          hits:
+            - _index: test_index
+              _source:
+                field1: test value
+                field2: 123
+        processor_results:
+          - processor_name: filter_query
+          # duration_millis: 0
+          - processor_name: sort
+            input_data: []
+            output_data: []

--- a/tests/default/_core/search/pipeline/verbose_pipeline.yaml
+++ b/tests/default/_core/search/pipeline/verbose_pipeline.yaml
@@ -3,7 +3,7 @@ $schema: ../../../../../json_schemas/test_story.schema.yaml
 description: Test the verbose_pipeline parameter with search pipelines.
 warnings:
   invalid-path-detected: false
-version: '>= 2.16'
+version: '>= 3.0'
 prologues:
   # Create test data
   - path: /test_index/_doc/1

--- a/tests/default/query/datasources.yaml
+++ b/tests/default/query/datasources.yaml
@@ -29,7 +29,7 @@ chapters:
     response:
       status: 201
       payload: Created DataSource with name test_datasource
-  - synopsis: Retrieve the list of all query datasources.
+  - synopsis: Retrieve the list of all query data sources.
     path: /_plugins/_query/_datasources
     method: GET
     response:


### PR DESCRIPTION
### Description
1. Added [verbose_pipeline](https://github.com/opensearch-project/OpenSearch/blob/396add1a1c49d6350826ebd5831373f5f1ca0917/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java#L259-L261) to Search request spec, and its corresponding `processor_results` to the Search response spec.
2. Remove `ExplanationDetail` . The type is just [Explanation](https://github.com/opensearch-project/OpenSearch/blob/396add1a1c49d6350826ebd5831373f5f1ca0917/server/src/main/java/org/opensearch/action/explain/ExplainResponse.java#L224)
3. `store` field was added in https://github.com/opensearch-project/OpenSearch/pull/14774/files to  TermsLookup.  
4. `ValueType` was added in 2.17 per https://opensearch.org/docs/latest/query-dsl/term/terms/#bitmap-filtering
5. Specified the required fields in TermsLookup 

### Issues Resolved
General spec fixes, contributing to accuracy of the Search Protobufs:
https://github.com/opensearch-project/OpenSearch/issues/16783
https://github.com/opensearch-project/opensearch-protobufs/issues/30

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
