### PR TITLE
Fix required/optional tokenizer parameters

### DIFF
--- a/spec/schemas/_common.analysis.yaml
+++ b/spec/schemas/_common.analysis.yaml
@@ -1644,9 +1644,6 @@ components:
               items:
                 $ref: '#/components/schemas/TokenChar'
           required:
-            - max_gram
-            - min_gram
-            - token_chars
             - type
     TokenChar:
       type: string
@@ -1669,7 +1666,6 @@ components:
             buffer_size:
               type: integer
           required:
-            - buffer_size
             - type
     LetterTokenizer:
       allOf:
@@ -1713,9 +1709,6 @@ components:
               items:
                 $ref: '#/components/schemas/TokenChar'
           required:
-            - max_gram
-            - min_gram
-            - token_chars
             - type
     NoriTokenizer:
       allOf:
@@ -1758,10 +1751,6 @@ components:
             skip:
               $ref: '_common.yaml#/components/schemas/StringifiedInteger'
           required:
-            - buffer_size
-            - delimiter
-            - reverse
-            - skip
             - type
     StandardTokenizer:
       allOf:


### PR DESCRIPTION
### Description
The `opensearch-java` client fails to deserialize OpenSearch payloads due to optional parameters in tokenizers set to required.

In this PR, required properties for tokenizers have been set according to the documented values from the corresponding tokenizer on https://docs.opensearch.org/latest/analyzers/tokenizers/index/

### Issues Resolved
fixes https://github.com/opensearch-project/opensearch-java/issues/1797

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
