### PR TITLE
Add name and metadata to metric aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed the default parameters for `data_stream/_stats` and `shard_stores/status` ([#931](https://github.com/opensearch-project/opensearch-api-specification/pull/931))
 - Fixed the type of `SearchStats`'s `concurrent_avg_slice_count` to be a double ([#942](https://github.com/opensearch-project/opensearch-api-specification/pull/942))
+- Fixed name and metadata missing from metric aggregations ([#969](https://github.com/opensearch-project/opensearch-api-specification/pull/969))
 - Fixed the type of `param` in pull-based ingestion's `ingestion_source` to take in Object for value instead of string ([#945](https://github.com/opensearch-project/opensearch-api-specification/pull/945))
 
 ### Changed

--- a/spec/schemas/_common.aggregations.yaml
+++ b/spec/schemas/_common.aggregations.yaml
@@ -1840,14 +1840,16 @@ components:
             format:
               type: string
     MetricAggregationBase:
-      type: object
-      properties:
-        field:
-          $ref: '_common.yaml#/components/schemas/Field'
-        missing:
-          $ref: '_common.yaml#/components/schemas/FieldValue'
-        script:
-          $ref: '_common.yaml#/components/schemas/Script'
+      allOf:
+        - $ref: '#/components/schemas/Aggregation'
+        - type: object
+          properties:
+            field:
+              $ref: '_common.yaml#/components/schemas/Field'
+            missing:
+              $ref: '_common.yaml#/components/schemas/FieldValue'
+            script:
+              $ref: '_common.yaml#/components/schemas/Script'
     AverageBucketAggregation:
       allOf:
         - $ref: '#/components/schemas/PipelineAggregationBase'


### PR DESCRIPTION
### Description
Base aggregation schema includes name and metadata which is applied to almost all aggregations.
Metric aggregations should inherit these properties as well.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
