### PR TITLE
Remove unsupported PinnedQuery and mark x-version-deprecated to cutoff_frequency in MultiMatchQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))
 - Remove `force` from `VersionType` ([#949](https://github.com/opensearch-project/opensearch-api-specification/pull/949))
+- Remove unsupported `PinnedQuery` and mark x-version-deprecated to field `cutoff_frequency` in `MultiMatchQuery` ([#1000](https://github.com/opensearch-project/opensearch-api-specification/pull/1000))
 
 ### Fixed
 - Fixed the default parameters for `data_stream/_stats` and `shard_stores/status` ([#931](https://github.com/opensearch-project/opensearch-api-specification/pull/931))

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -150,8 +150,6 @@ components:
           $ref: '#/components/schemas/ParentIdQuery'
         percolate:
           $ref: '#/components/schemas/PercolateQuery'
-        pinned:
-          $ref: '#/components/schemas/PinnedQuery'
         prefix:
           description: Returns documents that contain a specific prefix in a provided field.
           type: object
@@ -1404,7 +1402,7 @@ components:
               description: If `true`, match phrase queries are automatically created for multi-term synonyms.
               type: boolean
             cutoff_frequency:
-              deprecated: true
+              x-version-deprecated: '2.0'
               type: number
               format: float
             fields:
@@ -1541,44 +1539,6 @@ components:
               $ref: '_common.yaml#/components/schemas/VersionNumber'
           required:
             - field
-    PinnedQuery:
-      allOf:
-        - $ref: '#/components/schemas/QueryBase'
-        - allOf:
-            - type: object
-              properties:
-                organic:
-                  $ref: '#/components/schemas/QueryContainer'
-              required:
-                - organic
-            - type: object
-              properties:
-                ids:
-                  description: |-
-                    Document IDs listed in the order they are to appear in results.
-                    Required if `docs` is not specified.
-                  type: array
-                  items:
-                    $ref: '_common.yaml#/components/schemas/Id'
-                docs:
-                  description: |-
-                    Documents listed in the order they are to appear in results.
-                    Required if `ids` is not specified.
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/PinnedDoc'
-              minProperties: 1
-              maxProperties: 1
-    PinnedDoc:
-      type: object
-      properties:
-        _id:
-          $ref: '_common.yaml#/components/schemas/Id'
-        _index:
-          $ref: '_common.yaml#/components/schemas/IndexName'
-      required:
-        - _id
-        - _index
     PrefixQuery:
       oneOf:
         - title: value


### PR DESCRIPTION
### Description
1. Remove unsupported PinnedQuery. https://github.com/opensearch-project/OpenSearch/issues/72
2. Mark x-version-deprecated to cutoff_frequency in MultiMatchQuery
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
