### PR TITLE
Fix code bug for NeuralStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Changed `DistanceFeatureQuery` and `RangeQuery` from (allOf + oneOf) to (oneOf + allOf) ([#865](https://github.com/opensearch-project/opensearch-api-specification/pull/865))
 - Changed `ClusterJvm.versions`, `ClusterOperatingSystemName.name` and `ClusterOperatingSystemPrettyName.pretty_name` to not be required as AOS does not return them ([#866](https://github.com/opensearch-project/opensearch-api-specification/pull/866))
 - Changed `ScriptedMetricAggregate` value from true to {} ([#892](https://github.com/opensearch-project/opensearch-api-specification/pull/892))
+- Changed `NeuralStats` schema validation from `oneOf` to `anyOf` ([#900](https://github.com/opensearch-project/opensearch-api-specification/pull/900))
 
 ## [0.1.0] - 2024-10-25
 

--- a/spec/schemas/neural._common.yaml
+++ b/spec/schemas/neural._common.yaml
@@ -7,7 +7,7 @@ paths: {}
 components:
   schemas:
     NeuralStats:
-      oneOf:
+      anyOf:
         - $ref: '#/components/schemas/NestedNeuralStats'
         - $ref: '#/components/schemas/FlatNeuralStats'
     # Separate schemas for flattened vs unflattened


### PR DESCRIPTION
### Description
There's a code bug in the `NeuralStats` schema, the object should be `anyOf` `NestedNeuralStats` and `FlatNeuralStats`, instead of `oneOf`.

### Issues Resolved
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
