### PR TITLE
Changed DistanceFeatureQuery and RangeQuery from allOf + oneOf to oneOf + allOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Changed `ml.get_memory` and `ml.get_message` to split out `get_all` variants ([#796](https://github.com/opensearch-project/opensearch-api-specification/pull/796))
 - Changed `ml.get_tools` to have two different operation groups `ml.get_all_tools` and `ml.get_tool` ([#799](https://github.com/opensearch-project/opensearch-api-specification/pull/799))
 - Changed `FlowFrameworkDeleteResponse` to utilize `WriteResponseBase` ([#814](https://github.com/opensearch-project/opensearch-api-specification/pull/814))
+- Changed `DistanceFeatureQuery` and `RangeQuery` from (allOf + oneOf) to (oneOf + allOf) ([#865](https://github.com/opensearch-project/opensearch-api-specification/pull/865))
 
 ## [0.1.0] - 2024-10-25
 

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -424,33 +424,33 @@ components:
     DistanceFeatureQuery:
       oneOf:
         - allOf:
-          - $ref: '#/components/schemas/QueryBase'
-          - type: object
-            properties:
-              origin:
-                $ref: '_common.yaml#/components/schemas/GeoLocation'
-              pivot:
-                $ref: '_common.yaml#/components/schemas/Distance'
-              field:
-                $ref: '_common.yaml#/components/schemas/Field'
-            required:
-              - field
-              - origin
-              - pivot
+            - $ref: '#/components/schemas/QueryBase'
+            - type: object
+              properties:
+                origin:
+                  $ref: '_common.yaml#/components/schemas/GeoLocation'
+                pivot:
+                  $ref: '_common.yaml#/components/schemas/Distance'
+                field:
+                  $ref: '_common.yaml#/components/schemas/Field'
+              required:
+                - field
+                - origin
+                - pivot
         - allOf:
-          - $ref: '#/components/schemas/QueryBase'
-          - type: object
-            properties:
-              origin:
-                $ref: '_common.yaml#/components/schemas/DateMath'
-              pivot:
-                $ref: '_common.yaml#/components/schemas/Duration'
-              field:
-                $ref: '_common.yaml#/components/schemas/Field'
-            required:
-              - field
-              - origin
-              - pivot
+            - $ref: '#/components/schemas/QueryBase'
+            - type: object
+              properties:
+                origin:
+                  $ref: '_common.yaml#/components/schemas/DateMath'
+                pivot:
+                  $ref: '_common.yaml#/components/schemas/Duration'
+                field:
+                  $ref: '_common.yaml#/components/schemas/Field'
+              required:
+                - field
+                - origin
+                - pivot
     ExistsQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
@@ -1671,8 +1671,8 @@ components:
             - $ref: '#/components/schemas/RangeQueryBase'
             - $ref: '#/components/schemas/NumberRangeQueryParameters'
         - allOf:
-          - $ref: '#/components/schemas/RangeQueryBase'
-          - $ref: '#/components/schemas/DateRangeQueryParameters'
+            - $ref: '#/components/schemas/RangeQueryBase'
+            - $ref: '#/components/schemas/DateRangeQueryParameters'
     DateRangeQueryParameters:
       type: object
       properties:

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -422,33 +422,35 @@ components:
           required:
             - queries
     DistanceFeatureQuery:
-      allOf:
-        - $ref: '#/components/schemas/QueryBase'
-        - oneOf:
-            - type: object
-              properties:
-                origin:
-                  $ref: '_common.yaml#/components/schemas/GeoLocation'
-                pivot:
-                  $ref: '_common.yaml#/components/schemas/Distance'
-                field:
-                  $ref: '_common.yaml#/components/schemas/Field'
-              required:
-                - field
-                - origin
-                - pivot
-            - type: object
-              properties:
-                origin:
-                  $ref: '_common.yaml#/components/schemas/DateMath'
-                pivot:
-                  $ref: '_common.yaml#/components/schemas/Duration'
-                field:
-                  $ref: '_common.yaml#/components/schemas/Field'
-              required:
-                - field
-                - origin
-                - pivot
+      oneOf:
+        - allOf:
+          - $ref: '#/components/schemas/QueryBase'
+          - type: object
+            properties:
+              origin:
+                $ref: '_common.yaml#/components/schemas/GeoLocation'
+              pivot:
+                $ref: '_common.yaml#/components/schemas/Distance'
+              field:
+                $ref: '_common.yaml#/components/schemas/Field'
+            required:
+              - field
+              - origin
+              - pivot
+        - allOf:
+          - $ref: '#/components/schemas/QueryBase'
+          - type: object
+            properties:
+              origin:
+                $ref: '_common.yaml#/components/schemas/DateMath'
+              pivot:
+                $ref: '_common.yaml#/components/schemas/Duration'
+              field:
+                $ref: '_common.yaml#/components/schemas/Field'
+            required:
+              - field
+              - origin
+              - pivot
     ExistsQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
@@ -1664,11 +1666,13 @@ components:
           required:
             - query
     RangeQuery:
-      allOf:
-        - $ref: '#/components/schemas/RangeQueryBase'
-        - oneOf:
+      oneOf:
+        - allOf:
+            - $ref: '#/components/schemas/RangeQueryBase'
             - $ref: '#/components/schemas/NumberRangeQueryParameters'
-            - $ref: '#/components/schemas/DateRangeQueryParameters'
+        - allOf:
+          - $ref: '#/components/schemas/RangeQueryBase'
+          - $ref: '#/components/schemas/DateRangeQueryParameters'
     DateRangeQueryParameters:
       type: object
       properties:


### PR DESCRIPTION
### Description
Changed DistanceFeatureQuery and RangeQuery from allOf + oneOf to oneOf + allOf.

The original structure (allOf + oneOf) is not well-supported by the OpenAPI Protobuf generator, as it causes to the loss of mutual exclusivity in the flattened models. 

This change does not affect REST API behavior or payloads.

Before the change.  All fields from variants are flattened into a single message.
```
message RangeQuery {

  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  optional string underscore_name = 2;

  optional RangeRelation relation = 3;

  optional string gt = 4;

  optional string gte = 5;

  optional string lt = 6;

  optional string lte = 7;

  optional string from = 8;

  optional string to = 9;

  // The date format pattern.
  optional string format = 10;

  // The time zone identifier.
  optional string time_zone = 11;

}
```
After the change
```
message RangeQuery {
  oneof range_query {
    RangeQueryOneOf range_query_one_of = 1;
    
    RangeQueryOneOf1 range_query_one_of1 = 2;
  }
}
message RangeQueryOneOf {
  // Floating point number used to decrease or increase the relevance scores of
  // the query. Boost values are relative to the default value of 1.0. A boost
  // value between 0 and 1.0 decreases the relevance score. A value greater
  // than 1.0 increases the relevance score.
  optional float boost = 1;

  optional string underscore_name = 2;

  optional RangeRelation relation = 3;

  // Greater than.
  optional double gt = 4;

  // Greater than or equal to.
  optional double gte = 5;

  // Less than.
  optional double lt = 6;

  // Less than or equal to.
  optional double lte = 7;

  optional NumberRangeQueryParametersFrom from = 8;

  optional NumberRangeQueryParametersTo to = 9;
}
message RangeQueryOneOf1 {
  // Floating point number used to decrease or increase the relevance scores of
  // the query. Boost values are relative to the default value of 1.0. A boost
  // value between 0 and 1.0 decreases the relevance score. A value greater
  // than 1.0 increases the relevance score.
  optional float boost = 1;

  optional string underscore_name = 2;

  optional RangeRelation relation = 3;

  optional string gt = 4;

  optional string gte = 5;

  optional string lt = 6;

  optional string lte = 7;

  optional string from = 8;

  optional string to = 9;

  // The date format pattern.
  optional string format = 10;

  // The time zone identifier.
  optional string time_zone = 11;
}
message RangeQueryBase {
  // Floating point number used to decrease or increase the relevance scores of
  // the query. Boost values are relative to the default value of 1.0. A boost
  // value between 0 and 1.0 decreases the relevance score. A value greater
  // than 1.0 increases the relevance score.
  optional float boost = 1;

  optional string underscore_name = 2;

  optional RangeRelation relation = 3;
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
