### PR TITLE
Add additional_config field

### DIFF
--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -931,6 +931,14 @@ components:
                 description: The model description.
               model_group_id:
                 $ref: '../schemas/_common.yaml#/components/schemas/Id'
+              model_content_hash_value:
+                type: string
+                description: The model content hash value.
+              model_config:
+                $ref: '../schemas/ml._common.yaml#/components/schemas/ModelConfig'
+              url:
+                type: string
+                description: The model URL.
               function_name:
                 type: string
                 description: The function name.

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -305,6 +305,8 @@ components:
     ModelConfig:
       type: object
       properties:
+        additional_config:
+          $ref: '#/components/schemas/AdditionalConfig'
         all_config:
           type: string
           description: The all config.
@@ -318,6 +320,12 @@ components:
         framework_type:
           type: string
           description: The framework type.
+    AdditionalConfig:
+      type: object
+      properties:
+        space_type:
+          type: string
+          description: The distance metric for k-NN search.
     Status:
       type: string
       description: The status.

--- a/tests/plugins/ml/ml/models/register_custom.yaml
+++ b/tests/plugins/ml/ml/models/register_custom.yaml
@@ -1,0 +1,70 @@
+$schema: ../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the creation of custom model with space type value.
+version: '>= 3.1'
+warnings:
+  multiple-paths-detected: false
+  invalid-path-detected: false
+prologues:
+  - path: /_cluster/settings
+    method: PUT
+    request:
+      payload:
+        persistent:
+          plugins.ml_commons.allow_registering_model_via_url: true
+          plugins.ml_commons.only_run_on_ml_node: false
+epilogues:
+  - path: /_plugins/_ml/models/{model_id}
+    parameters:
+      model_id: ${get_task.model_id}
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Register custom model.
+    id: register_model
+    path: /_plugins/_ml/models/_register
+    method: POST
+    request:
+      payload:
+        name: huggingface/sentence-transformers/all-MiniLM-L6-v2
+        version: 1.0.2
+        model_format: TORCH_SCRIPT
+        model_content_hash_value: 25e2858993cd477936f24e412a508b005aa6b59a308301cc69690e4b90cab439
+        function_name: text_embedding
+        model_config:
+          model_type: distilbert
+          embedding_dimension: 768
+          framework_type: sentence_transformers
+          additional_config:
+            space_type: l2
+        url: https://artifacts.opensearch.org/models/ml-models/huggingface/sentence-transformers/all-MiniLM-L6-v2/1.0.2/torch_script/sentence-transformers_all-MiniLM-L6-v2-1.0.2-torch_script.zip
+    response:
+      status: 200
+    output:
+      task_id: payload.task_id
+  - synopsis: Get task status.
+    id: get_task
+    path: /_plugins/_ml/tasks/{task_id}
+    method: GET
+    parameters:
+      task_id: ${register_model.task_id}
+    response:
+      status: 200
+      payload:
+        state: COMPLETED
+    output:
+      model_id: payload.model_id
+    retry:
+      count: 5
+      wait: 30000
+  - synopsis: Get model status.
+    path: /_plugins/_ml/models/{model_id}
+    method: GET
+    parameters:
+      model_id: ${get_task.model_id}
+    response:
+      status: 200
+      payload:
+        model_config:
+          additional_config:
+            space_type: l2


### PR DESCRIPTION
### Description
Add new `additional_config` field in the `model_config` and some missing fields required when registering a custom model.
Doc reference: https://docs.opensearch.org/docs/latest/ml-commons-plugin/api/model-apis/register-model/#the-model_config-object

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
