### PR TITLE
[Pull-based Ingestion] Update params value type in ingestion source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed the default parameters for `data_stream/_stats` and `shard_stores/status` ([#931](https://github.com/opensearch-project/opensearch-api-specification/pull/931))
 - Fixed the type of `SearchStats`'s `concurrent_avg_slice_count` to be a double ([#942](https://github.com/opensearch-project/opensearch-api-specification/pull/942))
+- Fixed the type of `param` in pull-based ingestion's `ingestion_source` to take in Object for value instead of string ([#945](https://github.com/opensearch-project/opensearch-api-specification/pull/945))
 
 ### Changed
 - Changed schema of `NodeInfoSearchPipelines`'s `response_processors` & `request_processors` to use `NodeInfoSearchPipelineProcessor` instead of `NodeInfoIngestProcessor` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))

--- a/spec/schemas/indices._common.yaml
+++ b/spec/schemas/indices._common.yaml
@@ -208,8 +208,7 @@ components:
           description: Defines the size of the internal blocking queue in pull-based ingestion.
         param:
           type: object
-          additionalProperties:
-            type: string
+          additionalProperties: true
           description: Custom parameters for the ingestion source.
     IngestionSourcePointer:
       type: object


### PR DESCRIPTION
### Description
The ingestion source setting in pull-based ingestion contains a "params" Map<String, Object>. However, api-spec defines this as Map<String, String>. Correct the api-spec to take in any type. Note: pull-based ingestion is an experimental feature.

### Issues Resolved
Follow up for #908 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
