### PR TITLE
Fix `Explanation`'s `details` property to be optional

### DIFF
--- a/spec/schemas/_core.explain.yaml
+++ b/spec/schemas/_core.explain.yaml
@@ -27,5 +27,4 @@ components:
               format: double
       required:
         - description
-        - details
         - value


### PR DESCRIPTION
### Description
`Explanation` is a recursive structure, as such `details` can not be required, otherwise there could never be a final level.

### Issues Resolved
Relates to https://github.com/opensearch-project/opensearch-java/issues/1615

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
