### PR TITLE
Remove force from VersionType (correction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))
-- Remove `force` from `VersionType` ([#949](https://github.com/opensearch-project/opensearch-api-specification/pull/949))
 - Remove unsupported `PinnedQuery` and mark x-version-deprecated to field `cutoff_frequency` in `MultiMatchQuery` ([#1000](https://github.com/opensearch-project/opensearch-api-specification/pull/1000))
+- Remove `force` from `VersionType` ([#1017](https://github.com/opensearch-project/opensearch-api-specification/pull/1017))
 
 ### Fixed
 - Fixed the default parameters for `data_stream/_stats` and `shard_stores/status` ([#931](https://github.com/opensearch-project/opensearch-api-specification/pull/931))

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -802,9 +802,6 @@ components:
           const: external_gte
           description: The version number must be greater than or equal to the current version.
         - type: string
-          const: force
-          description: The version number is forced to be the given value.
-        - type: string
           const: internal
           description: The version number is managed internally by OpenSearch.
     TimeZone:


### PR DESCRIPTION
### Description
The change in https://github.com/opensearch-project/opensearch-api-specification/pull/949/files did not properly get applied in the previous PR so fixing it in this one. 
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
