### PR TITLE
Do not mark force_source as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Changed `WaitForActiveShards` to utilize `StringifiedInteger` ([#896](https://github.com/opensearch-project/opensearch-api-specification/pull/896))
 - Changed `NeuralStats` schema validation from `oneOf` to `anyOf` ([#900](https://github.com/opensearch-project/opensearch-api-specification/pull/900))
 - Changed `ErrorCause` schema header type to map ([#982](https://github.com/opensearch-project/opensearch-api-specification/pull/982))
+- Changed `force_source` to not be deprecated ([#996](https://github.com/opensearch-project/opensearch-api-specification/pull/996))
 
 ## [0.1.0] - 2024-10-25
 

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -146,10 +146,10 @@ components:
           format: int64
         input_data: {}
         output_data: {}
-        status: 
+        status:
           type: string
         tag:
-          type: string 
+          type: string
         error:
           type: string
     NestedIdentity:
@@ -846,7 +846,6 @@ components:
             This parameter takes the form of a language tag, for example, `"en-US"`, `"fr-FR"`, or `"ja-JP"`.
           type: string
         force_source:
-          deprecated: true
           type: boolean
         fragmenter:
           $ref: '#/components/schemas/HighlighterFragmenter'
@@ -1329,10 +1328,10 @@ components:
           $ref: '_common.yaml#/components/schemas/PhaseTook'
         hits:
           $ref: '#/components/schemas/HitsMetadata'
-        processor_results: 
+        processor_results:
           x-version-added: '3.0'
           type: array
-          items: 
+          items:
             $ref: '#/components/schemas/ProcessorExecutionDetail'
         aggregations:
           type: object


### PR DESCRIPTION
### Description
force_source is an active field in AbstractHighlighterBuilder (which HighlightBuilder.Field extends).

### Issues Resolved
General spec fix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
