### PR TITLE
Add no_sub_matches and no_overlapping_matches to HyphenationDecompounderTokenFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add `x-protobuf-excluded` to QueryContainer::template ([#1013](https://github.com/opensearch-project/opensearch-api-specification/pull/1013))
 - Add proto compatibility check workflow for PRs and post-deployment ([#1020](https://github.com/opensearch-project/opensearch-api-specification/pull/1020))
 - Split proto check and comment into separate workflows and addressing "Not Found" errors for posting proto compatibility reports.([#1023](https://github.com/opensearch-project/opensearch-api-specification/pull/1023)),([#1026](https://github.com/opensearch-project/opensearch-api-specification/pull/1026)),([#1028](https://github.com/opensearch-project/opensearch-api-specification/pull/1028))
-
+- Add `no_sub_matches` and `no_overlapping_matches` to `HyphenationDecompounderTokenFilter` ([#1026](https://github.com/opensearch-project/opensearch-api-specification/pull/1026)),([#1029](https://github.com/opensearch-project/opensearch-api-specification/pull/1029))
 
 ### Removed
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))

--- a/spec/schemas/_common.analysis.yaml
+++ b/spec/schemas/_common.analysis.yaml
@@ -719,6 +719,10 @@ components:
               type: string
               enum:
                 - hyphenation_decompounder
+            no_sub_matches:
+              type: boolean
+            no_overlapping_matches:
+              type: boolean
           required:
             - type
     CompoundWordTokenFilterBase:


### PR DESCRIPTION
### Description

Add missing properties `no_sub_matches` and `no_overlapping_matches` to `HyphenationDecompounderTokenFilter`.

See https://github.com/opensearch-project/OpenSearch/blob/ae713e436662ad56bc151d6b8076a1f93321a975/modules/analysis-common/src/main/java/org/opensearch/analysis/common/HyphenationCompoundWordTokenFilterFactory.java#L64

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).