### PR TITLE
Add x-protobuf-excluded to SearchResult::hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `semantic` field type ([#995](https://github.com/opensearch-project/opensearch-api-specification/pull/995))
 - Add `x-protobuf-required` vendor extension for enforcing required Protobuf fields ([#1002](https://github.com/opensearch-project/opensearch-api-specification/pull/1002))
 - Add `RepositoryStatsSnapshot` schema to `ShardRepositoriesStats` in nodes.stats API ([#997](https://github.com/opensearch-project/opensearch-api-specification/pull/997))
+- Add `x-protobuf-excluded` to SearchResult::hits ([#1012](https://github.com/opensearch-project/opensearch-api-specification/pull/1012))
 
 ### Removed
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -1343,6 +1343,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/HitsMetadata'
             - type: object
+              x-protobuf-excluded: true
               properties:
                 hits:
                   type: array


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/opensearch-api-specification/pull/1011
Adding an extra hits definition could impact protobuf. Adding `x-protobuf-excluded` to avoid introducing a breaking change for protobuf
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
