### PR TITLE
Add API Spec for Geospatial plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `searchOnly` to `NodeShard` ([#883](https://github.com/opensearch-project/opensearch-api-specification/pull/883))
 - Added `GET /_plugins/_neural/stats` ([#850](https://github.com/opensearch-project/opensearch-api-specification/pull/850))
 - Added `ToolAttributes` to `ml._common.yaml` ([#878](https://github.com/opensearch-project/opensearch-api-specification/pull/878)) 
+- Added `GET _plugins/geospatial/_upload/stats`, `PUT`, `POST _plugins/geospatial/geojson/_upload`, `GET _plugins/geospatial/ip2geo/datasource`, `GET`, `PUT`, `DELETE _plugins/geospatial/ip2geo/datasource/{name}` and `PUT _plugins/geospatial/ip2geo/datasource/{name}/_settings` ([#893](https://github.com/opensearch-project/opensearch-api-specification/pull/893))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/spec/namespaces/geospatial.yaml
+++ b/spec/namespaces/geospatial.yaml
@@ -43,22 +43,34 @@ paths:
         '200':
           $ref: '#/components/responses/geospatial.get_upload_stats@200'
 
+  /_plugins/geospatial/ip2geo/datasource:
+    get:
+      operationId: geospatial.get_ip2geo_datasource.0
+      x-operation-group: geospatial.get_ip2geo_datasource
+      x-version-added: '2.11'
+      description: Get one or more IP2Geo data sources, defaulting to returning all if no names specified.
+      externalDocs:
+        url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#sending-a-get-request'
+      responses:
+        '200':
+          $ref: '#/components/responses/geospatial.get_ip2geo_datasource@200'
+
   /_plugins/geospatial/ip2geo/datasource/{name}:
     get:
-      operationId: geospatial.get_ip_to_geo_datasource.0
-      x-operation-group: geospatial.get_ip_to_geo_datasource
+      operationId: geospatial.get_ip2geo_datasource.1
+      x-operation-group: geospatial.get_ip2geo_datasource
       x-version-added: '2.11'
       description: Get one or more IP2Geo data sources, defaulting to returning all if no names specified.
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#sending-a-get-request'
       parameters:
-        - $ref: '#/components/parameters/geospatial.get_ip_to_geo_datasource::path.name'
+        - $ref: '#/components/parameters/geospatial.get_ip2geo_datasource::path.name'
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.get_ip_to_geo_datasource@200'
+          $ref: '#/components/responses/geospatial.get_ip2geo_datasource@200'
     put:
-      operationId: geospatial.put_ip_to_geo_datasource.0
-      x-operation-group: geospatial.put_ip_to_geo_datasource
+      operationId: geospatial.put_ip2geo_datasource.0
+      x-operation-group: geospatial.put_ip2geo_datasource
       x-version-added: '2.11'
       description: |-
         Create a specific IP2Geo data source.
@@ -68,67 +80,67 @@ paths:
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#data-source-options'
       parameters:
-        - $ref: '#/components/parameters/geospatial.put_ip_to_geo_datasource::path.name'
+        - $ref: '#/components/parameters/geospatial.put_ip2geo_datasource::path.name'
       requestBody:
-        $ref: '#/components/requestBodies/geospatial.put_ip_to_geo_datasource'
+        $ref: '#/components/requestBodies/geospatial.put_ip2geo_datasource'
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.put_ip_to_geo_datasource@200'
+          $ref: '#/components/responses/geospatial.put_ip2geo_datasource@200'
         '400':
-          $ref: '#/components/responses/geospatial.put_ip_to_geo_datasource@400'
+          $ref: '#/components/responses/geospatial.put_ip2geo_datasource@400'
     delete:
-      operationId: geospatial.delete_ip_to_geo_datasource.0
-      x-operation-group: geospatial.delete_ip_to_geo_datasource
+      operationId: geospatial.delete_ip2geo_datasource.0
+      x-operation-group: geospatial.delete_ip2geo_datasource
       x-version-added: '2.11'
       description: Delete a specific IP2Geo data source.
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#deleting-the-ip2geo-data-source'
       parameters:
-        - $ref: '#/components/parameters/geospatial.delete_ip_to_geo_datasource::path.name'
+        - $ref: '#/components/parameters/geospatial.delete_ip2geo_datasource::path.name'
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.delete_ip_to_geo_datasource@200'
+          $ref: '#/components/responses/geospatial.delete_ip2geo_datasource@200'
         '404':
-          $ref: '#/components/responses/geospatial.delete_ip_to_geo_datasource@404'
+          $ref: '#/components/responses/geospatial.delete_ip2geo_datasource@404'
   /_plugins/geospatial/ip2geo/datasource/{name}/_settings:
     put:
-      operationId: geospatial.put_ip_to_geo_datasource_settings.0
-      x-operation-group: geospatial.put_ip_to_geo_datasource_settings
+      operationId: geospatial.put_ip2geo_datasource_settings.0
+      x-operation-group: geospatial.put_ip2geo_datasource_settings
       x-version-added: '2.11'
       description: Update a specific IP2Geo data source.
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#updating-an-ip2geo-data-source'
       parameters:
-        - $ref: '#/components/parameters/geospatial.put_ip_to_geo_datasource_settings::path.name'
+        - $ref: '#/components/parameters/geospatial.put_ip2geo_datasource_settings::path.name'
       requestBody:
-        $ref: '#/components/requestBodies/geospatial.put_ip_to_geo_datasource_settings'
+        $ref: '#/components/requestBodies/geospatial.put_ip2geo_datasource_settings'
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.put_ip_to_geo_datasource_settings@200'
+          $ref: '#/components/responses/geospatial.put_ip2geo_datasource_settings@200'
         '404':
-          $ref: '#/components/responses/geospatial.put_ip_to_geo_datasource_settings@404'
+          $ref: '#/components/responses/geospatial.put_ip2geo_datasource_settings@404'
 
 components:
   parameters:
-    geospatial.get_ip_to_geo_datasource::path.name:
+    geospatial.get_ip2geo_datasource::path.name:
       name: name
       in: path
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/StringOrStringArray'
-    geospatial.put_ip_to_geo_datasource::path.name:
+    geospatial.put_ip2geo_datasource::path.name:
       name: name
       in: path
       required: true
       schema:
         type: string
-    geospatial.delete_ip_to_geo_datasource::path.name:
+    geospatial.delete_ip2geo_datasource::path.name:
       name: name
       in: path
       required: true
       schema:
         type: string
-    geospatial.put_ip_to_geo_datasource_settings::path.name:
+    geospatial.put_ip2geo_datasource_settings::path.name:
       name: name
       in: path
       required: true
@@ -147,13 +159,13 @@ components:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoJSONRequest'
-    geospatial.put_ip_to_geo_datasource:
+    geospatial.put_ip2geo_datasource:
       required: false
       content:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/PutIP2GeoDataSourceRequest'
-    geospatial.put_ip_to_geo_datasource_settings:
+    geospatial.put_ip2geo_datasource_settings:
       required: true
       content:
         application/json:
@@ -184,43 +196,43 @@ components:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoSpatialUploadStats'
-    geospatial.get_ip_to_geo_datasource@200:
+    geospatial.get_ip2geo_datasource@200:
       description: Provides information for getting IP2Geo data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/GetDataSourceResponse'
-    geospatial.put_ip_to_geo_datasource@200:
+    geospatial.put_ip2geo_datasource@200:
       description: Provides information for deleting IP2Geo data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    geospatial.delete_ip_to_geo_datasource@200:
+    geospatial.delete_ip2geo_datasource@200:
       description: Provides information for deleting IP2Geo data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    geospatial.put_ip_to_geo_datasource_settings@200:
+    geospatial.put_ip2geo_datasource_settings@200:
       description: Acknowledged response when create, delete or update a data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    geospatial.put_ip_to_geo_datasource@400:
+    geospatial.put_ip2geo_datasource@400:
       description: Invalid request for creating a data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
-    geospatial.delete_ip_to_geo_datasource@404:
+    geospatial.delete_ip2geo_datasource@404:
       description: Invalid request for deleting a data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
-    geospatial.put_ip_to_geo_datasource_settings@404:
+    geospatial.put_ip2geo_datasource_settings@404:
       description: Invalid request for updating a data source setting.
       content:
         application/json:

--- a/spec/namespaces/geospatial.yaml
+++ b/spec/namespaces/geospatial.yaml
@@ -1,0 +1,246 @@
+openapi: 3.1.0
+info:
+  title: OpenSearch Geospatial API
+  description: OpenSearch Geospatial API.
+  version: 1.0.0
+paths:
+  /_plugins/geospatial/geojson/_upload:
+    post:
+      operationId: geospatial.geojson_upload_post.0
+      x-operation-group: geospatial.geojson_upload_post
+      x-version-added: '2.11'
+      description: |- 
+        Use an OpenSearch query to upload `GeoJSON`, operation will fail if index exists.
+        - When type is `geo_point`, only Point geometry is allowed
+        - When type is `geo_shape`, all geometry types are allowed (Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon, GeometryCollection, Envelope).
+      requestBody:
+        $ref: '#/components/requestBodies/geospatial.geojson_upload_post'
+      responses:
+        '200':
+          $ref: '#/components/responses/geospatial.geojson_upload_post@200'
+        '400':
+          $ref: '#/components/responses/geospatial.geojson_upload_post@400'
+    put:
+      operationId: geospatial.geojson_upload_put.0
+      x-operation-group: geospatial.geojson_upload_put
+      x-version-added: '2.11'
+      description: |- 
+        Use an OpenSearch query to upload `GeoJSON` regardless if index exists.
+        - When type is `geo_point`, only Point geometry is allowed
+        - When type is `geo_shape`, all geometry types are allowed (Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon, GeometryCollection, Envelope).
+      requestBody:
+        $ref: '#/components/requestBodies/geospatial.geojson_upload_put'
+      responses:
+        '200':
+          $ref: '#/components/responses/geospatial.geojson_upload_put@200'
+  /_plugins/geospatial/_upload/stats:
+    get:
+      operationId: geospatial.upload_stats.0
+      x-operation-group: geospatial.upload_stats
+      x-version-added: '2.11'
+      description: Retrieves statistics for all geospatial uploads.
+      responses:
+        '200':
+          $ref: '#/components/responses/geospatial.upload_stats@200'
+
+  /_plugins/geospatial/ip2geo/datasource:
+    get:
+      operationId: geospatial.ip_to_geo_get_all_datasource.0
+      x-operation-group: geospatial.ip_to_geo_get_all_datasource
+      x-version-added: '2.11'
+      description: Get information about all IP2Geo data sources.
+      externalDocs:
+        url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/'
+      responses:
+        '200':
+          $ref: '#/components/responses/geospatial.ip_to_geo_get_all_datasource@200'
+
+  /_plugins/geospatial/ip2geo/datasource/{datasource_name}:
+    get:
+      operationId: geospatial.ip_to_geo_get_datasource.0
+      x-operation-group: geospatial.ip_to_geo_get_datasource
+      x-version-added: '2.11'
+      description: Get information for a specific IP2Geo data source.
+      externalDocs:
+        url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#sending-a-get-request'
+      parameters:
+        - $ref: '#/components/parameters/geospatial.ip_to_geo_get_datasource::path.datasource_name'
+      responses:
+        '200':
+          $ref: '#/components/responses/geospatial.ip_to_geo_get_datasource@200'
+    put:
+      operationId: geospatial.ip_to_geo_put_datasource.0
+      x-operation-group: geospatial.ip_to_geo_put_datasource
+      x-version-added: '2.11'
+      description: |-
+        Create a specific IP2Geo data source.
+        Default values:
+          - `endpoint`: `"https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json"`
+          - `update_interval_in_days`: 3.
+      externalDocs:
+        url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#data-source-options'
+      parameters:
+        - $ref: '#/components/parameters/geospatial.ip_to_geo_put_datasource::path.datasource_name'
+      requestBody:
+        $ref: '#/components/requestBodies/geospatial.ip_to_geo_put_datasource'
+      responses:
+        '200':
+          $ref: '#/components/responses/geospatial.ip_to_geo_put_datasource@200'
+        '400':
+          $ref: '#/components/responses/geospatial.ip_to_geo_put_datasource@400'
+    delete:
+      operationId: geospatial.ip_to_geo_delete_datasource.0
+      x-operation-group: geospatial.ip_to_geo_delete_datasource
+      x-version-added: '2.11'
+      description: Delete a specific IP2Geo data source.
+      externalDocs:
+        url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#deleting-the-ip2geo-data-source'
+      parameters:
+        - $ref: '#/components/parameters/geospatial.ip_to_geo_delete_datasource::path.datasource_name'
+      responses:
+        '200':
+          $ref: '#/components/responses/geospatial.ip_to_geo_delete_datasource@200'
+        '404':
+          $ref: '#/components/responses/geospatial.ip_to_geo_delete_datasource@404'
+  /_plugins/geospatial/ip2geo/datasource/{datasource_name}/_settings:
+    put:
+      operationId: geospatial.ip_to_geo_datasource_settings.0
+      x-operation-group: geospatial.ip_to_geo_datasource_settings
+      x-version-added: '2.11'
+      description: Update a specific IP2Geo data source.
+      externalDocs:
+        url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#updating-an-ip2geo-data-source'
+      parameters:
+        - $ref: '#/components/parameters/geospatial.ip_to_geo_datasource_settings::path.datasource_name'
+      requestBody:
+        $ref: '#/components/requestBodies/geospatial.ip_to_geo_datasource_settings'
+      responses:
+        '200':
+          $ref: '#/components/responses/geospatial.ip_to_geo_datasource_settings@200'
+        '404':
+          $ref: '#/components/responses/geospatial.ip_to_geo_datasource_settings@404'
+
+components:
+  parameters:
+    geospatial.ip_to_geo_get_datasource::path.datasource_name:
+      name: datasource_name
+      in: path
+      required: true
+      schema:
+        type: string
+    geospatial.ip_to_geo_put_datasource::path.datasource_name:
+      name: datasource_name
+      in: path
+      required: true
+      schema:
+        type: string
+    geospatial.ip_to_geo_delete_datasource::path.datasource_name:
+      name: datasource_name
+      in: path
+      required: true
+      schema:
+        type: string
+    geospatial.ip_to_geo_datasource_settings::path.datasource_name:
+      name: datasource_name
+      in: path
+      required: true
+      schema:
+        type: string
+  requestBodies:
+    geospatial.geojson_upload_post:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoJSONRequest'
+    geospatial.geojson_upload_put:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoJSONRequest'
+    geospatial.ip_to_geo_put_datasource:
+      required: false
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/geospatial._common.yaml#/components/schemas/PutIP2GeoDataSourceRequest'
+    geospatial.ip_to_geo_datasource_settings:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/geospatial._common.yaml#/components/schemas/PutIP2GeoDataSourceRequest'
+  responses:
+    geospatial.geojson_upload_post@200:
+      description: Provides information for uploading `GeoJSON` result.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoSpatialGeojsonUploadResponse'
+    geospatial.geojson_upload_put@200:
+      description: Provides information for uploading `GeoJSON` result.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoSpatialGeojsonUploadResponse'
+    geospatial.geojson_upload_post@400:
+      description: Invalid request for uploading `GeoJSON` result.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+    geospatial.upload_stats@200:
+      description: Provides information for getting all stats for upload.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoSpatialUploadStats'
+    geospatial.ip_to_geo_get_all_datasource@200:
+      description: Provides information for getting IP2Geo data source.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/geospatial._common.yaml#/components/schemas/GetDataSourceResponse'
+    geospatial.ip_to_geo_get_datasource@200:
+      description: Provides information for getting IP2Geo data source.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/geospatial._common.yaml#/components/schemas/GetDataSourceResponse'
+    geospatial.ip_to_geo_put_datasource@200:
+      description: Provides information for deleting IP2Geo data source.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
+    geospatial.ip_to_geo_delete_datasource@200:
+      description: Provides information for deleting IP2Geo data source.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
+    geospatial.ip_to_geo_datasource_settings@200:
+      description: Acknowledged response when create, delete or update a datasource.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
+    geospatial.ip_to_geo_put_datasource@400:
+      description: Invalid request for creating a datasource.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+    geospatial.ip_to_geo_delete_datasource@404:
+      description: Invalid request for deleting a datasource.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+    geospatial.ip_to_geo_datasource_settings@404:
+      description: Invalid request for updating a datasource setting.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'

--- a/spec/namespaces/geospatial.yaml
+++ b/spec/namespaces/geospatial.yaml
@@ -35,42 +35,42 @@ paths:
           $ref: '#/components/responses/geospatial.geojson_upload_put@200'
   /_plugins/geospatial/_upload/stats:
     get:
-      operationId: geospatial.upload_stats.0
-      x-operation-group: geospatial.upload_stats
+      operationId: geospatial.get_upload_stats.0
+      x-operation-group: geospatial.get_upload_stats
       x-version-added: '2.11'
       description: Retrieves statistics for all geospatial uploads.
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.upload_stats@200'
+          $ref: '#/components/responses/geospatial.get_upload_stats@200'
 
   /_plugins/geospatial/ip2geo/datasource:
     get:
-      operationId: geospatial.ip_to_geo_get_all_datasource.0
-      x-operation-group: geospatial.ip_to_geo_get_all_datasource
+      operationId: geospatial.get_all_ip_to_geo_datasources.0
+      x-operation-group: geospatial.get_all_ip_to_geo_datasources
       x-version-added: '2.11'
       description: Get information about all IP2Geo data sources.
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/'
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.ip_to_geo_get_all_datasource@200'
+          $ref: '#/components/responses/geospatial.get_all_ip_to_geo_datasources@200'
 
   /_plugins/geospatial/ip2geo/datasource/{datasource_name}:
     get:
-      operationId: geospatial.ip_to_geo_get_datasource.0
-      x-operation-group: geospatial.ip_to_geo_get_datasource
+      operationId: geospatial.get_ip_to_geo_datasource.0
+      x-operation-group: geospatial.get_ip_to_geo_datasource
       x-version-added: '2.11'
       description: Get information for a specific IP2Geo data source.
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#sending-a-get-request'
       parameters:
-        - $ref: '#/components/parameters/geospatial.ip_to_geo_get_datasource::path.datasource_name'
+        - $ref: '#/components/parameters/geospatial.get_ip_to_geo_datasource::path.datasource_name'
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.ip_to_geo_get_datasource@200'
+          $ref: '#/components/responses/geospatial.get_ip_to_geo_datasource@200'
     put:
-      operationId: geospatial.ip_to_geo_put_datasource.0
-      x-operation-group: geospatial.ip_to_geo_put_datasource
+      operationId: geospatial.put_ip_to_geo_datasource.0
+      x-operation-group: geospatial.put_ip_to_geo_datasource
       x-version-added: '2.11'
       description: |-
         Create a specific IP2Geo data source.
@@ -80,67 +80,67 @@ paths:
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#data-source-options'
       parameters:
-        - $ref: '#/components/parameters/geospatial.ip_to_geo_put_datasource::path.datasource_name'
+        - $ref: '#/components/parameters/geospatial.put_ip_to_geo_datasource::path.datasource_name'
       requestBody:
-        $ref: '#/components/requestBodies/geospatial.ip_to_geo_put_datasource'
+        $ref: '#/components/requestBodies/geospatial.put_ip_to_geo_datasource'
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.ip_to_geo_put_datasource@200'
+          $ref: '#/components/responses/geospatial.put_ip_to_geo_datasource@200'
         '400':
-          $ref: '#/components/responses/geospatial.ip_to_geo_put_datasource@400'
+          $ref: '#/components/responses/geospatial.put_ip_to_geo_datasource@400'
     delete:
-      operationId: geospatial.ip_to_geo_delete_datasource.0
-      x-operation-group: geospatial.ip_to_geo_delete_datasource
+      operationId: geospatial.delete_ip_to_geo_datasource.0
+      x-operation-group: geospatial.delete_ip_to_geo_datasource
       x-version-added: '2.11'
       description: Delete a specific IP2Geo data source.
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#deleting-the-ip2geo-data-source'
       parameters:
-        - $ref: '#/components/parameters/geospatial.ip_to_geo_delete_datasource::path.datasource_name'
+        - $ref: '#/components/parameters/geospatial.delete_ip_to_geo_datasource::path.datasource_name'
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.ip_to_geo_delete_datasource@200'
+          $ref: '#/components/responses/geospatial.delete_ip_to_geo_datasource@200'
         '404':
-          $ref: '#/components/responses/geospatial.ip_to_geo_delete_datasource@404'
+          $ref: '#/components/responses/geospatial.delete_ip_to_geo_datasource@404'
   /_plugins/geospatial/ip2geo/datasource/{datasource_name}/_settings:
     put:
-      operationId: geospatial.ip_to_geo_datasource_settings.0
-      x-operation-group: geospatial.ip_to_geo_datasource_settings
+      operationId: geospatial.put_ip_to_geo_datasource_settings.0
+      x-operation-group: geospatial.put_ip_to_geo_datasource_settings
       x-version-added: '2.11'
       description: Update a specific IP2Geo data source.
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#updating-an-ip2geo-data-source'
       parameters:
-        - $ref: '#/components/parameters/geospatial.ip_to_geo_datasource_settings::path.datasource_name'
+        - $ref: '#/components/parameters/geospatial.put_ip_to_geo_datasource_settings::path.datasource_name'
       requestBody:
-        $ref: '#/components/requestBodies/geospatial.ip_to_geo_datasource_settings'
+        $ref: '#/components/requestBodies/geospatial.put_ip_to_geo_datasource_settings'
       responses:
         '200':
-          $ref: '#/components/responses/geospatial.ip_to_geo_datasource_settings@200'
+          $ref: '#/components/responses/geospatial.put_ip_to_geo_datasource_settings@200'
         '404':
-          $ref: '#/components/responses/geospatial.ip_to_geo_datasource_settings@404'
+          $ref: '#/components/responses/geospatial.put_ip_to_geo_datasource_settings@404'
 
 components:
   parameters:
-    geospatial.ip_to_geo_get_datasource::path.datasource_name:
+    geospatial.get_ip_to_geo_datasource::path.datasource_name:
       name: datasource_name
       in: path
       required: true
       schema:
         type: string
-    geospatial.ip_to_geo_put_datasource::path.datasource_name:
+    geospatial.put_ip_to_geo_datasource::path.datasource_name:
       name: datasource_name
       in: path
       required: true
       schema:
         type: string
-    geospatial.ip_to_geo_delete_datasource::path.datasource_name:
+    geospatial.delete_ip_to_geo_datasource::path.datasource_name:
       name: datasource_name
       in: path
       required: true
       schema:
         type: string
-    geospatial.ip_to_geo_datasource_settings::path.datasource_name:
+    geospatial.put_ip_to_geo_datasource_settings::path.datasource_name:
       name: datasource_name
       in: path
       required: true
@@ -159,13 +159,13 @@ components:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoJSONRequest'
-    geospatial.ip_to_geo_put_datasource:
+    geospatial.put_ip_to_geo_datasource:
       required: false
       content:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/PutIP2GeoDataSourceRequest'
-    geospatial.ip_to_geo_datasource_settings:
+    geospatial.put_ip_to_geo_datasource_settings:
       required: true
       content:
         application/json:
@@ -190,56 +190,56 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
-    geospatial.upload_stats@200:
+    geospatial.get_upload_stats@200:
       description: Provides information for getting all stats for upload.
       content:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoSpatialUploadStats'
-    geospatial.ip_to_geo_get_all_datasource@200:
+    geospatial.get_all_ip_to_geo_datasources@200:
       description: Provides information for getting IP2Geo data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/GetDataSourceResponse'
-    geospatial.ip_to_geo_get_datasource@200:
+    geospatial.get_ip_to_geo_datasource@200:
       description: Provides information for getting IP2Geo data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/GetDataSourceResponse'
-    geospatial.ip_to_geo_put_datasource@200:
+    geospatial.put_ip_to_geo_datasource@200:
       description: Provides information for deleting IP2Geo data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    geospatial.ip_to_geo_delete_datasource@200:
+    geospatial.delete_ip_to_geo_datasource@200:
       description: Provides information for deleting IP2Geo data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    geospatial.ip_to_geo_datasource_settings@200:
-      description: Acknowledged response when create, delete or update a datasource.
+    geospatial.put_ip_to_geo_datasource_settings@200:
+      description: Acknowledged response when create, delete or update a data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
-    geospatial.ip_to_geo_put_datasource@400:
-      description: Invalid request for creating a datasource.
+    geospatial.put_ip_to_geo_datasource@400:
+      description: Invalid request for creating a data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
-    geospatial.ip_to_geo_delete_datasource@404:
-      description: Invalid request for deleting a datasource.
+    geospatial.delete_ip_to_geo_datasource@404:
+      description: Invalid request for deleting a data source.
       content:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
-    geospatial.ip_to_geo_datasource_settings@404:
-      description: Invalid request for updating a datasource setting.
+    geospatial.put_ip_to_geo_datasource_settings@404:
+      description: Invalid request for updating a data source setting.
       content:
         application/json:
           schema:

--- a/spec/namespaces/geospatial.yaml
+++ b/spec/namespaces/geospatial.yaml
@@ -43,28 +43,16 @@ paths:
         '200':
           $ref: '#/components/responses/geospatial.get_upload_stats@200'
 
-  /_plugins/geospatial/ip2geo/datasource:
-    get:
-      operationId: geospatial.get_all_ip_to_geo_datasources.0
-      x-operation-group: geospatial.get_all_ip_to_geo_datasources
-      x-version-added: '2.11'
-      description: Get information about all IP2Geo data sources.
-      externalDocs:
-        url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/'
-      responses:
-        '200':
-          $ref: '#/components/responses/geospatial.get_all_ip_to_geo_datasources@200'
-
-  /_plugins/geospatial/ip2geo/datasource/{datasource_name}:
+  /_plugins/geospatial/ip2geo/datasource/{name}:
     get:
       operationId: geospatial.get_ip_to_geo_datasource.0
       x-operation-group: geospatial.get_ip_to_geo_datasource
       x-version-added: '2.11'
-      description: Get information for a specific IP2Geo data source.
+      description: Get one or more IP2Geo data sources, defaulting to returning all if no names specified.
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#sending-a-get-request'
       parameters:
-        - $ref: '#/components/parameters/geospatial.get_ip_to_geo_datasource::path.datasource_name'
+        - $ref: '#/components/parameters/geospatial.get_ip_to_geo_datasource::path.name'
       responses:
         '200':
           $ref: '#/components/responses/geospatial.get_ip_to_geo_datasource@200'
@@ -80,7 +68,7 @@ paths:
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#data-source-options'
       parameters:
-        - $ref: '#/components/parameters/geospatial.put_ip_to_geo_datasource::path.datasource_name'
+        - $ref: '#/components/parameters/geospatial.put_ip_to_geo_datasource::path.name'
       requestBody:
         $ref: '#/components/requestBodies/geospatial.put_ip_to_geo_datasource'
       responses:
@@ -96,13 +84,13 @@ paths:
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#deleting-the-ip2geo-data-source'
       parameters:
-        - $ref: '#/components/parameters/geospatial.delete_ip_to_geo_datasource::path.datasource_name'
+        - $ref: '#/components/parameters/geospatial.delete_ip_to_geo_datasource::path.name'
       responses:
         '200':
           $ref: '#/components/responses/geospatial.delete_ip_to_geo_datasource@200'
         '404':
           $ref: '#/components/responses/geospatial.delete_ip_to_geo_datasource@404'
-  /_plugins/geospatial/ip2geo/datasource/{datasource_name}/_settings:
+  /_plugins/geospatial/ip2geo/datasource/{name}/_settings:
     put:
       operationId: geospatial.put_ip_to_geo_datasource_settings.0
       x-operation-group: geospatial.put_ip_to_geo_datasource_settings
@@ -111,7 +99,7 @@ paths:
       externalDocs:
         url: 'https://docs.opensearch.org/docs/latest/ingest-pipelines/processors/ip2geo/#updating-an-ip2geo-data-source'
       parameters:
-        - $ref: '#/components/parameters/geospatial.put_ip_to_geo_datasource_settings::path.datasource_name'
+        - $ref: '#/components/parameters/geospatial.put_ip_to_geo_datasource_settings::path.name'
       requestBody:
         $ref: '#/components/requestBodies/geospatial.put_ip_to_geo_datasource_settings'
       responses:
@@ -122,26 +110,26 @@ paths:
 
 components:
   parameters:
-    geospatial.get_ip_to_geo_datasource::path.datasource_name:
-      name: datasource_name
+    geospatial.get_ip_to_geo_datasource::path.name:
+      name: name
+      in: path
+      required: true
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/StringOrStringArray'
+    geospatial.put_ip_to_geo_datasource::path.name:
+      name: name
       in: path
       required: true
       schema:
         type: string
-    geospatial.put_ip_to_geo_datasource::path.datasource_name:
-      name: datasource_name
+    geospatial.delete_ip_to_geo_datasource::path.name:
+      name: name
       in: path
       required: true
       schema:
         type: string
-    geospatial.delete_ip_to_geo_datasource::path.datasource_name:
-      name: datasource_name
-      in: path
-      required: true
-      schema:
-        type: string
-    geospatial.put_ip_to_geo_datasource_settings::path.datasource_name:
-      name: datasource_name
+    geospatial.put_ip_to_geo_datasource_settings::path.name:
+      name: name
       in: path
       required: true
       schema:
@@ -196,12 +184,6 @@ components:
         application/json:
           schema:
             $ref: '../schemas/geospatial._common.yaml#/components/schemas/GeoSpatialUploadStats'
-    geospatial.get_all_ip_to_geo_datasources@200:
-      description: Provides information for getting IP2Geo data source.
-      content:
-        application/json:
-          schema:
-            $ref: '../schemas/geospatial._common.yaml#/components/schemas/GetDataSourceResponse'
     geospatial.get_ip_to_geo_datasource@200:
       description: Provides information for getting IP2Geo data source.
       content:

--- a/spec/schemas/geospatial._common.yaml
+++ b/spec/schemas/geospatial._common.yaml
@@ -1,0 +1,392 @@
+openapi: 3.1.0
+info:
+  title: Schemas of `geospatial` Category
+  description: Schemas of `geospatial` category.
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    GeoSpatialGeojsonUploadResponse:
+      type: object
+      properties:
+        took:
+          $ref: '_common.yaml#/components/schemas/DurationValueUnitMillis'
+        errors:
+          type: boolean
+          description: Whether there were any errors.
+        total:
+          type: integer
+          description: Total number of features processed.
+        success:
+          type: integer
+          description: Number of features successfully uploaded.
+        failure:
+          type: integer
+          description: Number of features that failed to upload.
+      required:
+        - errors
+        - failure
+        - success
+        - took
+        - total
+    GeoSpatialUploadStats:
+      type: object
+      properties:
+        total:
+          $ref: '#/components/schemas/UploadStatsTotal'
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/UploadStatsMetric'
+      required:
+        - metrics
+        - total
+    UploadStatsTotal:
+      type: object
+      properties:
+        request_count:
+          type: integer
+          description: Total number of upload requests.
+        upload:
+          type: integer
+          description: Total number of uploads.
+        success:
+          type: integer
+          description: Total successful uploads.
+        failed:
+          type: integer
+          description: Total failed uploads.
+        duration:
+          $ref: '_common.yaml#/components/schemas/DurationValueUnitMillis'
+      required:
+        - duration
+        - failed
+        - request_count
+        - success
+        - upload
+    UploadStatsMetric:
+      type: object
+      properties:
+        node_id:
+          $ref: '_common.yaml#/components/schemas/NodeId'
+        id:
+          $ref: '_common.yaml#/components/schemas/Id'
+        type:
+          type: string
+          description: Type of upload (such as "GeoJSON").
+        upload:
+          type: integer
+          description: Number of features in this upload.
+        success:
+          type: integer
+          description: Number of successful features in this upload.
+        failed:
+          type: integer
+          description: Number of failed features in this upload.
+        duration:
+          $ref: '_common.yaml#/components/schemas/DurationValueUnitMillis'
+      required:
+        - duration
+        - failed
+        - id
+        - node_id
+        - success
+        - type
+        - upload
+    GetDataSourceResponse:
+      type: object
+      properties:
+        datasources:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataSource'
+      required:
+        - datasources
+    DataSource:
+      type: object
+      properties:
+        name:
+          $ref: '_common.yaml#/components/schemas/Name'
+        state:
+          type: string
+          enum:
+            - AVAILABLE
+            - CREATE_FAILED
+            - CREATING
+            - DELETING
+          description: State of the datasource.
+        endpoint:
+          type: string
+          description: URL endpoint for the datasource.
+        update_interval_in_days:
+          type: integer
+          description: Update interval.
+        next_update_at_in_epoch_millis:
+          $ref: '_common.yaml#/components/schemas/EpochTimeUnitMillis'
+        database:
+          type: object
+          $ref: '#/components/schemas/Database'
+        update_stats:
+          type: object
+          $ref: '#/components/schemas/UpdateStats'
+      required:
+        - database
+        - endpoint
+        - name
+        - next_update_at_in_epoch_millis
+        - state
+        - update_interval_in_days
+        - update_stats
+    Database:
+      type: object
+      properties:
+        provider:
+          type: string
+        sha256_hash:
+          type: string
+        updated_at_in_epoch_millis:
+          $ref: '_common.yaml#/components/schemas/EpochTimeUnitMillis'
+        valid_for_in_days:
+          type: integer
+        fields:
+          type: array
+          items:
+            type: string
+    UpdateStats:
+      type: object
+      properties:
+        last_succeeded_at_in_epoch_millis:
+          $ref: '_common.yaml#/components/schemas/EpochTimeUnitMillis'
+        last_processing_time_in_millis:
+          $ref: '_common.yaml#/components/schemas/EpochTimeUnitMillis'
+    PutIP2GeoDataSourceRequest:
+      type: object
+      properties:
+        endpoint:
+          type: string
+          description: URL endpoint for the datasource.
+          default: 'https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json'
+        update_interval_in_days:
+          type: integer
+          description: Update interval in days.
+          default: 3
+    GeoJSONRequest:
+      type: object
+      properties:
+        index:
+          $ref: '_common.yaml#/components/schemas/IndexName'
+        field:
+          type: string
+          default: location
+          description: Field name for the geospatial data.
+        type:
+          type: string
+          description: Field type for the geospatial data.
+          enum:
+            - geo_point
+            - geo_shape
+        data:
+          type: array
+          maxItems: 10000
+          description: Array of GeoJSON features.
+          items:
+            $ref: '#/components/schemas/GeoJSONData'
+      required:
+        - data
+        - index
+        - type
+    GeoJSONData:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - Feature
+            - FeatureCollection
+        geometry:
+          oneOf:
+            - allOf:
+                - $ref: '#/components/schemas/GeoShapes'
+                - $ref: '#/components/schemas/Point'
+            - allOf:
+                - $ref: '#/components/schemas/GeoShapes'
+                - $ref: '#/components/schemas/MultiPoint'
+            - allOf:
+                - $ref: '#/components/schemas/GeoShapes'
+                - $ref: '#/components/schemas/LineString'
+            - allOf:
+                - $ref: '#/components/schemas/GeoShapes'
+                - $ref: '#/components/schemas/MultiLineString'
+            - allOf:
+                - $ref: '#/components/schemas/GeoShapes'
+                - $ref: '#/components/schemas/Polygon'
+            - allOf:
+                - $ref: '#/components/schemas/GeoShapes'
+                - $ref: '#/components/schemas/MultiPolygon'
+            - allOf:
+                - $ref: '#/components/schemas/GeoShapes'
+                - $ref: '#/components/schemas/GeometryCollection'
+            - allOf:
+                - $ref: '#/components/schemas/GeoShapes'
+                - $ref: '#/components/schemas/Envelope'
+        properties:
+          type: object
+      required:
+        - geometry
+        - type
+    GeoShapes:
+      oneOf:
+        - $ref: '#/components/schemas/Point'
+        - $ref: '#/components/schemas/MultiPoint'
+        - $ref: '#/components/schemas/LineString'
+        - $ref: '#/components/schemas/MultiLineString'
+        - $ref: '#/components/schemas/Polygon'
+        - $ref: '#/components/schemas/MultiPolygon'
+        - $ref: '#/components/schemas/Envelope'
+      description: |-
+        GeoJSON `geoshape` types supported by OpenSearch.
+        For more details, see: https://docs.opensearch.org/docs/latest/field-types/supported-field-types/geo-shape.
+    Geometry:
+      oneOf:
+        - $ref: '#/components/schemas/GeoShapes'
+        - $ref: '#/components/schemas/GeometryCollection'
+    Point:
+      type: object
+      required:
+        - coordinates
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - Point
+        coordinates:
+          $ref: '#/components/schemas/PointCoordinates'
+    MultiPoint:
+      type: object
+      required:
+        - coordinates
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPoint
+        coordinates:
+          $ref: '#/components/schemas/MultiPointCoordinates'
+    LineString:
+      type: object
+      required:
+        - coordinates
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - LineString
+        coordinates:
+          $ref: '#/components/schemas/LineStringCoordinates'
+    MultiLineString:
+      type: object
+      required:
+        - coordinates
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiLineString
+        coordinates:
+          $ref: '#/components/schemas/MultiLineStringCoordinates'
+    Polygon:
+      type: object
+      required:
+        - coordinates
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - Polygon
+        coordinates:
+          $ref: '#/components/schemas/PolygonCoordinates'
+    MultiPolygon:
+      type: object
+      required:
+        - coordinates
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPolygon
+        coordinates:
+          $ref: '#/components/schemas/MultiPolygonCoordinates'
+    Envelope:
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        $ref: '#/components/schemas/PointCoordinates'
+      description: |-
+        An envelope specified by upper-left and lower-right points
+        [[minLon, maxLat], [maxLon, minLat]].
+    GeometryCollection:
+      type: object
+      required:
+        - geometries
+        - type
+      properties:
+        type:
+          type: string
+          enum: [GeometryCollection]
+        geometries:
+          type: array
+          maxItems: 100
+          description: Array of geometry objects.
+          items:
+            $ref: '#/components/schemas/Geometry'
+    PointCoordinates:
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        type: number
+        minimum: -180
+        maximum: 180
+      description: |-
+        A Point coordinates array [longitude, latitude].
+        - longitude must be between -180 and 180
+        - latitude must be between -90 and 90.
+    MultiPointCoordinates:
+      type: array
+      items:
+        $ref: '#/components/schemas/PointCoordinates'
+      description: An array of Point coordinates.
+    LineStringCoordinates:
+      type: array
+      minItems: 2
+      items:
+        $ref: '#/components/schemas/PointCoordinates'
+      description: An array of Point coordinates forming a line.
+    MultiLineStringCoordinates:
+      type: array
+      items:
+        $ref: '#/components/schemas/LineStringCoordinates'
+      description: An array of LineString coordinates.
+    PolygonCoordinates:
+      type: array
+      items:
+        type: array
+        items:
+          $ref: '#/components/schemas/PointCoordinates'
+        minItems: 4
+      description: |-
+        An array of linear ring coordinate arrays.
+        - First and last points must be the same to close the polygon
+        - Minimum 4 points required (first and last being the same).
+    MultiPolygonCoordinates:
+      type: array
+      items:
+        $ref: '#/components/schemas/PolygonCoordinates'
+      description: An array of Polygon coordinates.

--- a/spec/schemas/geospatial._common.yaml
+++ b/spec/schemas/geospatial._common.yaml
@@ -114,10 +114,10 @@ components:
             - CREATE_FAILED
             - CREATING
             - DELETING
-          description: State of the datasource.
+          description: State of the data source.
         endpoint:
           type: string
-          description: URL endpoint for the datasource.
+          description: URL endpoint for the data source.
         update_interval_in_days:
           type: integer
           description: Update interval.
@@ -164,7 +164,7 @@ components:
       properties:
         endpoint:
           type: string
-          description: URL endpoint for the datasource.
+          description: URL endpoint for the data source.
           default: 'https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json'
         update_interval_in_days:
           type: integer
@@ -204,31 +204,7 @@ components:
             - Feature
             - FeatureCollection
         geometry:
-          oneOf:
-            - allOf:
-                - $ref: '#/components/schemas/GeoShapes'
-                - $ref: '#/components/schemas/Point'
-            - allOf:
-                - $ref: '#/components/schemas/GeoShapes'
-                - $ref: '#/components/schemas/MultiPoint'
-            - allOf:
-                - $ref: '#/components/schemas/GeoShapes'
-                - $ref: '#/components/schemas/LineString'
-            - allOf:
-                - $ref: '#/components/schemas/GeoShapes'
-                - $ref: '#/components/schemas/MultiLineString'
-            - allOf:
-                - $ref: '#/components/schemas/GeoShapes'
-                - $ref: '#/components/schemas/Polygon'
-            - allOf:
-                - $ref: '#/components/schemas/GeoShapes'
-                - $ref: '#/components/schemas/MultiPolygon'
-            - allOf:
-                - $ref: '#/components/schemas/GeoShapes'
-                - $ref: '#/components/schemas/GeometryCollection'
-            - allOf:
-                - $ref: '#/components/schemas/GeoShapes'
-                - $ref: '#/components/schemas/Envelope'
+          $ref: '#/components/schemas/Geometry'
         properties:
           type: object
       required:
@@ -330,7 +306,7 @@ components:
         $ref: '#/components/schemas/PointCoordinates'
       description: |-
         An envelope specified by upper-left and lower-right points
-        [[minLon, maxLat], [maxLon, minLat]].
+        [[`minLon`, `maxLat`], [`maxLon`, `minLat`]].
     GeometryCollection:
       type: object
       required:
@@ -339,7 +315,8 @@ components:
       properties:
         type:
           type: string
-          enum: [GeometryCollection]
+          enum:
+            - GeometryCollection
         geometries:
           type: array
           maxItems: 100

--- a/tests/default/geospatial/geojson/upload.yaml
+++ b/tests/default/geospatial/geojson/upload.yaml
@@ -1,0 +1,93 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test the API endpoints of geospatial plugin.
+version: '>= 2.11'
+prologues: []
+epilogues:
+  - path: /national_parks
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Successfully upload geojson to a non-exist index via POST.
+    path: /_plugins/geospatial/geojson/_upload
+    method: POST
+    request:
+      payload:
+        index: national_parks
+        field: boundary
+        type: geo_shape
+        data: 
+          - type: Feature
+            geometry: 
+              type: Polygon
+              coordinates: 
+                - 
+                  - [0,100]
+                  - [0,101]
+                  - [1,101]
+                  - [1,100]
+                  - [0,100]
+            properties:
+              name: Yosemite Valley
+              type: National Park
+              state: California
+          - type: Feature
+            geometry: 
+              type: LineString
+              coordinates: 
+                - [6,106]
+                - [6.1,106.1]
+                - [6.2,106.2]
+                - [6.3,106.3]
+            properties:
+              name: Grand Canyon Trail
+              type: Hiking Trail
+              difficulty: Moderate
+    response:
+      status: 200
+  - synopsis: Upload geojson to an exist index via POST.
+    path: /_plugins/geospatial/geojson/_upload
+    method: POST
+    request:
+      payload:
+        index: national_parks
+        field: boundary
+        type: geo_shape
+        data: 
+          - type: Feature
+            geometry: 
+              type: LineString
+              coordinates: 
+                - [6,106]
+                - [6.1,106.1]
+                - [6.2,106.2]
+                - [6.3,106.3]
+            properties:
+              name: Grand Canyon Trail
+              type: Hiking Trail
+              difficulty: Moderate
+    response:
+      status: 400
+  - synopsis: Upload geojson to an exist index via PUT.
+    path: /_plugins/geospatial/geojson/_upload
+    method: PUT
+    request:
+      payload:
+        index: national_parks
+        field: boundary
+        type: geo_shape
+        data: 
+          - type: Feature
+            geometry: 
+              type: LineString
+              coordinates: 
+                - [6,106]
+                - [6.1,106.1]
+                - [6.2,106.2]
+                - [6.3,106.3]
+            properties:
+              name: Grand Canyon Trail
+              type: Hiking Trail
+              difficulty: Moderate
+    response:
+      status: 200

--- a/tests/default/geospatial/ip2geo/datasource.yaml
+++ b/tests/default/geospatial/ip2geo/datasource.yaml
@@ -44,10 +44,8 @@ chapters:
     response:
       status: 200
   - synopsis: Get all datasources.
-    path: /_plugins/geospatial/ip2geo/datasource/{name}
+    path: /_plugins/geospatial/ip2geo/datasource
     method: GET
-    parameters:
-      name: []
     response:
       status: 200
   - synopsis: Delete a specific datasource.

--- a/tests/default/geospatial/ip2geo/datasource.yaml
+++ b/tests/default/geospatial/ip2geo/datasource.yaml
@@ -15,10 +15,10 @@ epilogues:
     status: [200, 404]
 chapters:
   - synopsis: Create a new specific datasource.
-    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    path: /_plugins/geospatial/ip2geo/datasource/{name}
     method: PUT
     parameters:
-      datasource_name: my-datasource
+      name: my-datasource
     request:
       payload:
         endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
@@ -26,10 +26,10 @@ chapters:
     response:
       status: 200
   - synopsis: Create an already exist datasource.
-    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    path: /_plugins/geospatial/ip2geo/datasource/{name}
     method: PUT
     parameters:
-      datasource_name: my-datasource
+      name: my-datasource
     request:
       payload:
         endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
@@ -37,31 +37,33 @@ chapters:
     response:
       status: 400
   - synopsis: Get a specific datasource.
-    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    path: /_plugins/geospatial/ip2geo/datasource/{name}
     method: GET
     parameters:
-      datasource_name: my-datasource
+      name: my-datasource
     response:
       status: 200
   - synopsis: Get all datasources.
-    path: /_plugins/geospatial/ip2geo/datasource
+    path: /_plugins/geospatial/ip2geo/datasource/{name}
     method: GET
+    parameters:
+      name: []
     response:
       status: 200
   - synopsis: Delete a specific datasource.
-    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    path: /_plugins/geospatial/ip2geo/datasource/{name}
     method: DELETE
     parameters:
-      datasource_name: my-datasource
+      name: my-datasource
     response:
       status: 200
     retry:
       count: 5
       wait: 30000
   - synopsis: Delete a non exist datasource.
-    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    path: /_plugins/geospatial/ip2geo/datasource/{name}
     method: DELETE
     parameters:
-      datasource_name: no-exist-datasource
+      name: no-exist-datasource
     response:
       status: 404

--- a/tests/default/geospatial/ip2geo/datasource.yaml
+++ b/tests/default/geospatial/ip2geo/datasource.yaml
@@ -1,0 +1,67 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test the API endpoints of geospatial plugin.
+version: '>= 2.11'
+prologues:
+  - path: _plugins/geospatial/ip2geo/datasource/my-datasource
+    method: DELETE
+    status: [200, 404]
+  - path: _plugins/geospatial/ip2geo/datasource/no-exist-datasource
+    method: DELETE
+    status: [200, 404]
+epilogues:
+  - path: _plugins/geospatial/ip2geo/datasource/my-datasource
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create a new specific datasource.
+    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    method: PUT
+    parameters:
+      datasource_name: my-datasource
+    request:
+      payload:
+        endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
+        update_interval_in_days: 5
+    response:
+      status: 200
+  - synopsis: Create an already exist datasource.
+    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    method: PUT
+    parameters:
+      datasource_name: my-datasource
+    request:
+      payload:
+        endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
+        update_interval_in_days: 5
+    response:
+      status: 400
+  - synopsis: Get a specific datasource.
+    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    method: GET
+    parameters:
+      datasource_name: my-datasource
+    response:
+      status: 200
+  - synopsis: Get all datasources.
+    path: /_plugins/geospatial/ip2geo/datasource
+    method: GET
+    response:
+      status: 200
+  - synopsis: Delete a specific datasource.
+    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    method: DELETE
+    parameters:
+      datasource_name: my-datasource
+    response:
+      status: 200
+    retry:
+      count: 5
+      wait: 30000
+  - synopsis: Delete a non exist datasource.
+    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    method: DELETE
+    parameters:
+      datasource_name: no-exist-datasource
+    response:
+      status: 404

--- a/tests/default/geospatial/ip2geo/datasource/settings.yaml
+++ b/tests/default/geospatial/ip2geo/datasource/settings.yaml
@@ -3,10 +3,10 @@ $schema: ../../../../../json_schemas/test_story.schema.yaml
 description: Test the API endpoints of geospatial plugin.
 version: '>= 2.11'
 prologues:
-  - path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+  - path: /_plugins/geospatial/ip2geo/datasource/{name}
     method: PUT
     parameters:
-      datasource_name: my-datasource1
+      name: my-datasource1
     request:
       payload:
         endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
@@ -22,10 +22,10 @@ epilogues:
     status: [200, 404]
 chapters:
   - synopsis: Update a specific datasource setting.
-    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}/_settings
+    path: /_plugins/geospatial/ip2geo/datasource/{name}/_settings
     method: PUT
     parameters:
-      datasource_name: my-datasource1
+      name: my-datasource1
     request:
       payload:
         endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
@@ -36,10 +36,10 @@ chapters:
       count: 5
       wait: 30000
   - synopsis: Update a not exist datasource setting.
-    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}/_settings
+    path: /_plugins/geospatial/ip2geo/datasource/{name}/_settings
     method: PUT
     parameters:
-      datasource_name: no-exist-datasource1
+      name: no-exist-datasource1
     request:
       payload:
         endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json

--- a/tests/default/geospatial/ip2geo/datasource/settings.yaml
+++ b/tests/default/geospatial/ip2geo/datasource/settings.yaml
@@ -1,0 +1,48 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the API endpoints of geospatial plugin.
+version: '>= 2.11'
+prologues:
+  - path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}
+    method: PUT
+    parameters:
+      datasource_name: my-datasource1
+    request:
+      payload:
+        endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
+        update_interval_in_days: 5
+    response:
+      status: 200
+  - path: _plugins/geospatial/ip2geo/datasource/no-exist-datasource1
+    method: DELETE
+    status: [200, 404]
+epilogues:
+  - path: _plugins/geospatial/ip2geo/datasource/my-datasource1
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Update a specific datasource setting.
+    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}/_settings
+    method: PUT
+    parameters:
+      datasource_name: my-datasource1
+    request:
+      payload:
+        endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
+        update_interval_in_days: 10
+    response:
+      status: 200
+    retry:
+      count: 5
+      wait: 30000
+  - synopsis: Update a not exist datasource setting.
+    path: /_plugins/geospatial/ip2geo/datasource/{datasource_name}/_settings
+    method: PUT
+    parameters:
+      datasource_name: no-exist-datasource1
+    request:
+      payload:
+        endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
+        update_interval_in_days: 10
+    response:
+      status: 404

--- a/tests/default/geospatial/upload/stats.yaml
+++ b/tests/default/geospatial/upload/stats.yaml
@@ -1,0 +1,11 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test the API endpoints of geospatial plugin.
+version: '>= 2.11'
+chapters:
+  - synopsis: Get all geospatial upload stats.
+    path: /_plugins/geospatial/_upload/stats
+    method: GET
+    response:
+      status: 200
+

--- a/tools/src/linter/components/Operation.ts
+++ b/tools/src/linter/components/Operation.ts
@@ -11,7 +11,7 @@ import { type OperationSpec, type ValidationError } from 'types'
 import _ from 'lodash'
 import ValidatorBase from './base/ValidatorBase'
 
-const GROUP_REGEX = /^([a-z]+[a-z_]*[a-z]+\.)?([a-z]+[a-z_]*[a-z]+)$/
+const GROUP_REGEX = /^([a-z]+[a-z_]*[a-z]+\.)?([a-z]+[a-z0-9_]*[a-z0-9]+)$/
 
 export default class Operation extends ValidatorBase {
   path: string

--- a/tools/tests/linter/Operation.test.ts
+++ b/tools/tests/linter/Operation.test.ts
@@ -19,11 +19,11 @@ test('validate_group()', () => {
 
   const invalid_group = operation({ 'x-operation-group': 'indices_' })
   expect(invalid_group.validate_group())
-    .toEqual(invalid_group.error('Invalid x-operation-group \'indices_\'. Must match regex: /^([a-z]+[a-z_]*[a-z]+\\.)?([a-z]+[a-z_]*[a-z]+)$/.'))
+    .toEqual(invalid_group.error('Invalid x-operation-group \'indices_\'. Must match regex: /^([a-z]+[a-z_]*[a-z]+\\.)?([a-z]+[a-z0-9_]*[a-z0-9]+)$/.'))
 
   const invalid_action = operation({ 'x-operation-group': 'indices.create.index' })
   expect(invalid_action.validate_group())
-    .toEqual(invalid_action.error('Invalid x-operation-group \'indices.create.index\'. Must match regex: /^([a-z]+[a-z_]*[a-z]+\\.)?([a-z]+[a-z_]*[a-z]+)$/.'))
+    .toEqual(invalid_action.error('Invalid x-operation-group \'indices.create.index\'. Must match regex: /^([a-z]+[a-z_]*[a-z]+\\.)?([a-z]+[a-z0-9_]*[a-z0-9]+)$/.'))
 
   const valid_group = operation({ 'x-operation-group': 'indices.create' })
   expect(valid_group.validate_group())


### PR DESCRIPTION
### Description
This PR adds API Spec for [geospatial plugin](https://github.com/opensearch-project/geospatial)

### Tests
```
npm run test:spec -- --opensearch-insecure  --tests tests/default/geospatial 

> opensearch_api_tools@1.0.0 test:spec
> ts-node tools/src/tester/test.ts --opensearch-insecure --tests tests/default/geospatial

OpenSearch 2.19.0

PASSED  geojson/upload.yaml (tests/default/geospatial/geojson/upload.yaml)
PASSED  ip2geo/datasource.yaml (tests/default/geospatial/ip2geo/datasource.yaml)
PASSED  upload/stats.yaml (tests/default/geospatial/upload/stats.yaml)
PASSED  ip2geo/datasource/settings.yaml (tests/default/geospatial/ip2geo/datasource/settings.yaml)

Tested 8/611 paths.


```

```
npm run lint:spec

> opensearch_api_tools@1.0.0 lint:spec
> ts-node tools/src/linter/lint.ts

Validating /Users/zweijia/IdeaProjects/opensearch-api-specification/spec ...
No errors found.
```

### Issues Resolved
Closes [#238](https://github.com/opensearch-project/opensearch-api-specification/issues/238)
Closes https://github.com/opensearch-project/geospatial/issues/658 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
