### PR TITLE
LTR API enhancements: store operations, routing parameters, and model management

### DIFF
--- a/spec/namespaces/ltr.yaml
+++ b/spec/namespaces/ltr.yaml
@@ -152,6 +152,587 @@ paths:
         '200':
           $ref: '#/components/responses/ltr.cache_stats@200'
 
+  /_ltr/_feature:
+    get:
+      operationId: ltr.search_features.0
+      x-operation-group: ltr.search_features
+      x-version-added: '2.19'
+      description: Search for features in a feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.search_features::query.from'
+        - $ref: '#/components/parameters/ltr.search_features::query.prefix'
+        - $ref: '#/components/parameters/ltr.search_features::query.size'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.search_features@200'
+
+  /_ltr/{store}/_feature:
+    get:
+      operationId: ltr.search_features.1
+      x-operation-group: ltr.search_features
+      x-version-added: '2.19'
+      description: Search for features in a feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.search_features::path.store'
+        - $ref: '#/components/parameters/ltr.search_features::query.from'
+        - $ref: '#/components/parameters/ltr.search_features::query.prefix'
+        - $ref: '#/components/parameters/ltr.search_features::query.size'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.search_features@200'
+
+  /_ltr/_featureset:
+    get:
+      operationId: ltr.search_featuresets.0
+      x-operation-group: ltr.search_featuresets
+      x-version-added: '2.19'
+      description: Search for feature sets in a feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.search_featuresets::query.from'
+        - $ref: '#/components/parameters/ltr.search_featuresets::query.prefix'
+        - $ref: '#/components/parameters/ltr.search_featuresets::query.size'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.search_featuresets@200'
+
+  /_ltr/{store}/_featureset:
+    get:
+      operationId: ltr.search_featuresets.1
+      x-operation-group: ltr.search_featuresets
+      x-version-added: '2.19'
+      description: Search for feature sets in a feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.search_featuresets::path.store'
+        - $ref: '#/components/parameters/ltr.search_featuresets::query.from'
+        - $ref: '#/components/parameters/ltr.search_featuresets::query.prefix'
+        - $ref: '#/components/parameters/ltr.search_featuresets::query.size'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.search_featuresets@200'
+
+  /_ltr/_model:
+    get:
+      operationId: ltr.search_models.0
+      x-operation-group: ltr.search_models
+      x-version-added: '2.19'
+      description: Search for models in a feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.search_models::query.from'
+        - $ref: '#/components/parameters/ltr.search_models::query.prefix'
+        - $ref: '#/components/parameters/ltr.search_models::query.size'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.search_models@200'
+
+  /_ltr/{store}/_model:
+    get:
+      operationId: ltr.search_models.1
+      x-operation-group: ltr.search_models
+      x-version-added: '2.19'
+      description: Search for models in a feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.search_models::path.store'
+        - $ref: '#/components/parameters/ltr.search_models::query.from'
+        - $ref: '#/components/parameters/ltr.search_models::query.prefix'
+        - $ref: '#/components/parameters/ltr.search_models::query.size'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.search_models@200'
+
+  /_ltr/_feature/{id}:
+    get:
+      operationId: ltr.get_feature.0
+      x-operation-group: ltr.get_feature
+      x-version-added: '2.19'
+      description: Get a feature from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.get_feature::path.id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.get_feature@200'
+        '404':
+          $ref: '#/components/responses/ltr.get_feature@404'
+
+    post:
+      operationId: ltr.update_feature.0
+      x-operation-group: ltr.update_feature
+      x-version-added: '2.19'
+      description: Update a feature in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.update_feature::path.id'
+        - $ref: '#/components/parameters/ltr.update_feature::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.update_feature'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.update_feature@200'
+        '404':
+          $ref: '#/components/responses/ltr.update_feature@404'
+        '409':
+          $ref: '#/components/responses/ltr.update_feature@409'
+
+    put:
+      operationId: ltr.create_feature.0
+      x-operation-group: ltr.create_feature
+      x-version-added: '2.19'
+      description: Create or update a feature in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.create_feature::path.id'
+        - $ref: '#/components/parameters/ltr.create_feature::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.create_feature'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.create_feature@200'
+        '201':
+          $ref: '#/components/responses/ltr.create_feature@201'
+        '409':
+          $ref: '#/components/responses/ltr.create_feature@409'
+
+    delete:
+      operationId: ltr.delete_feature.0
+      x-operation-group: ltr.delete_feature
+      x-version-added: '2.19'
+      description: Delete a feature from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.delete_feature::path.id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.delete_feature@200'
+        '404':
+          $ref: '#/components/responses/ltr.delete_feature@404'
+
+  /_ltr/{store}/_feature/{id}:
+    get:
+      operationId: ltr.get_feature.1
+      x-operation-group: ltr.get_feature
+      x-version-added: '2.19'
+      description: Get a feature from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.get_feature::path.id'
+        - $ref: '#/components/parameters/ltr.get_feature::path.store'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.get_feature@200'
+        '404':
+          $ref: '#/components/responses/ltr.get_feature@404'
+
+    post:
+      operationId: ltr.update_feature.1
+      x-operation-group: ltr.update_feature
+      x-version-added: '2.19'
+      description: Update a feature in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.update_feature::path.id'
+        - $ref: '#/components/parameters/ltr.update_feature::path.store'
+        - $ref: '#/components/parameters/ltr.update_feature::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.update_feature'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.update_feature@200'
+        '404':
+          $ref: '#/components/responses/ltr.update_feature@404'
+        '409':
+          $ref: '#/components/responses/ltr.update_feature@409'
+
+    put:
+      operationId: ltr.create_feature.1
+      x-operation-group: ltr.create_feature
+      x-version-added: '2.19'
+      description: Create or update a feature in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.create_feature::path.id'
+        - $ref: '#/components/parameters/ltr.create_feature::path.store'
+        - $ref: '#/components/parameters/ltr.create_feature::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.create_feature'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.create_feature@200'
+        '201':
+          $ref: '#/components/responses/ltr.create_feature@201'
+        '409':
+          $ref: '#/components/responses/ltr.create_feature@409'
+
+    delete:
+      operationId: ltr.delete_feature.1
+      x-operation-group: ltr.delete_feature
+      x-version-added: '2.19'
+      description: Delete a feature from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.delete_feature::path.id'
+        - $ref: '#/components/parameters/ltr.delete_feature::path.store'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.delete_feature@200'
+        '404':
+          $ref: '#/components/responses/ltr.delete_feature@404'
+
+  /_ltr/_featureset/{id}:
+    get:
+      operationId: ltr.get_featureset.0
+      x-operation-group: ltr.get_featureset
+      x-version-added: '2.19'
+      description: Get a feature set from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.get_featureset::path.id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.get_featureset@200'
+        '404':
+          $ref: '#/components/responses/ltr.get_featureset@404'
+
+    post:
+      operationId: ltr.update_featureset.0
+      x-operation-group: ltr.update_featureset
+      x-version-added: '2.19'
+      description: Update a feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.update_featureset::path.id'
+        - $ref: '#/components/parameters/ltr.update_featureset::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.update_featureset'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.update_featureset@200'
+        '404':
+          $ref: '#/components/responses/ltr.update_featureset@404'
+        '409':
+          $ref: '#/components/responses/ltr.update_featureset@409'
+
+    put:
+      operationId: ltr.create_featureset.0
+      x-operation-group: ltr.create_featureset
+      x-version-added: '2.19'
+      description: Create or update a feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.create_featureset::path.id'
+        - $ref: '#/components/parameters/ltr.create_featureset::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.create_featureset'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.create_featureset@200'
+        '201':
+          $ref: '#/components/responses/ltr.create_featureset@201'
+        '409':
+          $ref: '#/components/responses/ltr.create_featureset@409'
+
+    delete:
+      operationId: ltr.delete_featureset.0
+      x-operation-group: ltr.delete_featureset
+      x-version-added: '2.19'
+      description: Delete a feature set from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.delete_featureset::path.id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.delete_featureset@200'
+        '404':
+          $ref: '#/components/responses/ltr.delete_featureset@404'
+
+  /_ltr/{store}/_featureset/{id}:
+    get:
+      operationId: ltr.get_featureset.1
+      x-operation-group: ltr.get_featureset
+      x-version-added: '2.19'
+      description: Get a feature set from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.get_featureset::path.id'
+        - $ref: '#/components/parameters/ltr.get_featureset::path.store'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.get_featureset@200'
+        '404':
+          $ref: '#/components/responses/ltr.get_featureset@404'
+
+    post:
+      operationId: ltr.update_featureset.1
+      x-operation-group: ltr.update_featureset
+      x-version-added: '2.19'
+      description: Update a feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.update_featureset::path.id'
+        - $ref: '#/components/parameters/ltr.update_featureset::path.store'
+        - $ref: '#/components/parameters/ltr.update_featureset::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.update_featureset'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.update_featureset@200'
+        '404':
+          $ref: '#/components/responses/ltr.update_featureset@404'
+        '409':
+          $ref: '#/components/responses/ltr.update_featureset@409'
+
+    put:
+      operationId: ltr.create_featureset.1
+      x-operation-group: ltr.create_featureset
+      x-version-added: '2.19'
+      description: Create or update a feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.create_featureset::path.id'
+        - $ref: '#/components/parameters/ltr.create_featureset::path.store'
+        - $ref: '#/components/parameters/ltr.create_featureset::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.create_featureset'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.create_featureset@200'
+        '201':
+          $ref: '#/components/responses/ltr.create_featureset@201'
+        '409':
+          $ref: '#/components/responses/ltr.create_featureset@409'
+
+    delete:
+      operationId: ltr.delete_featureset.1
+      x-operation-group: ltr.delete_featureset
+      x-version-added: '2.19'
+      description: Delete a feature set from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.delete_featureset::path.id'
+        - $ref: '#/components/parameters/ltr.delete_featureset::path.store'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.delete_featureset@200'
+        '404':
+          $ref: '#/components/responses/ltr.delete_featureset@404'
+
+  /_ltr/_model/{id}:
+    get:
+      operationId: ltr.get_model.0
+      x-operation-group: ltr.get_model
+      x-version-added: '2.19'
+      description: Get a model from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.get_model::path.id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.get_model@200'
+        '404':
+          $ref: '#/components/responses/ltr.get_model@404'
+
+
+    put:
+      operationId: ltr.create_model.0
+      x-operation-group: ltr.create_model
+      x-version-added: '2.19'
+      description: Create or update a model in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.create_model::path.id'
+        - $ref: '#/components/parameters/ltr.create_model::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.create_model'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.create_model@200'
+        '201':
+          $ref: '#/components/responses/ltr.create_model@201'
+        '409':
+          $ref: '#/components/responses/ltr.create_model@409'
+
+    delete:
+      operationId: ltr.delete_model.0
+      x-operation-group: ltr.delete_model
+      x-version-added: '2.19'
+      description: Delete a model from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.delete_model::path.id'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.delete_model@200'
+        '404':
+          $ref: '#/components/responses/ltr.delete_model@404'
+
+  /_ltr/{store}/_model/{id}:
+    get:
+      operationId: ltr.get_model.1
+      x-operation-group: ltr.get_model
+      x-version-added: '2.19'
+      description: Get a model from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.get_model::path.id'
+        - $ref: '#/components/parameters/ltr.get_model::path.store'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.get_model@200'
+        '404':
+          $ref: '#/components/responses/ltr.get_model@404'
+
+
+    put:
+      operationId: ltr.create_model.1
+      x-operation-group: ltr.create_model
+      x-version-added: '2.19'
+      description: Create or update a model in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.create_model::path.id'
+        - $ref: '#/components/parameters/ltr.create_model::path.store'
+        - $ref: '#/components/parameters/ltr.create_model::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.create_model'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.create_model@200'
+        '201':
+          $ref: '#/components/responses/ltr.create_model@201'
+        '409':
+          $ref: '#/components/responses/ltr.create_model@409'
+
+    delete:
+      operationId: ltr.delete_model.1
+      x-operation-group: ltr.delete_model
+      x-version-added: '2.19'
+      description: Delete a model from the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.delete_model::path.id'
+        - $ref: '#/components/parameters/ltr.delete_model::path.store'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.delete_model@200'
+        '404':
+          $ref: '#/components/responses/ltr.delete_model@404'
+
+  /_ltr/_featureset/{name}/_createmodel:
+    post:
+      operationId: ltr.create_model_from_set.0
+      x-operation-group: ltr.create_model_from_set
+      x-version-added: '2.19'
+      description: Create a model from an existing feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.create_model_from_set::path.name'
+        - $ref: '#/components/parameters/ltr.create_model_from_set::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.create_model_from_set'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.create_model_from_set@200'
+        '201':
+          $ref: '#/components/responses/ltr.create_model_from_set@201'
+        '405':
+          $ref: '#/components/responses/ltr.create_model_from_set@405'
+
+  /_ltr/{store}/_featureset/{name}/_createmodel:
+    post:
+      operationId: ltr.create_model_from_set.1
+      x-operation-group: ltr.create_model_from_set
+      x-version-added: '2.19'
+      description: Create a model from an existing feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.create_model_from_set::path.name'
+        - $ref: '#/components/parameters/ltr.create_model_from_set::path.store'
+        - $ref: '#/components/parameters/ltr.create_model_from_set::query.routing'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.create_model_from_set'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.create_model_from_set@200'
+        '201':
+          $ref: '#/components/responses/ltr.create_model_from_set@201'
+        '405':
+          $ref: '#/components/responses/ltr.create_model_from_set@405'
+
+  /_ltr/_featureset/{name}/_addfeatures:
+    post:
+      operationId: ltr.add_features_to_set.0
+      x-operation-group: ltr.add_features_to_set
+      x-version-added: '2.19'
+      description: Add features to an existing feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.add_features_to_set::path.name'
+        - $ref: '#/components/parameters/ltr.add_features_to_set::query.merge'
+        - $ref: '#/components/parameters/ltr.add_features_to_set::query.routing'
+        - $ref: '#/components/parameters/ltr.add_features_to_set::query.version'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.add_features_to_set'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.add_features_to_set@200'
+        '201':
+          $ref: '#/components/responses/ltr.add_features_to_set@201'
+        '400':
+          $ref: '#/components/responses/ltr.add_features_to_set@400'
+        '404':
+          $ref: '#/components/responses/ltr.add_features_to_set@404'
+        '409':
+          $ref: '#/components/responses/ltr.add_features_to_set@409'
+
+  /_ltr/_featureset/{name}/_addfeatures/{query}:
+    post:
+      operationId: ltr.add_features_to_set_by_query.0
+      x-operation-group: ltr.add_features_to_set_by_query
+      x-version-added: '2.19'
+      description: Add features to an existing feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::path.name'
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::path.query'
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::query.merge'
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::query.routing'
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::query.version'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@200'
+        '201':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@201'
+        '400':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@400'
+        '404':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@404'
+        '409':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@409'
+
+  /_ltr/{store}/_featureset/{name}/_addfeatures:
+    post:
+      operationId: ltr.add_features_to_set.2
+      x-operation-group: ltr.add_features_to_set
+      x-version-added: '2.19'
+      description: Add features to an existing feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.add_features_to_set::path.name'
+        - $ref: '#/components/parameters/ltr.add_features_to_set::path.store'
+        - $ref: '#/components/parameters/ltr.add_features_to_set::query.merge'
+        - $ref: '#/components/parameters/ltr.add_features_to_set::query.routing'
+        - $ref: '#/components/parameters/ltr.add_features_to_set::query.version'
+      requestBody:
+        $ref: '#/components/requestBodies/ltr.add_features_to_set'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.add_features_to_set@200'
+        '201':
+          $ref: '#/components/responses/ltr.add_features_to_set@201'
+        '400':
+          $ref: '#/components/responses/ltr.add_features_to_set@400'
+        '404':
+          $ref: '#/components/responses/ltr.add_features_to_set@404'
+        '409':
+          $ref: '#/components/responses/ltr.add_features_to_set@409'
+
+  /_ltr/{store}/_featureset/{name}/_addfeatures/{query}:
+    post:
+      operationId: ltr.add_features_to_set_by_query.1
+      x-operation-group: ltr.add_features_to_set_by_query
+      x-version-added: '2.19'
+      description: Add features to an existing feature set in the default feature store.
+      parameters:
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::path.name'
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::path.query'
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::path.store'
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::query.merge'
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::query.routing'
+        - $ref: '#/components/parameters/ltr.add_features_to_set_by_query::query.version'
+      responses:
+        '200':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@200'
+        '201':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@201'
+        '400':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@400'
+        '404':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@404'
+        '409':
+          $ref: '#/components/responses/ltr.add_features_to_set_by_query@409'
+
 
 components:
   parameters:
@@ -195,6 +776,8 @@ components:
             - cache
             - request_error_count
             - request_total_count
+            - status
+            - stores
       required: true
     ltr.stats::path.node_id:
       name: node_id
@@ -213,6 +796,386 @@ components:
       schema:
         type: string
       required: true
+    ltr.search_features::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.search_features::query.prefix:
+      name: prefix
+      in: query
+      description: A name prefix to filter features by.
+      schema:
+        type: string
+      required: false
+    ltr.search_features::query.from:
+      name: from
+      in: query
+      description: The offset from the first result (for pagination).
+      schema:
+        type: integer
+        default: 0
+      required: false
+    ltr.search_features::query.size:
+      name: size
+      in: query
+      description: The number of features to return.
+      schema:
+        type: integer
+        default: 20
+      required: false
+    ltr.search_featuresets::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.search_featuresets::query.prefix:
+      name: prefix
+      in: query
+      description: A name prefix to filter feature sets by.
+      schema:
+        type: string
+      required: false
+    ltr.search_featuresets::query.from:
+      name: from
+      in: query
+      description: The offset from the first result (for pagination).
+      schema:
+        type: integer
+        default: 0
+      required: false
+    ltr.search_featuresets::query.size:
+      name: size
+      in: query
+      description: The number of feature sets to return.
+      schema:
+        type: integer
+        default: 20
+      required: false
+    ltr.search_models::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.search_models::query.prefix:
+      name: prefix
+      in: query
+      description: A name prefix to filter models by.
+      schema:
+        type: string
+      required: false
+    ltr.search_models::query.from:
+      name: from
+      in: query
+      description: The offset from the first result (for pagination).
+      schema:
+        type: integer
+        default: 0
+      required: false
+    ltr.search_models::query.size:
+      name: size
+      in: query
+      description: The number of models to return.
+      schema:
+        type: integer
+        default: 20
+      required: false
+    ltr.get_feature::path.id:
+      name: id
+      in: path
+      description: The name of the feature.
+      schema:
+        type: string
+      required: true
+    ltr.get_feature::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.create_feature::path.id:
+      name: id
+      in: path
+      description: The name of the feature.
+      schema:
+        type: string
+      required: true
+    ltr.create_feature::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.delete_feature::path.id:
+      name: id
+      in: path
+      description: The name of the feature.
+      schema:
+        type: string
+      required: true
+    ltr.delete_feature::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.get_featureset::path.id:
+      name: id
+      in: path
+      description: The name of the feature set.
+      schema:
+        type: string
+      required: true
+    ltr.get_featureset::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.create_featureset::path.id:
+      name: id
+      in: path
+      description: The name of the feature set.
+      schema:
+        type: string
+      required: true
+    ltr.create_featureset::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.delete_featureset::path.id:
+      name: id
+      in: path
+      description: The name of the feature set.
+      schema:
+        type: string
+      required: true
+    ltr.delete_featureset::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.get_model::path.id:
+      name: id
+      in: path
+      description: The name of the model.
+      schema:
+        type: string
+      required: true
+    ltr.get_model::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.create_model::path.id:
+      name: id
+      in: path
+      description: The name of the model.
+      schema:
+        type: string
+      required: true
+    ltr.create_model::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.delete_model::path.id:
+      name: id
+      in: path
+      description: The name of the model.
+      schema:
+        type: string
+      required: true
+    ltr.delete_model::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.create_model_from_set::path.name:
+      name: name
+      in: path
+      description: The name of the feature set to use for creating the model.
+      schema:
+        type: string
+      required: true
+    ltr.create_model_from_set::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.add_features_to_set::path.name:
+      name: name
+      in: path
+      description: The name of the feature set to add features to.
+      schema:
+        type: string
+      required: true
+    ltr.add_features_to_set::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.add_features_to_set::query.merge:
+      name: merge
+      in: query
+      description: Whether to merge the feature list or append only.
+      schema:
+        type: boolean
+        default: false
+      required: false
+    ltr.add_features_to_set::query.routing:
+      name: routing
+      in: query
+      description: Specific routing value.
+      schema:
+        type: string
+      required: false
+    ltr.add_features_to_set::query.version:
+      name: version
+      in: query
+      description: Version check to ensure feature set is modified with expected version.
+      schema:
+        type: integer
+      required: false
+    ltr.update_feature::path.id:
+      name: id
+      in: path
+      description: The name of the feature.
+      schema:
+        type: string
+      required: true
+    ltr.update_feature::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.update_feature::query.routing:
+      name: routing
+      in: query
+      description: Specific routing value.
+      schema:
+        type: string
+      required: false
+    ltr.update_featureset::path.id:
+      name: id
+      in: path
+      description: The name of the feature set.
+      schema:
+        type: string
+      required: true
+    ltr.update_featureset::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.update_featureset::query.routing:
+      name: routing
+      in: query
+      description: Specific routing value.
+      schema:
+        type: string
+      required: false
+    ltr.create_feature::query.routing:
+      name: routing
+      in: query
+      description: Specific routing value.
+      schema:
+        type: string
+      required: false
+    ltr.create_featureset::query.routing:
+      name: routing
+      in: query
+      description: Specific routing value.
+      schema:
+        type: string
+      required: false
+    ltr.create_model::query.routing:
+      name: routing
+      in: query
+      description: Specific routing value.
+      schema:
+        type: string
+      required: false
+    ltr.create_model_from_set::query.routing:
+      name: routing
+      in: query
+      description: Specific routing value.
+      schema:
+        type: string
+      required: false
+    ltr.add_features_to_set_by_query::path.name:
+      name: name
+      in: path
+      description: The name of the feature set to add features to.
+      schema:
+        type: string
+      required: true
+    ltr.add_features_to_set_by_query::path.query:
+      name: query
+      in: path
+      description: Query string to filter existing features from the store by name. When provided, only features matching this query will be added to the feature set, and no request body should be included.
+      schema:
+        type: string
+      required: true
+    ltr.add_features_to_set_by_query::path.store:
+      name: store
+      in: path
+      description: The name of the feature store.
+      schema:
+        type: string
+      required: true
+    ltr.add_features_to_set_by_query::query.merge:
+      name: merge
+      in: query
+      description: Whether to merge the feature list or append only.
+      schema:
+        type: boolean
+        default: false
+      required: false
+    ltr.add_features_to_set_by_query::query.routing:
+      name: routing
+      in: query
+      description: Specific routing value.
+      schema:
+        type: string
+      required: false
+    ltr.add_features_to_set_by_query::query.version:
+      name: version
+      in: query
+      description: Version check to ensure feature set is modified with expected version.
+      schema:
+        type: integer
+      required: false
+
 
   responses:
     ltr.list_stores@200:
@@ -221,7 +1184,7 @@ components:
         application/json:
           schema:
             $ref: '../schemas/ltr._common.yaml#/components/schemas/ListStoresResponse'
-    
+
     ltr.delete_default_store@200:
       description: Successfully deleted the default feature store.
       content:
@@ -263,24 +1226,393 @@ components:
         application/json:
           schema:
             $ref: '../schemas/ltr._common.yaml#/components/schemas/AcknowledgedResponse'
-            
+
     ltr.stats@200:
       description: Provides information about the current status of the LTR plugin.
       content:
         application/json:
           schema:
             $ref: '../schemas/ltr._common.yaml#/components/schemas/Stats'
-            
+
     ltr.clear_cache@200:
       description: Successfully cleared the feature store cache.
       content:
         application/json:
           schema:
             $ref: '../schemas/ltr._common.yaml#/components/schemas/AcknowledgedResponse'
-            
+
     ltr.cache_stats@200:
       description: Returns cache statistics for all feature stores.
       content:
         application/json:
           schema:
             $ref: '../schemas/ltr._common.yaml#/components/schemas/CacheStatsResponse'
+
+    ltr.search_features@200:
+      description: Returns search results for features.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/SearchResponse'
+
+    ltr.search_featuresets@200:
+      description: Returns search results for feature sets.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/SearchResponse'
+
+    ltr.search_models@200:
+      description: Returns search results for models.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/SearchResponse'
+
+    ltr.get_feature@200:
+      description: Successfully retrieved the feature.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+
+    ltr.get_feature@404:
+      description: The feature does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/NotFoundResponse'
+
+    ltr.create_feature@200:
+      description: Successfully updated the feature.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.create_feature@201:
+      description: Successfully created the feature.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.create_feature@409:
+      description: Feature update failed due to version conflict.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.delete_feature@200:
+      description: Successfully deleted the feature.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.delete_feature@404:
+      description: The feature does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.get_featureset@200:
+      description: Successfully retrieved the feature set.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+
+    ltr.get_featureset@404:
+      description: The feature set does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/NotFoundResponse'
+
+    ltr.create_featureset@200:
+      description: Successfully updated the feature set.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.create_featureset@201:
+      description: Successfully created the feature set.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.create_featureset@409:
+      description: Feature set update failed - feature sets cannot be updated.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.delete_featureset@200:
+      description: Successfully deleted the feature set.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.delete_featureset@404:
+      description: The feature set does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/NotFoundResponse'
+
+    ltr.get_model@200:
+      description: Successfully retrieved the model.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+
+    ltr.get_model@404:
+      description: The model does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/NotFoundResponse'
+
+    ltr.create_model@200:
+      description: Successfully updated the model.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.create_model@201:
+      description: Successfully created the model.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.create_model@409:
+      description: Model update failed - models cannot be updated.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.delete_model@200:
+      description: Successfully deleted the model.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.delete_model@404:
+      description: The model does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/NotFoundResponse'
+
+    ltr.create_model_from_set@200:
+      description: Successfully updated the model.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.create_model_from_set@201:
+      description: Successfully created the model.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.create_model_from_set@405:
+      description: Model update failed - models cannot be updated.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.add_features_to_set@200:
+      description: Successfully updated the feature set with new features.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.add_features_to_set@201:
+      description: Successfully created the feature set with features.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.add_features_to_set@400:
+      description: Bad request - invalid feature data or parameters.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.add_features_to_set@404:
+      description: The feature set does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/NotFoundResponse'
+
+    ltr.add_features_to_set@409:
+      description: Feature set update failed due to version conflict.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.update_feature@200:
+      description: Successfully updated the feature.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.update_feature@404:
+      description: The feature does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/NotFoundResponse'
+
+    ltr.update_feature@409:
+      description: Feature update failed due to version conflict.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.update_featureset@200:
+      description: Successfully updated the feature set.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.update_featureset@404:
+      description: The feature set does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/NotFoundResponse'
+
+    ltr.update_featureset@409:
+      description: Feature set update failed due to version conflict.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.add_features_to_set_by_query@200:
+      description: Successfully updated the feature set with filtered features.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.add_features_to_set_by_query@201:
+      description: Successfully created the feature set with filtered features.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/DocumentResponse'
+
+    ltr.add_features_to_set_by_query@400:
+      description: Bad request - invalid query parameters or feature filtering.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+    ltr.add_features_to_set_by_query@404:
+      description: The feature set or filtered features do not exist.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ltr._common.yaml#/components/schemas/NotFoundResponse'
+
+    ltr.add_features_to_set_by_query@409:
+      description: Feature set update failed due to version conflict.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/ErrorResponseBase'
+
+
+  requestBodies:
+    ltr.create_feature:
+      description: The feature definition.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+      required: true
+
+    ltr.create_featureset:
+      description: The feature set definition.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+      required: true
+
+    ltr.create_model:
+      description: The model definition.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+      required: true
+
+    ltr.create_model_from_set:
+      description: The model definition for creating from a feature set.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+      required: true
+
+    ltr.add_features_to_set:
+      description: The features to add to the feature set.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+      required: true
+
+    ltr.update_feature:
+      description: The updated feature definition.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+      required: true
+
+    ltr.update_featureset:
+      description: The updated feature set definition.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+      required: true

--- a/spec/schemas/ltr._common.yaml
+++ b/spec/schemas/ltr._common.yaml
@@ -21,7 +21,7 @@ components:
         counts:
           type: object
           description: Count statistics for this store.
-      
+
     ListStoresResponse:
       type: object
       properties:
@@ -110,7 +110,7 @@ components:
           type: integer
         hit_count:
           type: integer
-          
+
     CacheItemStats:
       type: object
       properties:
@@ -120,7 +120,7 @@ components:
         count:
           type: integer
           description: Count of cached items.
-          
+
     CacheAllStats:
       type: object
       description: Aggregate cache statistics across all nodes.
@@ -133,7 +133,7 @@ components:
           $ref: '#/components/schemas/CacheItemStats'
         models:
           $ref: '#/components/schemas/CacheItemStats'
-          
+
     NodeStatsDetails:
       type: object
       description: Cache statistics for a node.
@@ -146,7 +146,7 @@ components:
           $ref: '#/components/schemas/CacheItemStats'
         models:
           $ref: '#/components/schemas/CacheItemStats'
-          
+
     NodeDetails:
       type: object
       properties:
@@ -158,7 +158,7 @@ components:
           description: Node hostname.
         stats:
           $ref: '#/components/schemas/NodeStatsDetails'
-    
+
     CacheStatsResponse:
       type: object
       properties:
@@ -176,3 +176,108 @@ components:
           description: Cache statistics per node.
           additionalProperties:
             $ref: '#/components/schemas/NodeDetails'
+
+    SearchResponse:
+      type: object
+      description: OpenSearch search response for LTR store elements.
+      properties:
+        took:
+          type: integer
+          description: Time in milliseconds the search took.
+        timed_out:
+          type: boolean
+          description: Whether the search timed out.
+        _shards:
+          $ref: '_common.yaml#/components/schemas/ShardStatistics'
+        hits:
+          $ref: '#/components/schemas/SearchHits'
+
+    SearchHits:
+      type: object
+      description: Search hits container.
+      properties:
+        total:
+          $ref: '#/components/schemas/SearchHitsTotal'
+        max_score:
+          type: number
+          nullable: true
+          description: Maximum score of the hits.
+        hits:
+          type: array
+          description: Array of hit objects.
+          items:
+            $ref: '#/components/schemas/SearchHit'
+
+    SearchHitsTotal:
+      type: object
+      description: Total hits information.
+      properties:
+        value:
+          type: integer
+          description: Total number of hits.
+        relation:
+          type: string
+          enum: [eq, gte]
+          description: Relation of the total hits count.
+
+    SearchHit:
+      type: object
+      description: Individual search hit.
+      properties:
+        _index:
+          type: string
+          description: Index name.
+        _id:
+          type: string
+          description: Document ID.
+        _score:
+          type: number
+          nullable: true
+          description: Document score.
+        _source:
+          type: object
+          description: Document source.
+          additionalProperties: true
+
+    DocumentResponse:
+      type: object
+      description: Standard OpenSearch document operation response.
+      properties:
+        _index:
+          type: string
+          description: Index name.
+        _id:
+          type: string
+          description: Document ID.
+        _version:
+          type: integer
+          description: Document version.
+        result:
+          type: string
+          description: Operation result (created, updated, deleted).
+        forced_refresh:
+          type: boolean
+          description: Whether a refresh was forced.
+        _shards:
+          $ref: '_common.yaml#/components/schemas/ShardStatistics'
+        _seq_no:
+          type: integer
+          description: Sequence number.
+        _primary_term:
+          type: integer
+          description: Primary term.
+
+    NotFoundResponse:
+      type: object
+      description: Standard OpenSearch not found response.
+      properties:
+        _index:
+          type: string
+          description: Index name.
+        _id:
+          type: string
+          description: Document ID.
+        found:
+          type: boolean
+          description: Whether the document was found.
+          default: false

--- a/tests/default/ltr/feature.yaml
+++ b/tests/default/ltr/feature.yaml
@@ -1,0 +1,367 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: LTR feature operations including search and CRUD.
+version: '>= 2.19'
+prologues:
+  - path: /_ltr
+    method: PUT
+    status: [200]
+  - path: /_ltr/{store}
+    method: PUT
+    parameters:
+      store: test_store
+    status: [200]
+
+epilogues:
+  - path: /_ltr
+    method: DELETE
+    status: [200, 404]
+  - path: /_ltr/{store}
+    method: DELETE
+    parameters:
+      store: test_store
+    status: [200, 404]
+
+chapters:
+  # Search operations
+  - synopsis: Search for features in the default store.
+    method: GET
+    path: /_ltr/_feature
+    response:
+      status: 200
+
+  - synopsis: Search for features in the default store with prefix filter.
+    method: GET
+    path: /_ltr/_feature
+    parameters:
+      prefix: test
+    response:
+      status: 200
+
+  - synopsis: Search for features in the default store with pagination.
+    method: GET
+    path: /_ltr/_feature
+    parameters:
+      from: 0
+      size: 10
+    response:
+      status: 200
+
+  - synopsis: Search for features in a specific store.
+    method: GET
+    path: /_ltr/{store}/_feature
+    parameters:
+      store: test_store
+    response:
+      status: 200
+
+  - synopsis: Search for features in a specific store with prefix filter.
+    method: GET
+    path: /_ltr/{store}/_feature
+    parameters:
+      store: test_store
+      prefix: test
+    response:
+      status: 200
+
+  - synopsis: Search for features in a specific store with pagination.
+    method: GET
+    path: /_ltr/{store}/_feature
+    parameters:
+      store: test_store
+      from: 0
+      size: 5
+    response:
+      status: 200
+
+  # Individual feature CRUD operations (default store)
+  - synopsis: Create a feature in the default store.
+    method: PUT
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              title: '{{keywords}}'
+    response:
+      status: [200, 201, 409]
+
+  - synopsis: Create a feature with routing parameter in the default store.
+    method: PUT
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature_routing
+      routing: test_routing_value
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              title: '{{keywords}}'
+    response:
+      status: [200, 201, 409]
+
+  - synopsis: Get a feature from the default store.
+    method: GET
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature
+    response:
+      status: 200
+
+  - synopsis: Update a feature in the default store.
+    method: PUT
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              description: '{{keywords}}'
+    response:
+      status: [200, 201, 409]
+
+  # POST update operations (default store)
+  - synopsis: Create a feature for POST update testing in the default store.
+    method: PUT
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature_post
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              title: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Update a feature using POST in the default store.
+    method: POST
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature_post
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              description: '{{keywords}}'
+    response:
+      status: [200, 404, 409]
+
+  - synopsis: Update a feature using POST with routing in the default store.
+    method: POST
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature_post
+      routing: test_routing
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              content: '{{keywords}}'
+    response:
+      status: [200, 404, 409]
+
+  - synopsis: Delete a feature from the default store.
+    method: DELETE
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature
+    response:
+      status: [200, 404]
+
+  - synopsis: Delete the POST test feature from the default store.
+    method: DELETE
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature_post
+    response:
+      status: [200, 404]
+
+  - synopsis: Try to get a deleted feature from the default store.
+    method: GET
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature
+    response:
+      status: 404
+
+  # Individual feature CRUD operations (named store)
+  - synopsis: Create a feature in a specific store.
+    method: PUT
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              title: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Create a feature with routing parameter in a specific store.
+    method: PUT
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store_routing
+      routing: test_routing_value
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              title: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Get a feature from a specific store.
+    method: GET
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store
+    response:
+      status: 200
+
+  - synopsis: Update a feature in a specific store.
+    method: PUT
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              description: '{{keywords}}'
+    response:
+      status: [200, 201, 409]
+
+  # POST update operations (named store)
+  - synopsis: Create a feature for POST update testing in a specific store.
+    method: PUT
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store_post
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              title: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Update a feature using POST in a specific store.
+    method: POST
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store_post
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              description: '{{keywords}}'
+    response:
+      status: [200, 404, 409]
+
+  - synopsis: Update a feature using POST with routing in a specific store.
+    method: POST
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store_post
+      routing: test_routing
+    request:
+      payload:
+        feature:
+          params:
+            - keywords
+          template:
+            match:
+              content: '{{keywords}}'
+    response:
+      status: [200, 404, 409]
+
+  - synopsis: Delete a feature from a specific store.
+    method: DELETE
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store
+    response:
+      status: [200, 404]
+
+  - synopsis: Delete the POST test feature from a specific store.
+    method: DELETE
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store_post
+    response:
+      status: [200, 404]
+
+  # Cleanup routing test features
+  - synopsis: Delete the routing test feature from the default store.
+    method: DELETE
+    path: /_ltr/_feature/{id}
+    parameters:
+      id: test_feature_routing
+    response:
+      status: [200, 404]
+
+  - synopsis: Delete the routing test feature from a specific store.
+    method: DELETE
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store_routing
+    response:
+      status: [200, 404]
+
+  - synopsis: Try to get a deleted feature from a specific store.
+    method: GET
+    path: /_ltr/{store}/_feature/{id}
+    parameters:
+      store: test_store
+      id: test_feature_store
+    response:
+      status: 404

--- a/tests/default/ltr/featureset.yaml
+++ b/tests/default/ltr/featureset.yaml
@@ -1,0 +1,421 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: LTR featureset operations including search and CRUD.
+version: '>= 2.19'
+prologues:
+  - path: /_ltr
+    method: PUT
+    status: [200]
+  - path: /_ltr/{store}
+    method: PUT
+    parameters:
+      store: test_store
+    status: [200]
+
+epilogues:
+  - path: /_ltr
+    method: DELETE
+    status: [200, 404]
+  - path: /_ltr/{store}
+    method: DELETE
+    parameters:
+      store: test_store
+    status: [200, 404]
+
+chapters:
+  # Search operations
+  - synopsis: Search for featuresets in the default store.
+    method: GET
+    path: /_ltr/_featureset
+    response:
+      status: 200
+
+  - synopsis: Search for featuresets in the default store with prefix filter.
+    method: GET
+    path: /_ltr/_featureset
+    parameters:
+      prefix: test
+    response:
+      status: 200
+
+  - synopsis: Search for featuresets in the default store with pagination.
+    method: GET
+    path: /_ltr/_featureset
+    parameters:
+      from: 0
+      size: 10
+    response:
+      status: 200
+
+  - synopsis: Search for featuresets in a specific store.
+    method: GET
+    path: /_ltr/{store}/_featureset
+    parameters:
+      store: test_store
+    response:
+      status: 200
+
+  - synopsis: Search for featuresets in a specific store with prefix filter.
+    method: GET
+    path: /_ltr/{store}/_featureset
+    parameters:
+      store: test_store
+      prefix: test
+    response:
+      status: 200
+
+  - synopsis: Search for featuresets in a specific store with pagination.
+    method: GET
+    path: /_ltr/{store}/_featureset
+    parameters:
+      store: test_store
+      from: 0
+      size: 5
+    response:
+      status: 200
+
+  # Individual featureset CRUD operations (default store)
+  - synopsis: Create a featureset in the default store.
+    method: PUT
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset
+    request:
+      payload:
+        featureset:
+          name: test_featureset
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  title: '{{keywords}}'
+            - name: feature2
+              params: [keywords]
+              template:
+                match:
+                  description: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Create a featureset with routing parameter in the default store.
+    method: PUT
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset_routing
+      routing: test_routing_value
+    request:
+      payload:
+        featureset:
+          name: test_featureset_routing
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  title: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Get a featureset from the default store.
+    method: GET
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset
+    response:
+      status: 200
+
+  - synopsis: Try to update a featureset in the default store (should fail).
+    method: PUT
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset
+    request:
+      payload:
+        featureset:
+          name: test_featureset
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  title: '{{keywords}}'
+            - name: feature2
+              params: [keywords]
+              template:
+                match:
+                  description: '{{keywords}}'
+            - name: feature3
+              params: [keywords]
+              template:
+                match:
+                  content: '{{keywords}}'
+    response:
+      status: [409]
+
+  # POST update operations (default store)
+  - synopsis: Create a featureset for POST update testing in the default store.
+    method: PUT
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset_post
+    request:
+      payload:
+        featureset:
+          name: test_featureset_post
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  title: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Update a featureset using POST in the default store.
+    method: POST
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset_post
+    request:
+      payload:
+        featureset:
+          name: test_featureset_post
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  description: '{{keywords}}'
+    response:
+      status: [200, 404, 409]
+
+  - synopsis: Update a featureset using POST with routing in the default store.
+    method: POST
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset_post
+      routing: test_routing
+    request:
+      payload:
+        featureset:
+          name: test_featureset_post
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  content: '{{keywords}}'
+    response:
+      status: [200, 404, 409]
+
+  - synopsis: Delete a featureset from the default store.
+    method: DELETE
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset
+    response:
+      status: [200, 404]
+
+  - synopsis: Delete the POST test featureset from the default store.
+    method: DELETE
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset_post
+    response:
+      status: [200, 404]
+
+  - synopsis: Try to get a deleted featureset from the default store.
+    method: GET
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset
+    response:
+      status: 404
+
+  # Individual featureset CRUD operations (named store)
+  - synopsis: Create a featureset in a specific store.
+    method: PUT
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store
+    request:
+      payload:
+        featureset:
+          name: test_featureset_store
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  title: '{{keywords}}'
+            - name: feature2
+              params: [keywords]
+              template:
+                match:
+                  description: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Create a featureset with routing parameter in a specific store.
+    method: PUT
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store_routing
+      routing: test_routing_value
+    request:
+      payload:
+        featureset:
+          name: test_featureset_store_routing
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  title: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Get a featureset from a specific store.
+    method: GET
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store
+    response:
+      status: 200
+
+  - synopsis: Try to update a featureset in a specific store (should fail).
+    method: PUT
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store
+    request:
+      payload:
+        featureset:
+          name: test_featureset_store
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  title: '{{keywords}}'
+            - name: feature2
+              params: [keywords]
+              template:
+                match:
+                  description: '{{keywords}}'
+            - name: feature3
+              params: [keywords]
+              template:
+                match:
+                  content: '{{keywords}}'
+    response:
+      status: [409]
+
+  # POST update operations (named store)
+  - synopsis: Create a featureset for POST update testing in a specific store.
+    method: PUT
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store_post
+    request:
+      payload:
+        featureset:
+          name: test_featureset_store_post
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  title: '{{keywords}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Update a featureset using POST in a specific store.
+    method: POST
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store_post
+    request:
+      payload:
+        featureset:
+          name: test_featureset_store_post
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  description: '{{keywords}}'
+    response:
+      status: [200, 404, 409]
+
+  - synopsis: Update a featureset using POST with routing in a specific store.
+    method: POST
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store_post
+      routing: test_routing
+    request:
+      payload:
+        featureset:
+          name: test_featureset_store_post
+          features:
+            - name: feature1
+              params: [keywords]
+              template:
+                match:
+                  content: '{{keywords}}'
+    response:
+      status: [200, 404, 409]
+
+  - synopsis: Delete a featureset from a specific store.
+    method: DELETE
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store
+    response:
+      status: [200, 404]
+
+  - synopsis: Delete the POST test featureset from a specific store.
+    method: DELETE
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store_post
+    response:
+      status: [200, 404]
+
+  # Cleanup routing test featuresets
+  - synopsis: Delete the routing test featureset from the default store.
+    method: DELETE
+    path: /_ltr/_featureset/{id}
+    parameters:
+      id: test_featureset_routing
+    response:
+      status: [200, 404]
+
+  - synopsis: Delete the routing test featureset from a specific store.
+    method: DELETE
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store_routing
+    response:
+      status: [200, 404]
+
+  - synopsis: Try to get a deleted featureset from a specific store.
+    method: GET
+    path: /_ltr/{store}/_featureset/{id}
+    parameters:
+      store: test_store
+      id: test_featureset_store
+    response:
+      status: 404

--- a/tests/default/ltr/featureset/addfeatures.yaml
+++ b/tests/default/ltr/featureset/addfeatures.yaml
@@ -1,0 +1,218 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+description: LTR feature set add features operations.
+version: '>= 2.19'
+prologues:
+  - path: /_ltr
+    method: PUT
+    status: [200]
+  - path: /_ltr/{store}
+    method: PUT
+    parameters:
+      store: test_store
+    status: [200]
+  - path: /_ltr/_featureset/{id}
+    method: PUT
+    parameters:
+      id: test_featureset
+    request:
+      payload:
+        featureset:
+          features:
+            - name: initial_feature
+              params:
+                - query_string
+              template:
+                match:
+                  title: '{{query_string}}'
+    status: [201]
+  - path: /_ltr/{store}/_featureset/{id}
+    method: PUT
+    parameters:
+      store: test_store
+      id: test_featureset_store
+    request:
+      payload:
+        featureset:
+          features:
+            - name: initial_feature
+              params:
+                - query_string
+              template:
+                match:
+                  title: '{{query_string}}'
+    status: [201]
+  - path: /_ltr/_feature/{id}
+    method: PUT
+    parameters:
+      id: filtered_feature
+    request:
+      payload:
+        feature:
+          params:
+            - query_string
+          template:
+            match:
+              category: '{{query_string}}'
+    status: [201]
+  - path: /_ltr/{store}/_feature/{id}
+    method: PUT
+    parameters:
+      store: test_store
+      id: store_filtered_feature
+    request:
+      payload:
+        feature:
+          params:
+            - query_string
+          template:
+            match:
+              status: '{{query_string}}'
+    status: [201]
+
+epilogues:
+  - path: /_ltr
+    method: DELETE
+    status: [200, 404]
+  - path: /_ltr/{store}
+    method: DELETE
+    parameters:
+      store: test_store
+    status: [200, 404]
+
+chapters:
+  - synopsis: Add features to feature set in default store.
+    method: POST
+    path: /_ltr/_featureset/{name}/_addfeatures
+    parameters:
+      name: test_featureset
+    request:
+      payload:
+        features:
+          - name: new_feature_1
+            params:
+              - query_string
+            template:
+              match:
+                content: '{{query_string}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Add features to feature set with merge parameter.
+    method: POST
+    path: /_ltr/_featureset/{name}/_addfeatures
+    parameters:
+      name: test_featureset
+      merge: true
+    request:
+      payload:
+        features:
+          - name: new_feature_2
+            params:
+              - query_string
+            template:
+              match:
+                tags: '{{query_string}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Add features to feature set with routing parameter.
+    method: POST
+    path: /_ltr/_featureset/{name}/_addfeatures
+    parameters:
+      name: test_featureset
+      routing: custom_routing
+    request:
+      payload:
+        features:
+          - name: new_feature_3
+            params:
+              - query_string
+            template:
+              match:
+                description: '{{query_string}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Add existing features to feature set using query filter - exact name match.
+    method: POST
+    path: /_ltr/_featureset/{name}/_addfeatures/{query}
+    parameters:
+      name: test_featureset
+      query: filtered_feature
+    response:
+      status: [200, 201]
+
+  - synopsis: Add features to feature set in named store.
+    method: POST
+    path: /_ltr/{store}/_featureset/{name}/_addfeatures
+    parameters:
+      store: test_store
+      name: test_featureset_store
+    request:
+      payload:
+        features:
+          - name: store_feature_1
+            params:
+              - query_string
+            template:
+              match:
+                author: '{{query_string}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Add features to feature set in named store with merge.
+    method: POST
+    path: /_ltr/{store}/_featureset/{name}/_addfeatures
+    parameters:
+      store: test_store
+      name: test_featureset_store
+      merge: false
+    request:
+      payload:
+        features:
+          - name: store_feature_2
+            params:
+              - query_string
+            template:
+              match:
+                keywords: '{{query_string}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Add existing features to feature set in named store using query filter.
+    method: POST
+    path: /_ltr/{store}/_featureset/{name}/_addfeatures/{query}
+    parameters:
+      store: test_store
+      name: test_featureset_store
+      query: store_filtered_feature
+    response:
+      status: [200, 201]
+
+  - synopsis: Add features to new feature set (creates if not exists).
+    method: POST
+    path: /_ltr/_featureset/{name}/_addfeatures
+    parameters:
+      name: new_featureset
+    request:
+      payload:
+        features:
+          - name: error_feature
+            params:
+              - query_string
+            template:
+              match:
+                field: '{{query_string}}'
+    response:
+      status: [200, 201]
+
+  - synopsis: Test 400 error - invalid feature payload.
+    method: POST
+    path: /_ltr/_featureset/{name}/_addfeatures
+    parameters:
+      name: test_featureset
+    request:
+      payload:
+        invalid_payload: bad_data
+    response:
+      status: 400

--- a/tests/default/ltr/featureset/createmodel.yaml
+++ b/tests/default/ltr/featureset/createmodel.yaml
@@ -1,0 +1,213 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: LTR create model from feature set operations.
+version: '>= 2.19'
+prologues:
+  - path: /_ltr
+    method: PUT
+    status: [200]
+  - path: /_ltr/{store}
+    method: PUT
+    parameters:
+      store: mystore
+    status: [200]
+  # Create feature sets for testing model creation
+  - path: /_ltr/_featureset/{id}
+    method: PUT
+    parameters:
+      id: my_featureset
+    request:
+      payload:
+        featureset:
+          name: my_featureset
+          features:
+            - name: feature1
+              params: query_string
+              template:
+                match:
+                  field_test1: '{{query_string}}'
+            - name: feature2
+              params: query_string
+              template:
+                match:
+                  field_test2: '{{query_string}}'
+    status: [200, 201]
+  - path: /_ltr/{store}/_featureset/{id}
+    method: PUT
+    parameters:
+      store: mystore
+      id: my_featureset
+    request:
+      payload:
+        featureset:
+          name: my_featureset
+          features:
+            - name: feature1
+              params: query_string
+              template:
+                match:
+                  field_test1: '{{query_string}}'
+            - name: feature2
+              params: query_string
+              template:
+                match:
+                  field_test2: '{{query_string}}'
+    status: [200, 201]
+
+epilogues:
+  # Clean up models first
+  - path: /_ltr/_model/{id}
+    method: DELETE
+    parameters:
+      id: my_model
+    status: [200, 404]
+  - path: /_ltr/_model/{id}
+    method: DELETE
+    parameters:
+      id: my_model_routing
+    status: [200, 404]
+  - path: /_ltr/{store}/_model/{id}
+    method: DELETE
+    parameters:
+      store: mystore
+      id: my_model
+    status: [200, 404]
+  - path: /_ltr/{store}/_model/{id}
+    method: DELETE
+    parameters:
+      store: mystore
+      id: my_model_routing
+    status: [200, 404]
+  # Clean up feature sets
+  - path: /_ltr/_featureset/{id}
+    method: DELETE
+    parameters:
+      id: my_featureset
+    status: [200, 404]
+  - path: /_ltr/{store}/_featureset/{id}
+    method: DELETE
+    parameters:
+      store: mystore
+      id: my_featureset
+    status: [200, 404]
+  # Clean up stores
+  - path: /_ltr
+    method: DELETE
+    status: [200, 404]
+  - path: /_ltr/{store}
+    method: DELETE
+    parameters:
+      store: mystore
+    status: [200, 404]
+
+chapters:
+  # Test create model from set in default store
+  - synopsis: Create a model from feature set in the default store.
+    method: POST
+    path: /_ltr/_featureset/{name}/_createmodel
+    parameters:
+      name: my_featureset
+    request:
+      payload:
+        model:
+          name: my_model
+          model:
+            type: model/linear
+            definition:
+              feature1: 1.3
+              feature2: 0.3
+    response:
+      status: [200, 201]
+
+  - synopsis: Create a model from feature set with routing in the default store.
+    method: POST
+    path: /_ltr/_featureset/{name}/_createmodel
+    parameters:
+      name: my_featureset
+      routing: test_routing_value
+    request:
+      payload:
+        model:
+          name: my_model_routing
+          model:
+            type: model/linear
+            definition:
+              feature1: 1
+              feature2: 0.5
+    response:
+      status: [200, 201]
+
+  # Try to update/recreate the model (should fail)
+  - synopsis: Try to recreate a model from feature set (should fail).
+    method: POST
+    path: /_ltr/_featureset/{name}/_createmodel
+    parameters:
+      name: my_featureset
+    request:
+      payload:
+        model:
+          name: my_model
+          model:
+            type: model/linear
+            definition:
+              feature1: 1.5
+              feature2: 0.5
+    response:
+      status: [405]
+
+  # Test create model from set in named store
+  - synopsis: Create a model from feature set in a named store.
+    method: POST
+    path: /_ltr/{store}/_featureset/{name}/_createmodel
+    parameters:
+      store: mystore
+      name: my_featureset
+    request:
+      payload:
+        model:
+          name: my_model
+          model:
+            type: model/linear
+            definition:
+              feature1: 1.3
+              feature2: 0.3
+    response:
+      status: [200, 201]
+
+  - synopsis: Create a model from feature set with routing in a named store.
+    method: POST
+    path: /_ltr/{store}/_featureset/{name}/_createmodel
+    parameters:
+      store: mystore
+      name: my_featureset
+      routing: test_routing_value
+    request:
+      payload:
+        model:
+          name: my_model_routing
+          model:
+            type: model/linear
+            definition:
+              feature1: 1
+              feature2: 0.5
+    response:
+      status: [200, 201]
+
+  # Try to update/recreate the model in named store (should fail)
+  - synopsis: Try to recreate a model from feature set in named store (should fail).
+    method: POST
+    path: /_ltr/{store}/_featureset/{name}/_createmodel
+    parameters:
+      store: mystore
+      name: my_featureset
+    request:
+      payload:
+        model:
+          name: my_model
+          model:
+            type: model/linear
+            definition:
+              feature1: 1.5
+              feature2: 0.5
+    response:
+      status: [405]

--- a/tests/default/ltr/model.yaml
+++ b/tests/default/ltr/model.yaml
@@ -1,0 +1,316 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: LTR model CRUD operations.
+version: '>= 2.19'
+prologues:
+  - path: /_ltr
+    method: PUT
+    status: [200]
+  - path: /_ltr/{store}
+    method: PUT
+    parameters:
+      store: test_store
+    status: [200]
+
+epilogues:
+  - path: /_ltr
+    method: DELETE
+    status: [200, 404]
+  - path: /_ltr/{store}
+    method: DELETE
+    parameters:
+      store: test_store
+    status: [200, 404]
+
+chapters:
+  # Search operations
+  - synopsis: Search for models in the default store.
+    method: GET
+    path: /_ltr/_model
+    response:
+      status: 200
+
+  - synopsis: Search for models in the default store with prefix filter.
+    method: GET
+    path: /_ltr/_model
+    parameters:
+      prefix: test
+    response:
+      status: 200
+
+  - synopsis: Search for models in the default store with pagination.
+    method: GET
+    path: /_ltr/_model
+    parameters:
+      from: 0
+      size: 10
+    response:
+      status: 200
+
+  - synopsis: Search for models in a specific store.
+    method: GET
+    path: /_ltr/{store}/_model
+    parameters:
+      store: test_store
+    response:
+      status: 200
+
+  - synopsis: Search for models in a specific store with prefix filter.
+    method: GET
+    path: /_ltr/{store}/_model
+    parameters:
+      store: test_store
+      prefix: test
+    response:
+      status: 200
+
+  - synopsis: Search for models in a specific store with pagination.
+    method: GET
+    path: /_ltr/{store}/_model
+    parameters:
+      store: test_store
+      from: 0
+      size: 5
+    response:
+      status: 200
+
+  # Individual model CRUD operations (default store)
+  - synopsis: Create a model in the default store.
+    method: PUT
+    path: /_ltr/_model/{id}
+    parameters:
+      id: test_model
+    request:
+      payload:
+        model:
+          feature_set:
+            name: test_featureset
+            features:
+              - name: title
+                params: query_string
+                template:
+                  match:
+                    title: '{{query_string}}'
+              - name: popularity_score
+                params: query_string
+                template:
+                  match:
+                    popularity_score: '{{query_string}}'
+          model:
+            type: model/linear
+            definition:
+              title: 1
+              popularity_score: 0.5
+    response:
+      status: [200, 201]
+
+  - synopsis: Create a model with routing parameter in the default store.
+    method: PUT
+    path: /_ltr/_model/{id}
+    parameters:
+      id: test_model_routing
+      routing: test_routing_value
+    request:
+      payload:
+        model:
+          feature_set:
+            name: test_featureset_routing
+            features:
+              - name: title
+                params: query_string
+                template:
+                  match:
+                    title: '{{query_string}}'
+          model:
+            type: model/linear
+            definition:
+              title: 1
+    response:
+      status: [200, 201]
+
+  - synopsis: Get a model from the default store.
+    method: GET
+    path: /_ltr/_model/{id}
+    parameters:
+      id: test_model
+    response:
+      status: 200
+
+  - synopsis: Try to update a model in the default store (should fail).
+    method: PUT
+    path: /_ltr/_model/{id}
+    parameters:
+      id: test_model
+    request:
+      payload:
+        model:
+          feature_set:
+            name: test_featureset
+            features:
+              - name: title
+                params: query_string
+                template:
+                  match:
+                    title: '{{query_string}}'
+              - name: popularity_score
+                params: query_string
+                template:
+                  match:
+                    popularity_score: '{{query_string}}'
+          model:
+            type: model/linear
+            definition:
+              title: 1.2
+              popularity_score: 0.7
+    response:
+      status: [400, 409]
+
+
+  - synopsis: Delete a model from the default store.
+    method: DELETE
+    path: /_ltr/_model/{id}
+    parameters:
+      id: test_model
+    response:
+      status: [200, 404]
+
+
+  - synopsis: Try to get a deleted model from the default store.
+    method: GET
+    path: /_ltr/_model/{id}
+    parameters:
+      id: test_model
+    response:
+      status: 404
+
+  # Individual model CRUD operations (named store)
+  - synopsis: Create a model in a specific store.
+    method: PUT
+    path: /_ltr/{store}/_model/{id}
+    parameters:
+      store: test_store
+      id: test_model_store
+    request:
+      payload:
+        model:
+          feature_set:
+            name: test_featureset_store
+            features:
+              - name: title
+                params: query_string
+                template:
+                  match:
+                    title: '{{query_string}}'
+              - name: popularity_score
+                params: query_string
+                template:
+                  match:
+                    popularity_score: '{{query_string}}'
+          model:
+            type: model/linear
+            definition:
+              title: 0.5
+              popularity_score: 1
+    response:
+      status: [200, 201]
+
+  - synopsis: Create a model with routing parameter in a specific store.
+    method: PUT
+    path: /_ltr/{store}/_model/{id}
+    parameters:
+      store: test_store
+      id: test_model_store_routing
+      routing: test_routing_value
+    request:
+      payload:
+        model:
+          feature_set:
+            name: test_featureset_store_routing
+            features:
+              - name: title
+                params: query_string
+                template:
+                  match:
+                    title: '{{query_string}}'
+          model:
+            type: model/linear
+            definition:
+              title: 0.8
+    response:
+      status: [200, 201]
+
+  - synopsis: Get a model from a specific store.
+    method: GET
+    path: /_ltr/{store}/_model/{id}
+    parameters:
+      store: test_store
+      id: test_model_store
+    response:
+      status: 200
+
+  - synopsis: Try to update a model in a specific store (should fail).
+    method: PUT
+    path: /_ltr/{store}/_model/{id}
+    parameters:
+      store: test_store
+      id: test_model_store
+    request:
+      payload:
+        model:
+          feature_set:
+            name: test_featureset_store
+            features:
+              - name: title
+                params: query_string
+                template:
+                  match:
+                    title: '{{query_string}}'
+              - name: popularity_score
+                params: query_string
+                template:
+                  match:
+                    popularity_score: '{{query_string}}'
+          model:
+            type: model/linear
+            definition:
+              title: 0.7
+              popularity_score: 1.2
+    response:
+      status: [400, 409]
+
+
+  - synopsis: Delete a model from a specific store.
+    method: DELETE
+    path: /_ltr/{store}/_model/{id}
+    parameters:
+      store: test_store
+      id: test_model_store
+    response:
+      status: [200, 404]
+
+  # Cleanup routing test models
+  - synopsis: Delete the routing test model from the default store.
+    method: DELETE
+    path: /_ltr/_model/{id}
+    parameters:
+      id: test_model_routing
+    response:
+      status: [200, 404]
+
+  - synopsis: Delete the routing test model from a specific store.
+    method: DELETE
+    path: /_ltr/{store}/_model/{id}
+    parameters:
+      store: test_store
+      id: test_model_store_routing
+    response:
+      status: [200, 404]
+
+  - synopsis: Try to get a deleted model from a specific store.
+    method: GET
+    path: /_ltr/{store}/_model/{id}
+    parameters:
+      store: test_store
+      id: test_model_store
+    response:
+      status: 404

--- a/tests/default/ltr/stats.yaml
+++ b/tests/default/ltr/stats.yaml
@@ -18,12 +18,28 @@ chapters:
     path: /_plugins/_ltr/stats
     response:
       status: 200
-  - synopsis: Get LTR stat.
+  - synopsis: Get LTR stat (cache).
     method: GET
     path: /_plugins/_ltr/stats/{stat}
     parameters:
       stat:
         - cache
+    response:
+      status: 200
+  - synopsis: Get LTR stat (stores).
+    method: GET
+    path: /_plugins/_ltr/stats/{stat}
+    parameters:
+      stat:
+        - stores
+    response:
+      status: 200
+  - synopsis: Get LTR stat (status).
+    method: GET
+    path: /_plugins/_ltr/stats/{stat}
+    parameters:
+      stat:
+        - status
     response:
       status: 200
   - synopsis: Get LTR stats for certain node.
@@ -34,7 +50,7 @@ chapters:
         - _all
     response:
       status: 200
-  - synopsis: Get LTR stat for certain node.
+  - synopsis: Get LTR stat for certain node (cache).
     method: GET
     path: /_plugins/_ltr/{node_id}/stats/{stat}
     parameters:
@@ -42,5 +58,25 @@ chapters:
         - _all
       stat:
         - cache
+    response:
+      status: 200
+  - synopsis: Get LTR stat for certain node (stores).
+    method: GET
+    path: /_plugins/_ltr/{node_id}/stats/{stat}
+    parameters:
+      node_id:
+        - _all
+      stat:
+        - stores
+    response:
+      status: 200
+  - synopsis: Get LTR stat for certain node (status).
+    method: GET
+    path: /_plugins/_ltr/{node_id}/stats/{stat}
+    parameters:
+      node_id:
+        - _all
+      stat:
+        - status
     response:
       status: 200


### PR DESCRIPTION
### Description

This PR adds enhancements to the Learning to Rank (LTR) API specification, including:
New Features

    Store Element Operations: Added CRUD operations and search capabilities for store elements
    Model Management: Enhanced model creation from featuresets and improved model update operations
    Feature Set Operations: Added "add features to set" endpoints for dynamic feature management
    Statistics: Enhanced stats endpoint with stores and status information
    Routing Support: Added routing parameter support across create operations

API Changes

    Added query parameter support in add features operation
    Implemented routing parameter testing and support
    Removed unsupported POST endpoints for model updates
    Added POST-based update operations where appropriate

This PR takes the place of #906 which was getting messy.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
