### PR TITLE
Bump latest default test version to 3.0.0-beta1

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -66,7 +66,7 @@ jobs:
           - version: 2.20.0
             hub: opensearchstaging
             ref: '@sha256:037a2eb5a4f48b9a9a29950be5e5fae4ebd82d41de1066e00bb8d8b0ce7871b1'
-          - version: 3.0.0-alpha1
+          - version: 3.0.0-beta1
 
     name: test-opensearch-spec (version=${{ matrix.entry.version }}, hub=${{ matrix.entry.hub || 'opensearchproject' }}, tests=${{ matrix.entry.tests || 'default' }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Bumps latest integ test version to latest release 3.0.0-beta1, replacing 2.20 and 3.0.0-alpha1 as discussed in #850 

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
