### PR TITLE
Remove duplicate Suggest from SearchResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,7 +332,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed `shape` query ([#531](https://github.com/opensearch-project/opensearch-api-specification/pull/531))
 - Removed unsupported DataStream Lifecycle types ([#600](https://github.com/opensearch-project/opensearch-api-specification/pull/600))
 - Removed unsupported runtime field types ([#634](https://github.com/opensearch-project/opensearch-api-specification/pull/634))
-
+- Removed duplicate Suggest from SearchResult ([#957](https://github.com/opensearch-project/opensearch-api-specification/pull/957))
 ### Fixed
 
 - Fixed GitHub pages ([#215](https://github.com/opensearch-project/opensearch-api-specification/pull/215))

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -1367,34 +1367,7 @@ components:
           additionalProperties:
             type: array
             items:
-              allOf:
-                - $ref: '#/components/schemas/Suggest'
-                - oneOf:
-                    - title: completion
-                      allOf:
-                        - $ref: '#/components/schemas/CompletionSuggest'
-                        - type: object
-                          properties:
-                            options:
-                              oneOf:
-                                - allOf:
-                                    - $ref: '#/components/schemas/CompletionSuggestOption'
-                                    - type: object
-                                      properties:
-                                        _source:
-                                          $ref: '#/components/schemas/TDocument'
-                                - type: array
-                                  items:
-                                    allOf:
-                                      - $ref: '#/components/schemas/CompletionSuggestOption'
-                                      - type: object
-                                        properties:
-                                          _source:
-                                            $ref: '#/components/schemas/TDocument'
-                    - title: phrase
-                      $ref: '#/components/schemas/PhraseSuggest'
-                    - title: term
-                      $ref: '#/components/schemas/TermSuggest'
+              $ref: '#/components/schemas/Suggest'
         terminated_early:
           type: boolean
       required:


### PR DESCRIPTION
### Description
Simplifies the `suggest` field by removing redundant schema definitions and consolidating the structure to use a single reference to the `Suggest` schema.

