### PR TITLE
Remove `max_score` from ResponseBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed `id` from `required` in `indices.termvectors@200` ([#734](https://github.com/opensearch-project/opensearch-api-specification/pull/734))
 - Removed duplicate `string` from `MultiTermQueryRewrite` ([#862](https://github.com/opensearch-project/opensearch-api-specification/pull/862/))
 - Removed unneeded `ExplanationDetail` from `Explanation` ([#860](https://github.com/opensearch-project/opensearch-api-specification/pull/860))
+- Removed unsupported `max_score` from ResponseBody ([#891](https://github.com/opensearch-project/opensearch-api-specification/pull/891))
 
 ### Fixed
 - Spec passes OpenAPI 3.1.0 validations ([#646](https://github.com/opensearch-project/opensearch-api-specification/pull/646))

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -1307,9 +1307,6 @@ components:
           type: object
           additionalProperties:
             type: object
-        max_score:
-          type: number
-          format: float
         num_reduce_phases:
           type: integer
           format: int32


### PR DESCRIPTION
### Description
The [SearchResponse#toXContent()](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/search/SearchResponse.java#L340-L371) does not have a field called `max_score`. 

There is however, a`max_score` in [SearchHits](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/SearchHits.java#L231), which corresponds to the [`HitsMetadata`](https://github.com/opensearch-project/opensearch-api-specification/blob/c042c5f70d9bbed1b308534fc4ee6e516021d2ae/spec/schemas/_core.search.yaml#L29) field in the spec.

### Issues Resolved
General spec fixes, contributing to accuracy of the Search Protobufs:
https://github.com/opensearch-project/OpenSearch/issues/16783
https://github.com/opensearch-project/opensearch-protobufs/issues/30

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
