### PR TITLE
Limit sub aggregations to bucket aggs only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Changed schema of `NodeInfoSearchPipelines`'s `response_processors` & `request_processors` to use `NodeInfoSearchPipelineProcessor` instead of `NodeInfoIngestProcessor` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))
 - Changed knn stats response types to use int64s instead of numbers ([#942](https://github.com/opensearch-project/opensearch-api-specification/pull/942))
+- Moved sub aggregations into `BucketAggregationBase` as their usage is only valid here ([#971](https://github.com/opensearch-project/opensearch-api-specification/pull/971))
 
 ## [0.2.0] - 2025-05-25
 

--- a/spec/schemas/_common.aggregations.yaml
+++ b/spec/schemas/_common.aggregations.yaml
@@ -1423,20 +1423,6 @@ components:
       allOf: 
         - type: object
           properties:
-            aggregations:
-              description: |-
-                Sub-aggregations for this aggregation.
-                Only applies to bucket aggregations.
-              type: object
-              additionalProperties:
-                $ref: '#/components/schemas/AggregationContainer'
-            aggs:
-              description: |-
-                Sub-aggregations for this aggregation.
-                Only applies to bucket aggregations.
-              type: object
-              additionalProperties:
-                $ref: '#/components/schemas/AggregationContainer'
             meta:
               $ref: '_common.yaml#/components/schemas/Metadata'
         - type: object
@@ -1782,6 +1768,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/Aggregation'
         - type: object
+          properties:
+            aggregations:
+              description: Sub-aggregations for this bucket aggregation
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/AggregationContainer'
+            aggs:
+              description: Sub-aggregations for this bucket aggregation
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/AggregationContainer'
     Aggregation:
       type: object
       properties:


### PR DESCRIPTION
### Description
Sub aggregations are currently included in the `AggregationContainer` spec however these are only valid for bucket aggregations. We should reflect this by moving them into the `BucketAggregationBase` spec.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
