### PR TITLE
Simplify RangeQuery to unified type with oneOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Changed `cluster.reroute`'s `metric` path param to use an enum of metrics ([#586](https://github.com/opensearch-project/opensearch-api-specification/pull/586))
 - Changed `indices.stats`'s `metric` path param to use an enum of metrics ([#586](https://github.com/opensearch-project/opensearch-api-specification/pull/586))
 - Changed `CleanupRepositoryResults`' properties to be `int64`s ([#587](https://github.com/opensearch-project/opensearch-api-specification/pull/587))
+- Changed `RangeQuery` to unified type with oneOf ([#958](https://github.com/opensearch-project/opensearch-api-specification/pull/958))
 
 ### Deprecated
 

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -1670,67 +1670,54 @@ components:
           required:
             - query
     RangeQuery:
-      oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/RangeQueryBase'
-            - $ref: '#/components/schemas/NumberRangeQueryParameters'
-        - allOf:
-            - $ref: '#/components/schemas/RangeQueryBase'
-            - $ref: '#/components/schemas/DateRangeQueryParameters'
-    DateRangeQueryParameters:
-      type: object
-      properties:
-        gt:
-          $ref: '_common.yaml#/components/schemas/DateMath'
-        gte:
-          $ref: '_common.yaml#/components/schemas/DateMath'
-        lt:
-          $ref: '_common.yaml#/components/schemas/DateMath'
-        lte:
-          $ref: '_common.yaml#/components/schemas/DateMath'
-        from:
-          oneOf:
-            - $ref: '_common.yaml#/components/schemas/DateMath'
-            - type: 'null'
-        to:
-          oneOf:
-            - $ref: '_common.yaml#/components/schemas/DateMath'
-            - type: 'null'
-        format:
-          $ref: '_common.yaml#/components/schemas/DateFormat'
-        time_zone:
-          $ref: '_common.yaml#/components/schemas/TimeZone'
-    NumberRangeQueryParameters:
-      type: object
-      properties:
-        gt:
-          description: Greater than.
-          type: number
-          format: double
-        gte:
-          description: Greater than or equal to.
-          type: number
-          format: double
-        lt:
-          description: Less than.
-          type: number
-          format: double
-        lte:
-          description: Less than or equal to.
-          type: number
-          format: double
-        from:
-          oneOf:
-            - type: number
-              format: double
-            - type: string
-            - type: 'null'
-        to:
-          oneOf:
-            - type: number
-              format: double
-            - type: string
-            - type: 'null'
+      allOf:
+        - $ref: '#/components/schemas/RangeQueryBase'
+        - type: object
+          properties:
+            gt:
+              description: Greater than.
+              oneOf:
+                - $ref: '_common.yaml#/components/schemas/DateMath'
+                - type: number
+                  format: double
+            gte:
+              description: Greater than or equal to.
+              oneOf:
+                - type: number
+                  format: double
+                - $ref: '_common.yaml#/components/schemas/DateMath'
+            lt:
+              description: Less than.
+              oneOf:
+                - $ref: '_common.yaml#/components/schemas/DateMath'
+                - type: number
+                  format: double
+            lte:
+              description: Less than or equal to.
+              oneOf:
+                - $ref: '_common.yaml#/components/schemas/DateMath'
+                - type: number
+                  format: double
+            from:
+              oneOf:
+                - $ref: '_common.yaml#/components/schemas/DateMath'
+                - type: 'null'
+                - type: number
+                  format: double
+            to:
+              oneOf:
+                - $ref: '_common.yaml#/components/schemas/DateMath'
+                - type: 'null'
+                - type: number
+                  format: double
+            include_lower:
+              type: boolean
+            include_upper:
+              type: boolean
+            format:
+              $ref: '_common.yaml#/components/schemas/DateFormat'
+            time_zone:
+              $ref: '_common.yaml#/components/schemas/TimeZone'
     RangeQueryBase:
       allOf:
         - $ref: '#/components/schemas/QueryBase'

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -771,7 +771,7 @@ components:
           $ref: '#/components/schemas/FieldLookup'
         shape:
           $ref: '#/components/schemas/GeoShape'
-        relation: 
+        relation:
           $ref: '_common.yaml#/components/schemas/GeoShapeRelation'
       required:
         - shape
@@ -1670,54 +1670,67 @@ components:
           required:
             - query
     RangeQuery:
+      oneOf:
+        - $ref: '#/components/schemas/NumberRangeQuery'
+        - $ref: '#/components/schemas/DateRangeQuery'
+    DateRangeQuery:
+      allOf:
+        - $ref: '#/components/schemas/RangeQueryBase'
+        - type: object
+          properties:
+            gt:
+              $ref: '_common.yaml#/components/schemas/DateMath'
+            gte:
+              $ref: '_common.yaml#/components/schemas/DateMath'
+            lt:
+              $ref: '_common.yaml#/components/schemas/DateMath'
+            lte:
+              $ref: '_common.yaml#/components/schemas/DateMath'
+            from:
+              oneOf:
+                - $ref: '_common.yaml#/components/schemas/DateMath'
+                - type: 'null'
+            to:
+              oneOf:
+                - $ref: '_common.yaml#/components/schemas/DateMath'
+                - type: 'null'
+            format:
+              $ref: '_common.yaml#/components/schemas/DateFormat'
+            time_zone:
+              $ref: '_common.yaml#/components/schemas/TimeZone'
+    NumberRangeQuery:
       allOf:
         - $ref: '#/components/schemas/RangeQueryBase'
         - type: object
           properties:
             gt:
               description: Greater than.
-              oneOf:
-                - $ref: '_common.yaml#/components/schemas/DateMath'
-                - type: number
-                  format: double
+              type: number
+              format: double
             gte:
               description: Greater than or equal to.
-              oneOf:
-                - type: number
-                  format: double
-                - $ref: '_common.yaml#/components/schemas/DateMath'
+              type: number
+              format: double
             lt:
               description: Less than.
-              oneOf:
-                - $ref: '_common.yaml#/components/schemas/DateMath'
-                - type: number
-                  format: double
+              type: number
+              format: double
             lte:
               description: Less than or equal to.
-              oneOf:
-                - $ref: '_common.yaml#/components/schemas/DateMath'
-                - type: number
-                  format: double
+              type: number
+              format: double
             from:
               oneOf:
-                - $ref: '_common.yaml#/components/schemas/DateMath'
-                - type: 'null'
                 - type: number
                   format: double
+                - type: string
+                - type: 'null'
             to:
               oneOf:
-                - $ref: '_common.yaml#/components/schemas/DateMath'
-                - type: 'null'
                 - type: number
                   format: double
-            include_lower:
-              type: boolean
-            include_upper:
-              type: boolean
-            format:
-              $ref: '_common.yaml#/components/schemas/DateFormat'
-            time_zone:
-              $ref: '_common.yaml#/components/schemas/TimeZone'
+                - type: string
+                - type: 'null'
     RangeQueryBase:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
@@ -2219,7 +2232,7 @@ components:
           $ref: '#/components/schemas/FieldLookup'
         shape:
           $ref: '#/components/schemas/XyShape'
-        relation: 
+        relation:
           $ref: '_common.yaml#/components/schemas/GeoShapeRelation'
       required:
         - shape


### PR DESCRIPTION
### Description
Update RangeQuery
Removed: DateRangeQueryParameters and NumberRangeQueryParameters separate types
Added: Single unified RangeQuery type with oneOf for each bound field
Added: Missing include_lower and include_upper fields
