### PR TITLE
Remove `_name` and `boost` from `TermsQuery`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed the type of `SearchStats`'s `concurrent_avg_slice_count` to be a double ([#942](https://github.com/opensearch-project/opensearch-api-specification/pull/942))
 - Fixed name and metadata missing from metric aggregations ([#969](https://github.com/opensearch-project/opensearch-api-specification/pull/969))
 - Fixed the type of `param` in pull-based ingestion's `ingestion_source` to take in Object for value instead of string ([#945](https://github.com/opensearch-project/opensearch-api-specification/pull/945))
+- Fixed `TermsQuery` `_name` and `boost` type ([#984](https://github.com/opensearch-project/opensearch-api-specification/pull/984))
 
 ### Changed
 - Changed schema of `NodeInfoSearchPipelines`'s `response_processors` & `request_processors` to use `NodeInfoSearchPipelineProcessor` instead of `NodeInfoIngestProcessor` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -2144,23 +2144,24 @@ components:
         - bitmap
         - default
     TermsQuery:
-      allOf:
-        - $ref: '#/components/schemas/QueryBase'
-        - type: object
-          properties:
-            _name: {}
-            boost: {}
-            value_type:
-              description: |-
-                Specifies the types of values used for filtering. Valid values are `default` and `bitmap`. Default is `default`.
-              $ref: '#/components/schemas/TermsQueryValueType'
-          propertyNames:
-            title: field
-            type: string
-          additionalProperties:
-            title: terms
-            $ref: '#/components/schemas/TermsQueryField'
-          minProperties: 1
+      type: object
+      properties:
+        _name:
+          type: string
+        boost:
+          type: number
+          format: float
+        value_type:
+          description: |-
+            Specifies the types of values used for filtering. Valid values are `default` and `bitmap`. Default is `default`.
+          $ref: '#/components/schemas/TermsQueryValueType'
+      propertyNames:
+        title: field
+        type: string
+      additionalProperties:
+        title: terms
+        $ref: '#/components/schemas/TermsQueryField'
+      minProperties: 1
     TermsQueryField:
       oneOf:
         - title: value


### PR DESCRIPTION
### Description
Remove `_name` and `boost` from `TermsQuery`

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
