### PR TITLE
Add `search` and `warm` node roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `allow_no_indices`, `ignore_unavailable`, and `ignore_throttled` query parameters to `create_pit` ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
 - Added `query` to TermsLookup to support terms lookup by query
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
+- Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -2558,6 +2558,13 @@ components:
           const: cluster_manager
           description: The node can act as a cluster manager.
           x-version-added: '2.0'
+        - type: string
+          const: search
+          description: The node can hold search replicas. Before 3.0 `search` nodes were `warm` nodes.
+        - type: string
+          const: warm
+          description: The node can act as a search node for searchable snapshots.
+          x-version-added: '3.0'
     HttpHeaders:
       type: object
       description: The HTTP headers.

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -2543,6 +2543,13 @@ components:
           const: cluster_manager
           description: The node can act as a cluster manager.
           x-version-added: '2.0'
+        - type: string
+          const: search
+          description: The node can hold search replicas. Before 3.0 `search` nodes were `warm` nodes.
+        - type: string
+          const: warm
+          description: The node can act as a search node for searchable snapshots.
+          x-version-added: '3.0'
     HttpHeaders:
       type: object
       description: The HTTP headers.

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -2560,10 +2560,16 @@ components:
           x-version-added: '2.0'
         - type: string
           const: search
-          description: The node can hold search replicas. Before 3.0 `search` nodes were `warm` nodes.
+          description: The node was dedicated to provide search capability for searchable snapshots. Renamed to `warm` in 3.0.
+          x-version-added: '2.4'
+          x-version-removed: '3.0'
+        - type: string
+          const: search
+          description: The node can host search replicas (search-only shards). This role must not be combined with any other role on a node. Introduced in 3.0; not to be confused with the pre-3.0 `search` role that was renamed to `warm`.
+          x-version-added: '3.0'
         - type: string
           const: warm
-          description: The node can act as a search node for searchable snapshots.
+          description: The node can hold warm indexes for searchable snapshots. Before 3.0 this role was named `search`.
           x-version-added: '3.0'
     HttpHeaders:
       type: object


### PR DESCRIPTION
### Description
Adds the node roles `search` and `warm` to the roles constants.
`search` has been available for a long while for searchable snapshots and renamed to `warm` in [3.0](https://github.com/opensearch-project/OpenSearch/pull/17573)

### Issues Resolved
fixes https://github.com/opensearch-project/opensearch-java/issues/893
(although it should be discussed if a static list of roles should be used as in theory any role defined in the node configuration would be provided and possibly break apis, as is the case for the java client)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
