### PR TITLE
Fix datatype for params min_size, min_index_age and min_primary_shard_size to string

### DIFF
--- a/spec/schemas/ism._common.yaml
+++ b/spec/schemas/ism._common.yaml
@@ -212,16 +212,16 @@ components:
       type: object
       properties:
         min_size:
-          type: number
+          type: string
           description: The minimum size to trigger rollover.
         min_index_age:
-          type: number
+          type: string
           description: The minimum index age to trigger rollover.
         min_doc_count:
           type: number
           description: The minimum document count to trigger rollover.
         min_primary_shard_size:
-          type: number
+          type: string
           description: The minimum primary shard size to trigger rollover.
         copy_alias:
           type: boolean


### PR DESCRIPTION
### Description
minIndexAge, minPrimaryShardSize and other such params are of type 'Number' but should be string as opensearch requires it be of format "5m", "1d" etc.

`java-client/src/generated/java/org/opensearch/client/opensearch/ism/ActionRollover.java`

Error: `failed to parse setting [min_index_age] with value [300000.0] as a time value: unit is missing or unrecognized`

The documentation seems to show the correct types: https://docs.opensearch.org/latest/im-plugin/ism/policies/#rollover


### Issues Resolved
#973

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
