### PR TITLE
Remove unused field from Cardinality, Terms, Missing aggregations

### DIFF
--- a/spec/schemas/_common.aggregations.yaml
+++ b/spec/schemas/_common.aggregations.yaml
@@ -1946,8 +1946,6 @@ components:
                 This allows to trade memory for accuracy.
               type: integer
               format: int32
-            rehash:
-              type: boolean
             execution_hint:
               $ref: '#/components/schemas/CardinalityExecutionMode'
     CardinalityExecutionMode:
@@ -1955,9 +1953,6 @@ components:
       enum:
         - direct
         - global_ordinals
-        - save_memory_heuristic
-        - save_time_heuristic
-        - segment_ordinals
     ChildrenAggregation:
       allOf:
         - $ref: '#/components/schemas/BucketAggregationBase'
@@ -3097,8 +3092,6 @@ components:
       type: string
       enum:
         - global_ordinals
-        - global_ordinals_hash
-        - global_ordinals_low_cardinality
         - map
     GoogleNormalizedDistanceHeuristic:
       type: object
@@ -3213,10 +3206,6 @@ components:
               format: int32
             missing:
               $ref: '_common.yaml#/components/schemas/FieldValue'
-            missing_order:
-              $ref: '#/components/schemas/MissingOrder'
-            missing_bucket:
-              type: boolean
             value_type:
               description: Coerced unmapped fields into the specified type.
               type: string


### PR DESCRIPTION
### Description
Remove several unused fields from aggregation types.

- Cardinality execution hints are unused:
save_memory_heuristic, save_time_heuristic, segment_ordinals are unused.
Only direct and global ords are valid: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregatorFactory.java#L62-L80
Some of these are ES concept it seems?

- Rehash is deprecated for cardinality agg:
https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/aggregations/metrics/CardinalityAggregationBuilder.java#L69-L81

- Terms agg does not have any "missing" boolean usages.

- Missing order param in terms agg does not seem appropriate.
Terms agg has deterministic ordering as missing buckets are replaced with "missing" key.
Missing order seems to be a composite agg only concept for cases where bucket keys are of different types.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
