### PR TITLE
adding ID to mtermvector api spec

### DIFF
--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -1711,6 +1711,7 @@ paths:
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
+        - $ref: '#/components/parameters/mtermvectors::path.id'
         - $ref: '#/components/parameters/mtermvectors::path.index'
         - $ref: '#/components/parameters/mtermvectors::query.field_statistics'
         - $ref: '#/components/parameters/mtermvectors::query.fields'
@@ -1737,6 +1738,7 @@ paths:
       externalDocs:
         url: https://opensearch.org/docs/latest
       parameters:
+        - $ref: '#/components/parameters/mtermvectors::path.id'
         - $ref: '#/components/parameters/mtermvectors::path.index'
         - $ref: '#/components/parameters/mtermvectors::query.field_statistics'
         - $ref: '#/components/parameters/mtermvectors::query.fields'
@@ -5071,6 +5073,14 @@ components:
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+      style: simple
+    mtermvectors::path.id:
+      in: path
+      name: id
+      description: Unique identifier of the document.
+      required: true
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/Id'
       style: simple
     mtermvectors::query.field_statistics:
       in: query

--- a/tests/default/_core/mtermvectors.yaml
+++ b/tests/default/_core/mtermvectors.yaml
@@ -1,6 +1,6 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
-description: Test _mtermvectors APIs.
+description: Test _mtermvectors and _termvectors APIs.
 prologues:
   - path: /books
     method: PUT
@@ -14,7 +14,7 @@ prologues:
               term_vector: yes
               type: text
             year:
-              type: integer     
+              type: integer
   - path: /_bulk
     method: POST
     parameters:
@@ -32,7 +32,7 @@ epilogues:
     status: [200, 404]
 
 chapters:
-  - synopsis: Retrieve term vectors for specific documents.
+  - synopsis: Retrieve term vectors for specific documents using _mtermvectors.
     path: /_mtermvectors
     method:
       - GET
@@ -42,3 +42,27 @@ chapters:
         docs:
           - _id: book1
             _index: books
+          - _id: book2
+            _index: books
+    response:
+      status: 200
+
+  - synopsis: Retrieve term vectors for a document using GET /{index}/_termvectors/{id}.
+    path: /{index}/_termvectors/{id}
+    method: GET
+    parameters:
+      index: books
+      id: book1
+      fields: title
+    response:
+      status: 200
+
+  - synopsis: Retrieve term vectors for a document using POST /{index}/_termvectors/{id}.
+    path: /{index}/_termvectors/{id}
+    method: POST
+    parameters:
+      index: books
+      id: book2
+    response:
+      status: 200
+


### PR DESCRIPTION
### Description
adding ID to mtermvector api spec

Further details:

When using below code to generate API docs:

```
<!-- spec_insert_start
api: mtermvectors
component: path_parameters
include_global: false
include_deprecated: false
pretty: false
-->
```

The only produced value is:

```
| Parameter | Data type | Description |
| :--- | :--- | :--- |
| `index` | String | Name of the index that contains the documents. |
```

Missing the 'id' part below:

```
| `id` | String | Unique identifier of the document. |
```

This change, together with the appropriate test ensures that this is rectified going forward.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
