### PR TITLE
Introducing the score ranker processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `search_only` to `IndexSettingBlocks` ([#883](https://github.com/opensearch-project/opensearch-api-specification/pull/883))
 - Added `searchOnly` to `NodeShard` ([#883](https://github.com/opensearch-project/opensearch-api-specification/pull/883))
 - Added `GET /_plugins/_neural/stats` ([#850](https://github.com/opensearch-project/opensearch-api-specification/pull/850))
-- Added `ToolAttributes` to `ml._common.yaml` ([#878](https://github.com/opensearch-project/opensearch-api-specification/pull/878)) 
+- Added `ToolAttributes` to `ml._common.yaml` ([#878](https://github.com/opensearch-project/opensearch-api-specification/pull/878))
 - Added `GET _plugins/geospatial/_upload/stats`, `PUT`, `POST _plugins/geospatial/geojson/_upload`, `GET _plugins/geospatial/ip2geo/datasource`, `GET`, `PUT`, `DELETE _plugins/geospatial/ip2geo/datasource/{name}` and `PUT _plugins/geospatial/ip2geo/datasource/{name}/_settings` ([#893](https://github.com/opensearch-project/opensearch-api-specification/pull/893))
+- Added schemas for the score ranker search processor ([#899](https://github.com/opensearch-project/opensearch-api-specification/pull/899))
 
 ### Removed
 - Removed unsupported `_common.mapping:SourceField`'s `mode` field and associated `_common.mapping:SourceFieldMode` enum ([#652](https://github.com/opensearch-project/opensearch-api-specification/pull/652))

--- a/spec/schemas/search_pipeline._common.yaml
+++ b/spec/schemas/search_pipeline._common.yaml
@@ -339,6 +339,13 @@ components:
               $ref: '#/components/schemas/NormalizationPhaseResultsProcessor'
           required:
             - normalization-processor
+        - type: object
+          title: score-ranker-processor
+          properties:
+            score-ranker-processor:
+              $ref: '#/components/schemas/ScoreRankerPhaseResultsProcessor'
+          required:
+            - score-ranker-processor
     NormalizationPhaseResultsProcessor:
       type: object
       properties:
@@ -383,3 +390,25 @@ components:
         - arithmetic_mean
         - geometric_mean
         - harmonic_mean
+    ScoreRankerPhaseResultsProcessor:
+      type: object
+      properties:
+        combination:
+          $ref: '#/components/schemas/ScoreRankerCombination'
+      required:
+        - combination
+    ScoreRankerCombination:
+      type: object
+      properties:
+        technique:
+          $ref: '#/components/schemas/ScoreRankerCombinationTechnique'
+        rank_constant:
+          type: integer
+          format: int32
+          minimum: 1
+      required:
+        - technique
+    ScoreRankerCombinationTechnique:
+      type: string
+      enum:
+        - rrf

--- a/tests/default/search_pipeline/search_phase_results_processors/score_ranker.yaml
+++ b/tests/default/search_pipeline/search_phase_results_processors/score_ranker.yaml
@@ -1,0 +1,42 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test search pipeline endpoints with score ranker processors.
+
+version: '>=2.19'
+
+prologues: []
+
+epilogues:
+  - path: /_search/pipeline/{id}
+    parameters:
+      id: spec-test-score-ranker-pipeline
+    method: DELETE
+    status: [200, 404]
+
+chapters:
+  - synopsis: Create a pipeline with a score ranker processor.
+    path: /_search/pipeline/{id}
+    method: PUT
+    parameters:
+      id: spec-test-score-ranker-pipeline
+    request:
+      payload:
+        description: Example pipeline for testing the pipeline endpoints as used with hybrid queries.
+        phase_results_processors:
+          - score-ranker-processor:
+              combination:
+                technique: rrf
+                rank_constant: 40
+  - synopsis: Get all search pipelines.
+    method: GET
+    path: /_search/pipeline
+    response:
+      status: 200
+      payload:
+        spec-test-score-ranker-pipeline:
+          description: Example pipeline for testing the pipeline endpoints as used with hybrid queries.
+          phase_results_processors:
+            - score-ranker-processor:
+                combination:
+                  technique: rrf
+                  rank_constant: 40


### PR DESCRIPTION
### Description
The [score ranker processor](https://docs.opensearch.org/docs/latest/search-plugins/search-pipelines/score-ranker-processor/) that was introduced in OpenSearch 2.19 is not yet supported/defined. Only the [normalization processor](https://github.com/opensearch-project/opensearch-java/blob/2.x/java-client/src/generated/java/org/opensearch/client/opensearch/search_pipeline/PhaseResultsProcessor.java) is supported. This PR introduces the score ranker processor into the specification.

### Issues Resolved
- opensearch-project/opensearch-java#1547

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
