### PR TITLE
Add specs for alert and finding endpoints of security_analytics plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+
+- Added specs for alert and finding endpoints of security_analytics plugin ([#907](https://github.com/opensearch-project/opensearch-api-specification/pull/907))
 - Added `template` to `QueryContainer` ([#904](https://github.com/opensearch-project/opensearch-api-specification/pull/904))
 - Added specs for Search Relevance Workbench plugin for stats endpoints ([#920](https://github.com/opensearch-project/opensearch-api-specification/pull/920))
 - Added `time_in_execution` and `time_in_execution_millis` to `PendingTask` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))

--- a/spec/namespaces/security_analytics.yaml
+++ b/spec/namespaces/security_analytics.yaml
@@ -86,13 +86,13 @@ components:
     security_analytics.get_alerts::query.detector_id:
       name: detector_id
       in: query
-      description: The ID of the detector used to fetch alerts. Optional when detectorType is specified. Otherwise required.
+      description: The ID of the detector used to fetch alerts. Optional when `detectorType` is specified. Otherwise required.
       schema:
         type: string
     security_analytics.get_alerts::query.detectorType:
       name: detectorType
       in: query
-      description: The type of detector used to fetch alerts. Optional when detector_id is specified. Otherwise required.
+      description: The type of detector used to fetch alerts. Optional when `detector_id` is specified. Otherwise required.
       schema:
         type: string
     security_analytics.get_alerts::query.severityLevel:
@@ -107,8 +107,7 @@ components:
       in: query
       description: Used to filter by alert state. Optional.
       schema:
-        type: string
-        enum: [ACKNOWLEDGED,ACTIVE, COMPLETED, DELETED, ERROR]
+        $ref: '../schemas/security_analytics.alerts.yaml#/components/schemas/AlertState'
       required: false
     security_analytics.get_alerts::query.sortString:
       name: sortString
@@ -122,8 +121,7 @@ components:
       in: query
       description: The order used to sort the list of findings. Possible values are asc or desc. Optional.
       schema:
-        type: string
-        enum: [asc, desc]
+        $ref: '../schemas/_common.yaml#/components/schemas/SortOrder'
       required: false
     security_analytics.get_alerts::query.missing:
       name: missing
@@ -160,13 +158,13 @@ components:
     security_analytics.get_findings::query.detector_id:
       name: detector_id
       in: query
-      description: The ID of the detector used to fetch alerts. Optional when the detectorType is specified. Otherwise required.
+      description: The ID of the detector used to fetch alerts. Optional when the `detectorType` is specified. Otherwise required.
       schema:
         type: string
     security_analytics.get_findings::query.detectorType:
       name: detectorType
       in: query
-      description: The type of detector used to fetch alerts. Optional when the detector_id is specified. Otherwise required.
+      description: The type of detector used to fetch alerts. Optional when the `detector_id` is specified. Otherwise required.
       schema:
         type: string
     security_analytics.get_findings::query.sortOrder:
@@ -174,8 +172,7 @@ components:
       in: query
       description: The order used to sort the list of findings. Possible values are asc or desc. Optional.
       schema:
-        type: string
-        enum: [asc, desc]
+        $ref: '../schemas/_common.yaml#/components/schemas/SortOrder'
       required: false
     security_analytics.get_findings::query.size:
       name: size
@@ -203,10 +200,9 @@ components:
     security_analytics.get_findings::query.severity:
       name: severity
       in: query
-      description: The severity of the detector rule used to fetch alerts. Severity can be critical, high, medium, or low. Optional.
+      description: The severity for which to retrieve findings. Severity can be critical, high, medium, or low. Optional.
       schema:
-        type: string
-        enum: [critical,high,low, medium]
+        $ref: '../schemas/security_analytics.findings.yaml#/components/schemas/Severity'
       required: false
     security_analytics.search_finding_correlations::query.finding:
       name: finding

--- a/spec/namespaces/security_analytics.yaml
+++ b/spec/namespaces/security_analytics.yaml
@@ -1,0 +1,238 @@
+openapi: 3.1.0
+info:
+  title: OpenSearch Security Analytics API
+  description: OpenSearch Security Analytics API.
+  version: 1.0.0
+paths:
+  /_plugins/_security_analytics/alerts:
+    get:
+      operationId: security_analytics.get_alerts.0
+      x-operation-group: security_analytics.get_alerts
+      x-version-added: '2.4'
+      description: Retrieve alerts related to a specific detector type or detector ID.
+      externalDocs:
+        url: https://docs.opensearch.org/docs/latest/security-analytics/api-tools/alert-finding-api/#get-alerts
+      parameters:
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.alertState'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.detectorType'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.detector_id'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.missing'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.searchString'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.severityLevel'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.size'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.sortOrder'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.sortString'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.startIndex'
+      responses:
+        '200':
+          $ref: '#/components/responses/security_analytics.get_alerts@200'
+  
+  /_plugins/_security_analytics/findings/_search:
+    get:
+      operationId: security_analytics.get_findings.0
+      x-operation-group: security_analytics.get_findings
+      x-version-added: '2.4'
+      description: Retrieve findings related to a specific detector type or detector ID.
+      externalDocs:
+        url: https://docs.opensearch.org/docs/latest/security-analytics/api-tools/alert-finding-api/#get-findings
+      parameters:
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.detectionType'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.detectorType'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.detector_id'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.severity'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.size'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.sortOrder'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.startIndex'
+      responses:
+        '200':
+          $ref: '#/components/responses/security_analytics.get_findings@200'
+
+  /_plugins/_security_analytics/findings/correlate:
+    get:
+      operationId: security_analytics.search_finding_correlations.0
+      x-operation-group: security_analytics.search_finding_correlations
+      x-version-added: '2.7'
+      description: List correlations for a finding.
+      externalDocs:
+        url: https://docs.opensearch.org/docs/latest/security-analytics/api-tools/correlation-eng/#list-correlations-for-a-finding-belonging-to-a-log-type
+      parameters:
+        - $ref: '#/components/parameters/security_analytics.search_finding_correlations::query.detector_type'
+        - $ref: '#/components/parameters/security_analytics.search_finding_correlations::query.finding'
+        - $ref: '#/components/parameters/security_analytics.search_finding_correlations::query.nearby_findings'
+        - $ref: '#/components/parameters/security_analytics.search_finding_correlations::query.time_window'
+      responses:
+        '200':
+          $ref: '#/components/responses/security_analytics.search_finding_correlations@200'
+
+components:
+  responses:
+    security_analytics.get_alerts@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/security_analytics.alerts.yaml#/components/schemas/GetAlertsResponse'
+    security_analytics.get_findings@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/security_analytics.findings.yaml#/components/schemas/GetFindingsResponse'
+    security_analytics.search_finding_correlations@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/security_analytics.findings.yaml#/components/schemas/SearchFindingCorrelationsResponse'
+
+  parameters:
+    security_analytics.get_alerts::query.detector_id:
+      name: detector_id
+      in: query
+      description: The ID of the detector used to fetch alerts. Optional when detectorType is specified. Otherwise required.
+      schema:
+        type: string
+    security_analytics.get_alerts::query.detectorType:
+      name: detectorType
+      in: query
+      description: The type of detector used to fetch alerts. Optional when detector_id is specified. Otherwise required.
+      schema:
+        type: string
+    security_analytics.get_alerts::query.severityLevel:
+      name: severityLevel
+      in: query
+      description: Used to filter by alert severity level. Optional.
+      schema:
+        type: string
+      required: false
+    security_analytics.get_alerts::query.alertState:
+      name: alertState
+      in: query
+      description: Used to filter by alert state. Optional.
+      schema:
+        type: string
+        enum: [ACKNOWLEDGED,ACTIVE, COMPLETED, DELETED, ERROR]
+      required: false
+    security_analytics.get_alerts::query.sortString:
+      name: sortString
+      in: query
+      description: Specifies which string Security Analytics uses to sort the alerts. Optional.
+      schema:
+        type: string
+      required: false
+    security_analytics.get_alerts::query.sortOrder:
+      name: sortOrder
+      in: query
+      description: The order used to sort the list of findings. Possible values are asc or desc. Optional.
+      schema:
+        type: string
+        enum: [asc, desc]
+      required: false
+    security_analytics.get_alerts::query.missing:
+      name: missing
+      in: query
+      description: A list of fields for which there are no found alias mappings. Optional.
+      schema:
+        type: array
+        items:
+          type: string
+      required: false
+    security_analytics.get_alerts::query.size:
+      name: size
+      in: query
+      description: The maximum number of results returned in the response. Optional.
+      schema:
+        type: integer
+        format: int64
+      required: false
+    security_analytics.get_alerts::query.startIndex:
+      name: startIndex
+      in: query
+      description: The pagination index. Optional.
+      schema:
+        type: integer
+        format: int64
+      required: false
+    security_analytics.get_alerts::query.searchString:
+      name: searchString
+      in: query
+      description: The alert attribute you want returned in the search. Optional.
+      schema:
+        type: string
+      required: false
+    security_analytics.get_findings::query.detector_id:
+      name: detector_id
+      in: query
+      description: The ID of the detector used to fetch alerts. Optional when the detectorType is specified. Otherwise required.
+      schema:
+        type: string
+    security_analytics.get_findings::query.detectorType:
+      name: detectorType
+      in: query
+      description: The type of detector used to fetch alerts. Optional when the detector_id is specified. Otherwise required.
+      schema:
+        type: string
+    security_analytics.get_findings::query.sortOrder:
+      name: sortOrder
+      in: query
+      description: The order used to sort the list of findings. Possible values are asc or desc. Optional.
+      schema:
+        type: string
+        enum: [asc, desc]
+      required: false
+    security_analytics.get_findings::query.size:
+      name: size
+      in: query
+      description: The maximum number of results returned in the response. Optional.
+      schema:
+        type: integer
+        format: int64
+      required: false
+    security_analytics.get_findings::query.startIndex:
+      name: startIndex
+      in: query
+      description: The pagination index. Optional.
+      schema:
+        type: integer
+        format: int64
+      required: false
+    security_analytics.get_findings::query.detectionType:
+      name: detectionType
+      in: query
+      description: The detection rule type that dictates the retrieval type for the findings. When the detection type is threat, it fetches threat intelligence feeds. When the detection type is rule, findings are fetched based on the detector’s rule. Optional.
+      schema:
+        type: string
+      required: false
+    security_analytics.get_findings::query.severity:
+      name: severity
+      in: query
+      description: The severity of the detector rule used to fetch alerts. Severity can be critical, high, medium, or low. Optional.
+      schema:
+        type: string
+        enum: [critical,high,low, medium]
+      required: false
+    security_analytics.search_finding_correlations::query.finding:
+      name: finding
+      in: query
+      description: The finding ID for which you want to find other findings that are correlated. Required.
+      schema:
+        type: string
+      required: true
+    security_analytics.search_finding_correlations::query.detector_type:
+      name: detector_type
+      in: query
+      description: The log type of findings you want to correlate with the specified finding. Required.
+      schema:
+        type: string
+      required: true
+    security_analytics.search_finding_correlations::query.nearby_findings:
+      name: nearby_findings
+      in: query
+      description: The number of nearby findings you want to return. Optional.
+      schema:
+        type: string
+      required: false
+    security_analytics.search_finding_correlations::query.time_window:
+      name: time_window
+      in: query
+      description: Sets a time window in which all of the correlations must have occurred together. Optional.
+      schema:
+        type: string
+      required: false

--- a/spec/namespaces/security_analytics.yaml
+++ b/spec/namespaces/security_analytics.yaml
@@ -16,6 +16,7 @@ paths:
         - $ref: '#/components/parameters/security_analytics.get_alerts::query.alertState'
         - $ref: '#/components/parameters/security_analytics.get_alerts::query.detectorType'
         - $ref: '#/components/parameters/security_analytics.get_alerts::query.detector_id'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.endTime'
         - $ref: '#/components/parameters/security_analytics.get_alerts::query.missing'
         - $ref: '#/components/parameters/security_analytics.get_alerts::query.searchString'
         - $ref: '#/components/parameters/security_analytics.get_alerts::query.severityLevel'
@@ -23,6 +24,7 @@ paths:
         - $ref: '#/components/parameters/security_analytics.get_alerts::query.sortOrder'
         - $ref: '#/components/parameters/security_analytics.get_alerts::query.sortString'
         - $ref: '#/components/parameters/security_analytics.get_alerts::query.startIndex'
+        - $ref: '#/components/parameters/security_analytics.get_alerts::query.startTime'
       responses:
         '200':
           $ref: '#/components/responses/security_analytics.get_alerts@200'
@@ -39,10 +41,16 @@ paths:
         - $ref: '#/components/parameters/security_analytics.get_findings::query.detectionType'
         - $ref: '#/components/parameters/security_analytics.get_findings::query.detectorType'
         - $ref: '#/components/parameters/security_analytics.get_findings::query.detector_id'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.endTime'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.findingIds'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.missing'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.searchString'
         - $ref: '#/components/parameters/security_analytics.get_findings::query.severity'
         - $ref: '#/components/parameters/security_analytics.get_findings::query.size'
         - $ref: '#/components/parameters/security_analytics.get_findings::query.sortOrder'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.sortString'
         - $ref: '#/components/parameters/security_analytics.get_findings::query.startIndex'
+        - $ref: '#/components/parameters/security_analytics.get_findings::query.startTime'
       responses:
         '200':
           $ref: '#/components/responses/security_analytics.get_findings@200'
@@ -95,12 +103,20 @@ components:
       description: The type of detector used to fetch alerts. Optional when `detector_id` is specified. Otherwise required.
       schema:
         type: string
+    security_analytics.get_alerts::query.endTime:
+      name: endTime
+      in: query
+      description: The end timestamp (in ms) of the time window in which you want to retrieve alerts. Optional.
+      schema:
+        type: integer
+        format: int64
+      required: false
     security_analytics.get_alerts::query.severityLevel:
       name: severityLevel
       in: query
       description: Used to filter by alert severity level. Optional.
       schema:
-        type: string
+        $ref: '../schemas/security_analytics.alerts.yaml#/components/schemas/AlertSeverityLevel'
       required: false
     security_analytics.get_alerts::query.alertState:
       name: alertState
@@ -112,25 +128,25 @@ components:
     security_analytics.get_alerts::query.sortString:
       name: sortString
       in: query
-      description: Specifies which string Security Analytics uses to sort the alerts. Optional.
+      description: The string used by Security Analytics to sort the alerts. Optional.
       schema:
         type: string
+        default: start_time
       required: false
     security_analytics.get_alerts::query.sortOrder:
       name: sortOrder
       in: query
-      description: The order used to sort the list of findings. Possible values are asc or desc. Optional.
+      description: The order used to sort the list of findings. Possible values are `asc` or `desc`. Optional.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/SortOrder'
+        default: asc
       required: false
     security_analytics.get_alerts::query.missing:
       name: missing
       in: query
-      description: A list of fields for which there are no found alias mappings. Optional.
+      description: Used to sort by whether the field `missing` exists or not in the documents associated with the alert. Optional.
       schema:
-        type: array
-        items:
-          type: string
+        type: string
       required: false
     security_analytics.get_alerts::query.size:
       name: size
@@ -139,6 +155,7 @@ components:
       schema:
         type: integer
         format: int64
+        default: 20
       required: false
     security_analytics.get_alerts::query.startIndex:
       name: startIndex
@@ -147,6 +164,7 @@ components:
       schema:
         type: integer
         format: int64
+        default: 0
       required: false
     security_analytics.get_alerts::query.searchString:
       name: searchString
@@ -154,6 +172,14 @@ components:
       description: The alert attribute you want returned in the search. Optional.
       schema:
         type: string
+      required: false
+    security_analytics.get_alerts::query.startTime:
+      name: startTime
+      in: query
+      description: The beginning timestamp (in ms) of the time window in which you want to retrieve alerts. Optional.
+      schema:
+        type: integer
+        format: int64
       required: false
     security_analytics.get_findings::query.detector_id:
       name: detector_id
@@ -167,12 +193,34 @@ components:
       description: The type of detector used to fetch alerts. Optional when the `detector_id` is specified. Otherwise required.
       schema:
         type: string
+    security_analytics.get_findings::query.endTime:
+      name: endTime
+      in: query
+      description: The end timestamp (in ms) of the time window in which you want to retrieve findings. Optional.
+      schema:
+        type: string
+      required: false
+    security_analytics.get_findings::query.findingIds:
+      name: findingIds
+      in: query
+      description: The comma-separated id list of findings for which you want retrieve details. Optional.
+      schema:
+        type: string
+      required: false
+    security_analytics.get_findings::query.missing:
+      name: missing
+      in: query
+      description: Used to sort by whether the field `missing` exists or not in the documents associated with the finding. Optional.
+      schema:
+        type: string
+      required: false
     security_analytics.get_findings::query.sortOrder:
       name: sortOrder
       in: query
-      description: The order used to sort the list of findings. Possible values are asc or desc. Optional.
+      description: The order used to sort the list of findings. Possible values are `asc` or `desc`. Optional.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/SortOrder'
+        default: asc
       required: false
     security_analytics.get_findings::query.size:
       name: size
@@ -181,6 +229,22 @@ components:
       schema:
         type: integer
         format: int64
+        default: 20
+      required: false
+    security_analytics.get_findings::query.searchString:
+      name: searchString
+      in: query
+      description: The finding attribute you want returned in the search. To search in a specific index, specify the index name in the request path. For example, to search findings in the indexABC index, use `searchString=indexABC’. Optional.
+      schema:
+        type: string
+      required: false
+    security_analytics.get_findings::query.sortString:
+      name: sortString
+      in: query
+      description: The string used by the Alerting plugin to sort the findings. Optional.
+      schema:
+        type: string
+        default: timestamp
       required: false
     security_analytics.get_findings::query.startIndex:
       name: startIndex
@@ -189,20 +253,30 @@ components:
       schema:
         type: integer
         format: int64
+        default: 0
+      required: false
+    security_analytics.get_findings::query.startTime:
+      name: startTime
+      in: query
+      description: The beginning timestamp (in ms) of the time window in which you want to retrieve findings. Optional.
+      schema:
+        type: integer
+        format: int64
       required: false
     security_analytics.get_findings::query.detectionType:
       name: detectionType
       in: query
-      description: The detection rule type that dictates the retrieval type for the findings. When the detection type is threat, it fetches threat intelligence feeds. When the detection type is rule, findings are fetched based on the detector’s rule. Optional.
+      description: The detection type that dictates the retrieval type for the findings. When the detection type is `threat`, it fetches threat intelligence feeds. When the detection type is `rule`, findings are fetched based on the detector’s rule. Optional.
       schema:
-        type: string
+        $ref: '../schemas/security_analytics.findings.yaml#/components/schemas/DetectionType'
+        default: rule
       required: false
     security_analytics.get_findings::query.severity:
       name: severity
       in: query
-      description: The severity for which to retrieve findings. Severity can be critical, high, medium, or low. Optional.
+      description: The rule severity for which retrieve findings. Severity can be `critical`, `high`, `medium`, or `low`. Optional.
       schema:
-        $ref: '../schemas/security_analytics.findings.yaml#/components/schemas/Severity'
+        $ref: '../schemas/security_analytics.findings.yaml#/components/schemas/RuleSeverity'
       required: false
     security_analytics.search_finding_correlations::query.finding:
       name: finding
@@ -223,12 +297,16 @@ components:
       in: query
       description: The number of nearby findings you want to return. Optional.
       schema:
-        type: string
+        type: integer
+        format: int64
+        default: 10
       required: false
     security_analytics.search_finding_correlations::query.time_window:
       name: time_window
       in: query
-      description: Sets a time window in which all of the correlations must have occurred together. Optional.
+      description: The time window (in ms) in which all of the correlations must have occurred together. Optional.
       schema:
-        type: string
+        type: integer
+        format: int64
+        default: 300000
       required: false

--- a/spec/schemas/security_analytics.alerts.yaml
+++ b/spec/schemas/security_analytics.alerts.yaml
@@ -90,3 +90,7 @@ components:
         throttled_count:
           type: integer
           format: int64
+
+    AlertState:
+      type: string
+      enum: [ACKNOWLEDGED, ACTIVE, COMPLETED, DELETED, ERROR]

--- a/spec/schemas/security_analytics.alerts.yaml
+++ b/spec/schemas/security_analytics.alerts.yaml
@@ -14,11 +14,8 @@ components:
         total_alerts:
           type: integer
           format: int64
-        detectorType:
-          type: string
       required:
         - alerts
-        - detectorType
         - total_alerts
 
     Alerts:
@@ -55,7 +52,7 @@ components:
           type: string
           enum: [ACKNOWLEDGED,ACTIVE, COMPLETED, DELETED, ERROR]
         error_message:
-          type: string
+          type: ['null', string]
         alert_history:
           type: array
           items:
@@ -71,9 +68,9 @@ components:
         last_notification_time:
           type: string
         end_time:
-          type: string
+          type: ['null', string]
         acknowledged_time:
-          type: string
+          type: ['null', string]
 
     AlertError:
       type: object

--- a/spec/schemas/security_analytics.alerts.yaml
+++ b/spec/schemas/security_analytics.alerts.yaml
@@ -1,0 +1,95 @@
+openapi: 3.1.0
+info:
+  title: Schemas of `security_analytics.alerts` Category
+  description: Schemas of `security_analytics.alerts` Category
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    GetAlertsResponse:
+      type: object
+      properties:
+        alerts:
+          $ref: '#/components/schemas/Alerts'
+        total_alerts:
+          type: integer
+          format: int64
+        detectorType:
+          type: string
+      required:
+        - alerts
+        - detectorType
+        - total_alerts
+
+    Alerts:
+      type: array
+      items:
+        $ref: '#/components/schemas/Alert'
+
+    Alert:
+      type: object
+      properties:
+        detector_id:
+          type: string
+        id:
+          type: string
+        version:
+          type: integer
+          format: int64
+        schema_version:
+          type: integer
+          format: int64
+        trigger_id:
+          type: string
+        trigger_name:
+          type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+        related_doc_ids:
+          type: array
+          items:
+            type: string
+        state:
+          type: string
+          enum: [ACKNOWLEDGED,ACTIVE, COMPLETED, DELETED, ERROR]
+        error_message:
+          type: string
+        alert_history:
+          type: array
+          items:
+            $ref: '#/components/schemas/AlertError'
+        severity:
+          type: string
+        action_execution_results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ActionExecutionResult'
+        start_time:
+          type: string
+        last_notification_time:
+          type: string
+        end_time:
+          type: string
+        acknowledged_time:
+          type: string
+
+    AlertError:
+      type: object
+      properties:
+        timestamp:
+          type: string
+        message:
+          type: string
+
+    ActionExecutionResult:
+      type: object
+      properties: 
+        action_id:
+          type: string
+        last_execution_time:
+          type: string
+        throttled_count:
+          type: integer
+          format: int64

--- a/spec/schemas/security_analytics.alerts.yaml
+++ b/spec/schemas/security_analytics.alerts.yaml
@@ -49,8 +49,7 @@ components:
           items:
             type: string
         state:
-          type: string
-          enum: [ACKNOWLEDGED,ACTIVE, COMPLETED, DELETED, ERROR]
+          $ref: '#/components/schemas/AlertState'
         error_message:
           type: ['null', string]
         alert_history:
@@ -94,3 +93,8 @@ components:
     AlertState:
       type: string
       enum: [ACKNOWLEDGED, ACTIVE, COMPLETED, DELETED, ERROR]
+
+    AlertSeverityLevel:
+      type: string
+      description: Severity level with 1 the highest and 5 the lowest. `ALL` designates no particular severity.
+      enum: ['1', '2', '3', '4', '5', ALL]

--- a/spec/schemas/security_analytics.findings.yaml
+++ b/spec/schemas/security_analytics.findings.yaml
@@ -107,6 +107,10 @@ components:
           items:
             type: string
 
-    Severity:
+    RuleSeverity:
       type: string
-      enum: [critical,high,low, medium]
+      enum: [critical, high, low, medium]
+
+    DetectionType:
+      type: string
+      enum: [rule,threat]

--- a/spec/schemas/security_analytics.findings.yaml
+++ b/spec/schemas/security_analytics.findings.yaml
@@ -41,7 +41,8 @@ components:
           items:
             $ref: '#/components/schemas/Query'
         timestamp:
-          type: string
+          type: integer
+          format: int64
         document_list:
           type: array
           items:
@@ -101,4 +102,7 @@ components:
         score:
           type: number
           format: float
-
+        rules:
+          type: array
+          items:
+            type: string

--- a/spec/schemas/security_analytics.findings.yaml
+++ b/spec/schemas/security_analytics.findings.yaml
@@ -1,0 +1,104 @@
+openapi: 3.1.0
+info:
+  title: Schemas of `security_analytics.findings` Category
+  description: Schemas of `security_analytics.findings` Category
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    GetFindingsResponse:
+      type: object
+      properties:
+        total_findings:
+          type: integer
+          format: int64
+        findings:
+          $ref: '#/components/schemas/Findings'
+      required:
+        - findings
+        - total_findings
+
+    Findings:
+      type: array
+      items:
+        $ref: '#/components/schemas/Finding'
+
+    Finding:
+      type: object
+      properties:
+        detectorId:
+          type: string
+        id:
+          type: string
+        related_doc_ids:
+          type: array
+          items:
+            type: string
+        index:
+          type: string
+        queries:
+          type: array
+          items:
+            $ref: '#/components/schemas/Query'
+        timestamp:
+          type: string
+        document_list:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+
+    Query:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        fields:
+          type: array
+          items:
+            type: string
+        query:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        query_field_names:
+          type: array
+          items:
+            type: string
+
+    Document:
+      type: object
+      properties:
+        index:
+          type: string
+        id:
+          type: string
+        found:
+          type: boolean
+        document:
+          type: string
+
+    SearchFindingCorrelationsResponse:
+      type: object
+      properties:
+        findings: 
+          type: array
+          items:
+            $ref: '#/components/schemas/FindingWithScore'
+      required:
+        - findings
+
+    FindingWithScore:
+      type: object
+      properties:
+        finding:
+          type: string
+        detector_type:
+          type: string
+        score:
+          type: number
+          format: float
+

--- a/spec/schemas/security_analytics.findings.yaml
+++ b/spec/schemas/security_analytics.findings.yaml
@@ -106,3 +106,7 @@ components:
           type: array
           items:
             type: string
+
+    Severity:
+      type: string
+      enum: [critical,high,low, medium]

--- a/tests/default/security_analytics/alerts_and_findings.yaml
+++ b/tests/default/security_analytics/alerts_and_findings.yaml
@@ -56,7 +56,7 @@ prologues:
               type: integer
     status: [200]
 
-  - path: /_plugins/_security_analytics/rules?category={category}
+  - path: /_plugins/_security_analytics/rules
     id: create_rule_movies
     method: POST
     parameters:
@@ -84,7 +84,7 @@ prologues:
       rule_id: payload._id
     status: [201]
 
-  - path: /_plugins/_security_analytics/rules?category={category}
+  - path: /_plugins/_security_analytics/rules
     id: create_rule_books
     method: POST
     parameters:
@@ -267,14 +267,14 @@ epilogues:
       id: ${create_detector_books.detector_id}
     status: [200]
 
-  - path: /_plugins/_security_analytics/rules/{id}?forced={forced}
+  - path: /_plugins/_security_analytics/rules/{id}
     method: DELETE
     parameters:
       forced: true
       id: ${create_rule_movies.rule_id}
     status: [200]
 
-  - path: /_plugins/_security_analytics/rules/{id}?forced={forced}
+  - path: /_plugins/_security_analytics/rules/{id}
     method: DELETE
     parameters:
       forced: true

--- a/tests/default/security_analytics/alerts_and_findings.yaml
+++ b/tests/default/security_analytics/alerts_and_findings.yaml
@@ -1,0 +1,302 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test alert and finding endpoints.
+version: '>= 2.4'
+
+prologues:
+  - path: /_plugins/_security_analytics/logtype
+    id: create_logtype_movies
+    method: POST
+    request:
+      payload:
+        description: log type for movies
+        name: movies
+        source: Custom
+    output:
+      logtype_id: payload._id
+    status: [201]
+
+  - path: /_plugins/_security_analytics/logtype
+    id: create_logtype_books
+    method: POST
+    request:
+      payload:
+        description: log type for books
+        name: books
+        source: Custom
+    output:
+      logtype_id: payload._id
+    status: [201]
+
+  - path: /movies
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            director: 
+              type: text
+            title:
+              type: text
+            year: 
+              type: integer
+    status: [200]
+
+  - path: /books
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            author: 
+              type: text
+            title:
+              type: text
+            year: 
+              type: integer
+    status: [200]
+
+  - path: /_plugins/_security_analytics/rules?category={category}
+    id: create_rule_movies
+    method: POST
+    parameters:
+      category: movies
+    request:
+      payload:
+        title: Movies Published in 1998
+        id: 25b9c01c-350d-4b95-bed1-836d04a4f324
+        description: Detects when movies were published in 1998
+        status: experimental
+        author: Unknown
+        date: 2021/05/06
+        modified: 2021/11/30
+        references: []
+        tags: []
+        logsource:
+          product: unknown
+        detection:
+          selection:
+            year: 1998
+          condition: selection
+        level: critical
+        falsepositives: []
+    output:
+      rule_id: payload._id
+    status: [201]
+
+  - path: /_plugins/_security_analytics/rules?category={category}
+    id: create_rule_books
+    method: POST
+    parameters:
+      category: books
+    request:
+      payload:
+        title: Books Published in 1998
+        id: c3b33f93-55c3-4427-bf0e-05b07d34ca25
+        description: Detects when books were published in 1998
+        status: experimental
+        author: Unknown
+        date: 2021/05/06
+        modified: 2021/11/30
+        references: []
+        tags: []
+        logsource:
+          product: unknown
+        detection:
+          selection:
+            year: 1998
+          condition: selection
+        level: critical
+        falsepositives: []
+    output:
+      rule_id: payload._id
+    status: [201]
+    
+  - path: /_plugins/_security_analytics/detectors
+    id: create_detector_movies
+    method: POST
+    request:
+      payload:
+        enabled: true
+        name: 'Detector movies'
+        schedule:
+          period:
+            interval: 1
+            unit: 'MINUTES'
+        detector_type: 'movies'
+        type: 'detector'
+        inputs:
+          - detector_input:
+              description: 'Detector for movies'
+              custom_rules:
+                - id: '${create_rule_movies.rule_id}'
+              indices:
+                - 'movies'
+              pre_packaged_rules: []
+        triggers:
+          - ids:
+              - '${create_rule_movies.rule_id}'
+            types: []
+            tags: []
+            severity: 1
+            actions: []
+            id: '8qhrBoQBYK1JzUUDzH'
+            sev_levels: []
+            name: 'Default trigger'
+    output:
+      detector_id: payload._id
+    status: [201]
+
+  - path: /_plugins/_security_analytics/detectors
+    id: create_detector_books
+    method: POST
+    request:
+      payload:
+        enabled: true
+        name: 'Detector books'
+        schedule:
+          period:
+            interval: 1
+            unit: 'MINUTES'
+        detector_type: 'books'
+        type: 'detector'
+        inputs:
+          - detector_input:
+              description: 'Detector for books'
+              custom_rules:
+                - id: '${create_rule_books.rule_id}'
+              indices:
+                - 'books'
+              pre_packaged_rules: []
+        triggers:
+          - ids:
+              - '${create_rule_books.rule_id}'
+            types: []
+            tags: []
+            severity: 1
+            actions: []
+            id: '8qhrBoQBYK1JzUUDzHd'
+            sev_levels: []
+            name: 'Default trigger'
+    output:
+      detector_id: payload._id
+    status: [201]
+
+  - path: /_plugins/_security_analytics/correlation/rules
+    method: POST
+    request:
+      payload:
+        name: custom-rule
+        correlate:
+          - index: movies
+            category: movies
+            query: year:1998
+          - index: books
+            category: books
+            query: year:1998
+        time_window: 10000
+        triggers: []
+    status: [201]
+
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: movies, _id: movie1}}
+        - {director: Bennett, title: The Cruise, year: 1998}
+        - {create: {_index: movies, _id: movie2}}
+        - {director: Bennett, title: Truman Capote, year: 2005}
+        - {create: {_index: books, _id: book1}}
+        - {author: J. K. Rowling, title: "Harry Potter: Philosopher's Stone", year: 1997}
+        - {create: {_index: books, _id: book2}}
+        - {author: "J. K. Rowling", title: "Harry Potter: Chamber of Secrets", year: 1998}
+    status: [200]
+
+chapters:
+  - synopsis: Retrieve all findings for a specific detector. [GET]
+    id: get_findings
+    path: /_plugins/_security_analytics/findings/_search
+    method: GET
+    parameters:
+      detector_id: ${create_detector_movies.detector_id}
+    response:
+      payload:
+        total_findings: 1
+      status: [200]
+    retry:
+      count: 1
+      wait: 65000 #We need to wait 1 minutes for the detector to apply the sigma rule on the new documents added to indexes
+    output:
+      finding_id: payload.findings[0].id
+
+  - synopsis: Retrieve all alerts for a specific detector. [GET]
+    path: /_plugins/_security_analytics/alerts
+    method: GET
+    parameters:
+      detector_id: ${create_detector_books.detector_id}
+    response:
+      payload:
+        total_alerts: 1
+      status: [200]
+
+  - synopsis: List correlations for a specific finding. [GET]
+    path: /_plugins/_security_analytics/findings/correlate
+    method: GET
+    parameters:
+      finding: ${get_findings.finding_id}
+      detector_type: movies
+    response:
+      payload:
+        findings:
+          - detector_type: books
+      status: [200]
+
+epilogues:
+  - path: /_plugins/_security_analytics/detectors/{id}
+    method: DELETE
+    parameters:
+      id: ${create_detector_movies.detector_id}
+    status: [200]
+    
+  - path: /_plugins/_security_analytics/detectors/{id}
+    method: DELETE
+    parameters:
+      id: ${create_detector_books.detector_id}
+    status: [200]
+
+  - path: /_plugins/_security_analytics/rules/{id}?forced={forced}
+    method: DELETE
+    parameters:
+      forced: true
+      id: ${create_rule_movies.rule_id}
+    status: [200]
+
+  - path: /_plugins/_security_analytics/rules/{id}?forced={forced}
+    method: DELETE
+    parameters:
+      forced: true
+      id: ${create_rule_books.rule_id}
+    status: [200]
+
+  - path: /_plugins/_security_analytics/logtype/{id}
+    method: DELETE
+    parameters:
+      id: ${create_logtype_movies.logtype_id}
+    status: [200]
+  
+  - path: /_plugins/_security_analytics/logtype/{id}
+    method: DELETE
+    parameters:
+      id: ${create_logtype_books.logtype_id}
+    status: [200]
+
+  - path: /movies
+    method: DELETE
+    status: [200]
+
+  - path: /books
+    method: DELETE
+    status: [200]

--- a/tests/default/security_analytics/alerts_and_findings.yaml
+++ b/tests/default/security_analytics/alerts_and_findings.yaml
@@ -118,20 +118,20 @@ prologues:
     request:
       payload:
         enabled: true
-        name: 'Detector movies'
+        name: Detector movies
         schedule:
           period:
             interval: 1
-            unit: 'MINUTES'
-        detector_type: 'movies'
-        type: 'detector'
+            unit: MINUTES
+        detector_type: movies
+        type: detector
         inputs:
           - detector_input:
-              description: 'Detector for movies'
+              description: Detector for movies
               custom_rules:
                 - id: '${create_rule_movies.rule_id}'
               indices:
-                - 'movies'
+                - movies
               pre_packaged_rules: []
         triggers:
           - ids:
@@ -140,9 +140,9 @@ prologues:
             tags: []
             severity: 1
             actions: []
-            id: '8qhrBoQBYK1JzUUDzH'
+            id: 8qhrBoQBYK1JzUUDzH
             sev_levels: []
-            name: 'Default trigger'
+            name: Default trigger
     output:
       detector_id: payload._id
     status: [201]
@@ -153,20 +153,20 @@ prologues:
     request:
       payload:
         enabled: true
-        name: 'Detector books'
+        name: Detector books
         schedule:
           period:
             interval: 1
-            unit: 'MINUTES'
-        detector_type: 'books'
-        type: 'detector'
+            unit: MINUTES
+        detector_type: books
+        type: detector
         inputs:
           - detector_input:
-              description: 'Detector for books'
+              description: Detector for books
               custom_rules:
                 - id: '${create_rule_books.rule_id}'
               indices:
-                - 'books'
+                - books
               pre_packaged_rules: []
         triggers:
           - ids:
@@ -175,9 +175,9 @@ prologues:
             tags: []
             severity: 1
             actions: []
-            id: '8qhrBoQBYK1JzUUDzHd'
+            id: 8qhrBoQBYK1JzUUDzHd
             sev_levels: []
-            name: 'Default trigger'
+            name: Default trigger
     output:
       detector_id: payload._id
     status: [201]
@@ -212,7 +212,7 @@ prologues:
         - {create: {_index: books, _id: book1}}
         - {author: J. K. Rowling, title: "Harry Potter: Philosopher's Stone", year: 1997}
         - {create: {_index: books, _id: book2}}
-        - {author: "J. K. Rowling", title: "Harry Potter: Chamber of Secrets", year: 1998}
+        - {author: J. K. Rowling, title: 'Harry Potter: Chamber of Secrets', year: 1998}
     status: [200]
 
 chapters:
@@ -228,7 +228,7 @@ chapters:
       status: [200]
     retry:
       count: 1
-      wait: 65000 #We need to wait 1 minutes for the detector to apply the sigma rule on the new documents added to indexes
+      wait: 65000 # We need to wait 1 minutes for the detector to apply the sigma rule on the new documents added to indexes
     output:
       finding_id: payload.findings[0].id
 


### PR DESCRIPTION
### Description
This PR add specs for the 3 following endpoints :

- /_plugins/_security_analytics/alerts ["GET"]
- /_plugins/_security_analytics/findings/_search ["GET"]
- /_plugins/_security_analytics/findings/correlate ["GET"]

I intend to add all the other security analytics endpoints but I'd rather start with a small piece since this is the first time that I'm contributing to this repo.

Since there's no endpoint to directly create findings and alerts, I'm supposed to do it by hand with some `POST <index>/_create/<_id>` to test properly these endpoints then ?

### Issues Resolved
Related to #239. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
