### PR TITLE
Fix integer overflow issue in DocStatus by changing Integer to Long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `phase_results_processor` to `NodeInfoSearchPipelines` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))
 - Added new neural search stats and response filtering parameters (`include_individual_nodes`, `include_all_nodes`, `include_info`) to neural stats API ([#921](https://github.com/opensearch-project/opensearch-api-specification/pull/921))
 - Added `target_index_settings` to `Index Rollups API` from `index-management` plugin ([#822](https://github.com/opensearch-project/opensearch-api-specification/pull/822))
+- Changed the type of the `DocStatus` properties from int32 to int64 ([#933](https://github.com/opensearch-project/opensearch-api-specification/pull/933))
 
 ### Removed
 

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -27,23 +27,23 @@ components:
       properties:
         1xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of informational responses.
         2xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of successful responses.
         3xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of redirection responses.
         4xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of client error responses.
         5xx:
           type: integer
-          format: int32
+          format: int64
           description: The number of server error responses.
     Duration:
       description: A duration. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and `d` (days). Also accepts `0` without a unit and `-1` to indicate an unspecified value.


### PR DESCRIPTION
### Description

Since version 3.0.0 when calling `OpenSearchClient.nodes().stats()`, the function call fails on certain clusters with an error such as 
```
java.lang.RuntimeException: Jackson exception: Numeric value (5069719939) out of range of int (-2147483648 - 2147483647)
```
While debugging, it appears that the overflow error occurs because the `2xx` value in `doc_status` on a specific coordinator node exceeds the range of an integer.

![image](https://github.com/user-attachments/assets/53581d5a-f638-4959-88a9-e762f62f80d6)

To resolve this issue, the type of the `2xx` field was changed to `Long`.

### Issues Resolved

- https://github.com/opensearch-project/opensearch-java/issues/1645

