### PR TITLE
Remove tests against pre-release 2.20.0

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -62,9 +62,6 @@ jobs:
             tests: plugins/security
             cert: tests/plugins/security/.kirk.pem
             key: tests/plugins/security/.kirk-key.pem
-          - version: 2.20.0
-            hub: opensearchstaging
-            ref: '@sha256:037a2eb5a4f48b9a9a29950be5e5fae4ebd82d41de1066e00bb8d8b0ce7871b1'
 
     name: test-opensearch-spec (version=${{ matrix.entry.version }}, hub=${{ matrix.entry.hub || 'opensearchproject' }}, tests=${{ matrix.entry.tests || 'default' }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
There is no planned 2.20.0 release, so this being a nightly build has a negative impact on testing due to there being distribution plugins that are packaged in 2.19.0 and 3.0.0 but missing from this build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
