### PR TITLE
Change ism api last_update_times to long

### DIFF
--- a/spec/schemas/ism._common.yaml
+++ b/spec/schemas/ism._common.yaml
@@ -30,6 +30,7 @@ components:
           description: The description of the policy.
         last_updated_time:
           type: integer
+          format: int64
           description: When the policy was last updated.
         schema_version:
           type: number
@@ -411,6 +412,7 @@ components:
           description: The name of the notification destination.
         last_update_time:
           type: integer
+          format: int64
           description: When the notification destination was last updated.
       additionalProperties:
         anyOf:
@@ -475,6 +477,7 @@ components:
           description: The priority of the ISM template.
         last_updated_time:
           type: integer
+          format: int64
           description: When the ISM template was last updated.
     RetryIndexRequest:
       type: object


### PR DESCRIPTION
### Description
Changes last_update_time formats from int32 to int64 to avoid issues parsing it as integer instead of long

### Issues Resolved
part of a fix for https://github.com/opensearch-project/opensearch-java/issues/1717

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
