### PR TITLE
Add include_named_queries_score for msearch.

### DIFF
--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -286,6 +286,7 @@ paths:
         url: https://opensearch.org/docs/latest/api-reference/multi-search/
       parameters:
         - $ref: '#/components/parameters/msearch::query.ccs_minimize_roundtrips'
+        - $ref: '#/components/parameters/msearch::query.include_named_queries_score'
         - $ref: '#/components/parameters/msearch::query.max_concurrent_searches'
         - $ref: '#/components/parameters/msearch::query.max_concurrent_shard_requests'
         - $ref: '#/components/parameters/msearch::query.pre_filter_shard_size'
@@ -306,6 +307,7 @@ paths:
         url: https://opensearch.org/docs/latest/api-reference/multi-search/
       parameters:
         - $ref: '#/components/parameters/msearch::query.ccs_minimize_roundtrips'
+        - $ref: '#/components/parameters/msearch::query.include_named_queries_score'
         - $ref: '#/components/parameters/msearch::query.max_concurrent_searches'
         - $ref: '#/components/parameters/msearch::query.max_concurrent_shard_requests'
         - $ref: '#/components/parameters/msearch::query.pre_filter_shard_size'
@@ -4909,6 +4911,14 @@ components:
       schema:
         type: boolean
         default: true
+      style: form
+    msearch::query.include_named_queries_score:
+      in: query
+      name: include_named_queries_score
+      description: Indicates whether `hit.matched_queries` should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false).
+      schema:
+        type: boolean
+        default: false
       style: form
     msearch::query.max_concurrent_searches:
       in: query


### PR DESCRIPTION
### Description
Updates the API specification for the `msearch` endpoint, to include the `include_named_queries_score` query parameter, to go along with this PR https://github.com/opensearch-project/OpenSearch/pull/19241.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
