### PR TITLE
Added x-protobuf-excluded vendor extension

### DIFF
--- a/.cspell
+++ b/.cspell
@@ -8,3 +8,4 @@ mxyz
 opendistro
 opensearch
 OPENSEARCH
+protobuf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added API spec for `adjust_pure_negative` for bool queries ([#641](https://github.com/opensearch-project/opensearch-api-specification/pull/641))
 - Added a spec style checker [#620](https://github.com/opensearch-project/opensearch-api-specification/pull/620).
 - Added `remote_store` to node `Stats` ([#643](https://github.com/opensearch-project/opensearch-api-specification/pull/643))
+- Added `x-protobuf-excluded` vendor extension ([#980](https://github.com/opensearch-project/opensearch-api-specification/pull/980))
 
 ### Changed
 

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -5420,6 +5420,7 @@ components:
       schema:
         type: string
       style: form
+      x-protobuf-excluded: true
     search::query.batched_reduce_size:
       in: query
       name: batched_reduce_size
@@ -5481,6 +5482,7 @@ components:
       schema:
         type: boolean
       style: form
+      x-protobuf-excluded: true
     search::query.from:
       in: query
       name: from
@@ -5494,6 +5496,7 @@ components:
         format: int32
         default: 0
       style: form
+      x-protobuf-excluded: true
     search::query.ignore_throttled:
       in: query
       name: ignore_throttled
@@ -5516,6 +5519,7 @@ components:
         type: boolean
         default: false
         description: Indicates whether `hit.matched_queries` should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false)
+      x-protobuf-excluded: true
     search::query.lenient:
       in: query
       name: lenient
@@ -5525,6 +5529,7 @@ components:
       schema:
         type: boolean
       style: form
+      x-protobuf-excluded: true
     search::query.max_concurrent_shard_requests:
       in: query
       name: max_concurrent_shard_requests
@@ -5639,6 +5644,7 @@ components:
       schema:
         type: boolean
       style: form
+      x-protobuf-excluded: true
     search::query.size:
       in: query
       name: size
@@ -5651,6 +5657,7 @@ components:
         format: int32
         default: 10
       style: form
+      x-protobuf-excluded: true
     search::query.sort:
       in: query
       name: sort
@@ -5658,6 +5665,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/StringOrStringArray'
       style: form
+      x-protobuf-excluded: true
     search::query.stats:
       in: query
       name: stats
@@ -5667,6 +5675,7 @@ components:
         items:
           type: string
       style: form
+      x-protobuf-excluded: true
     search::query.stored_fields:
       in: query
       name: stored_fields
@@ -5678,6 +5687,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Fields'
       style: form
+      x-protobuf-excluded: true
     search::query.suggest_field:
       in: query
       name: suggest_field
@@ -5729,6 +5739,7 @@ components:
         type: integer
         format: int32
       style: form
+      x-protobuf-excluded: true
     search::query.timeout:
       in: query
       name: timeout
@@ -5738,6 +5749,7 @@ components:
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'
       style: form
+      x-protobuf-excluded: true
     search::query.track_scores:
       in: query
       name: track_scores
@@ -5745,6 +5757,7 @@ components:
       schema:
         type: boolean
       style: form
+      x-protobuf-excluded: true
     search::query.track_total_hits:
       in: query
       name: track_total_hits
@@ -5755,6 +5768,7 @@ components:
       schema:
         $ref: '../schemas/_core.search.yaml#/components/schemas/TrackHits'
       style: form
+      x-protobuf-excluded: true
     search::query.typed_keys:
       in: query
       name: typed_keys
@@ -5776,6 +5790,7 @@ components:
       schema:
         type: boolean
       style: form
+      x-protobuf-excluded: true
     search::query.version:
       in: query
       name: version
@@ -5783,6 +5798,7 @@ components:
       schema:
         type: boolean
       style: form
+      x-protobuf-excluded: true
     search::query.phase_took:
       name: phase_took
       in: query

--- a/tools/src/linter/SchemasValidator.ts
+++ b/tools/src/linter/SchemasValidator.ts
@@ -20,7 +20,8 @@ const ADDITIONAL_KEYWORDS = [
   'x-distributions-included',
   'x-distributions-excluded',
   'x-supports-typed-keys',
-  'x-is-generic-type-parameter'
+  'x-is-generic-type-parameter',
+  'x-protobuf-excluded'
 ]
 
 export default class SchemasValidator {

--- a/tools/src/tester/SchemaValidator.ts
+++ b/tools/src/tester/SchemaValidator.ts
@@ -23,7 +23,8 @@ const ADDITIONAL_KEYWORDS = [
   'x-distributions-included',
   'x-distributions-excluded',
   'x-supports-typed-keys',
-  'x-is-generic-type-parameter'
+  'x-is-generic-type-parameter',
+  'x-protobuf-excluded'
 ]
 
 export default class SchemaValidator {


### PR DESCRIPTION
### Description
Added x-protobuf-excluded vendor extension
The vendor extension is used for protobuf generate. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
