### PR TITLE
Add maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @harshavamsi @sachetalva @nhtruong @Xtansia @VachaShah @Tokesh @aabeshov
+*   @harshavamsi @sachetalva @nhtruong @Xtansia @VachaShah @Tokesh @aabeshov @karenyrx @lucy66hw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added API spec for `adjust_pure_negative` for bool queries ([#641](https://github.com/opensearch-project/opensearch-api-specification/pull/641))
 - Added a spec style checker [#620](https://github.com/opensearch-project/opensearch-api-specification/pull/620).
 - Added `remote_store` to node `Stats` ([#643](https://github.com/opensearch-project/opensearch-api-specification/pull/643))
+- Added `karenyrx` and `lucy66hw` in maintainers list ([#960](https://github.com/opensearch-project/opensearch-api-specification/pull/960))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,7 +299,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added API spec for `adjust_pure_negative` for bool queries ([#641](https://github.com/opensearch-project/opensearch-api-specification/pull/641))
 - Added a spec style checker [#620](https://github.com/opensearch-project/opensearch-api-specification/pull/620).
 - Added `remote_store` to node `Stats` ([#643](https://github.com/opensearch-project/opensearch-api-specification/pull/643))
-- Added `karenyrx` and `lucy66hw` in maintainers list ([#960](https://github.com/opensearch-project/opensearch-api-specification/pull/960))
 
 ### Changed
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,16 +8,16 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 ## Current Maintainers
 
 | Maintainer           | GitHub ID                                     | Affiliation |
-|----------------------| --------------------------------------------- |-------------|
+|----------------------|-----------------------------------------------|-------------|
 | Alen Abeshov         | [aabeshov](https://github.com/aabeshov)       |             |
 | Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
+| Karen Xu             | [karenyrx](https://github.com/karenyrx)       | Uber        |
 | Sachet Alva          | [sachetalva](https://github.com/sachetalva)   | Amazon      |
 | Theo Truong          | [nhtruong](https://github.com/nhtruong)       | Amazon      |
 | Thomas Farr          | [Xtansia](https://github.com/Xtansia)         | Amazon      |
 | Torekeldi Niyazbek   | [Tokesh](https://github.com/Tokesh)           |             |
 | Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |
-| Karen Xu             | [karenyrx](https://github.com/karenyrx)     | Uber        |
-| Xi Lu                | [lucy66hw](hhttps://github.com/lucy66hw)     | Uber        |
+| Xi Lu                | [lucy66hw](hhttps://github.com/lucy66hw)      | Uber        |
 
 
 ## Emeritus

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 ## Current Maintainers
 
 | Maintainer           | GitHub ID                                     | Affiliation |
-| -------------------- | --------------------------------------------- | ----------- |
+|----------------------| --------------------------------------------- |-------------|
 | Alen Abeshov         | [aabeshov](https://github.com/aabeshov)       |             |
 | Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
 | Sachet Alva          | [sachetalva](https://github.com/sachetalva)   | Amazon      |
@@ -16,6 +16,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Thomas Farr          | [Xtansia](https://github.com/Xtansia)         | Amazon      |
 | Torekeldi Niyazbek   | [Tokesh](https://github.com/Tokesh)           |             |
 | Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |
+| Karen Xu             | [karenyrx](https://github.com/karenyrx)     | Uber        |
+| Xi Lu                | [lucy66hw](hhttps://github.com/lucy66hw)     | Uber        |
+
 
 ## Emeritus
 


### PR DESCRIPTION
_Ammending on behalf of Xi Lu and Karen Xu_

@lucy66hw has authored 9 PRs:
- Refactoring changes - https://github.com/opensearch-project/opensearch-api-specification/pull/958, https://github.com/opensearch-project/opensearch-api-specification/pull/957, https://github.com/opensearch-project/opensearch-api-specification/pull/892, https://github.com/opensearch-project/opensearch-api-specification/pull/865, https://github.com/opensearch-project/opensearch-api-specification/pull/862, https://github.com/opensearch-project/opensearch-api-specification/pull/826
- Deprecating and bug fixes - https://github.com/opensearch-project/opensearch-api-specification/pull/956, https://github.com/opensearch-project/opensearch-api-specification/pull/948, https://github.com/opensearch-project/opensearch-api-specification/pull/961


@karenyrx has the following contributions:
- a huge proposal around protobuf tooling - https://github.com/opensearch-project/opensearch-api-specification/issues/677
- PR's involving fixes to the code base https://github.com/opensearch-project/opensearch-api-specification/pull/949, https://github.com/opensearch-project/opensearch-api-specification/pull/891, https://github.com/opensearch-project/opensearch-api-specification/pull/860, https://github.com/opensearch-project/opensearch-api-specification/pull/843

Based on these contributions, the maintainers have voted and accepted them to become new maintainers, will forward the email thread as needed