### PR TITLE
fixing default for shard_store status parameter

### DIFF
--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -4797,7 +4797,7 @@ components:
       name: status
       description: List of shard health statuses used to limit the request.
       schema:
-        default: all
+        default: 'yellow,red'
         oneOf:
           - $ref: '../schemas/indices.shard_stores.yaml#/components/schemas/ShardStoreStatus'
           - type: array


### PR DESCRIPTION
### Description
fixing default for shard_store status parameter


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
