### PR TITLE
Fix link to logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px" alt="OpenSearch logo">
+<img src="https://opensearch.org/wp-content/uploads/2025/01/opensearch_logo_default.svg" height="64px" alt="OpenSearch logo">
 
 ## OpenSearch API Specification
 


### PR DESCRIPTION
Fixes the logo at the top of the Readme.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
