### PR TITLE
Add predict/execute stream APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add proto compatibility check workflow for PRs and post-deployment ([#1020](https://github.com/opensearch-project/opensearch-api-specification/pull/1020))
 - Split proto check and comment into separate workflows and addressing "Not Found" errors for posting proto compatibility reports.([#1023](https://github.com/opensearch-project/opensearch-api-specification/pull/1023)),([#1026](https://github.com/opensearch-project/opensearch-api-specification/pull/1026)),([#1028](https://github.com/opensearch-project/opensearch-api-specification/pull/1028))
 - Add new 3.3 ML APIs ([#1010](https://github.com/opensearch-project/opensearch-api-specification/pull/1010))
+- Add new ML stream APIs ([#1031](https://github.com/opensearch-project/opensearch-api-specification/pull/1031))
 
 ### Removed
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -266,6 +266,19 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ml.predict_model@200'
+  /_plugins/_ml/models/{model_id}/_predict/stream:
+    post:
+      operationId: ml.predict_model_stream.0
+      x-operation-group: ml.predict_model_stream
+      x-version-added: '3.3'
+      description: Predicts a model in streaming mode.
+      parameters:
+        - $ref: '#/components/parameters/ml.predict_model_stream::path.model_id'
+      requestBody:
+        $ref: '#/components/requestBodies/ml.predict_model_stream'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.predict_model_stream@200'
   /_plugins/_ml/tasks/{task_id}:
     get:
       operationId: ml.get_task.0
@@ -456,6 +469,19 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ml.execute_agent@200'
+  /_plugins/_ml/agents/{agent_id}/_execute/stream:
+    post:
+      operationId: ml.execute_agent_stream.0
+      x-operation-group: ml.execute_agent_stream
+      x-version-added: '3.3'
+      description: Execute an agent in streaming mode.
+      parameters:
+        - $ref: '#/components/parameters/ml.execute_agent_stream::path.agent_id'
+      requestBody:
+        $ref: '#/components/requestBodies/ml.execute_agent_stream'
+      responses:
+        '200':
+          $ref: '#/components/responses/ml.execute_agent_stream@200'
   /_plugins/_ml/agents/{agent_id}:
     get:
       operationId: ml.get_agent.0
@@ -1327,6 +1353,16 @@ components:
                 description: The text documents.
             required:
               - text_docs
+    ml.predict_model_stream:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              parameters:
+                $ref: '../schemas/ml._common.yaml#/components/schemas/Parameters'
+            required:
+              - parameters
     ml.search_tasks:
       content:
         application/json:
@@ -1518,6 +1554,16 @@ components:
               parameters.verbose:
                 type: boolean
                 description: Whether to provide verbose output.
+            required:
+              - parameters
+    ml.execute_agent_stream:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              parameters:
+                $ref: '../schemas/ml._common.yaml#/components/schemas/Parameters'
             required:
               - parameters
     ml.search_agents:
@@ -2006,6 +2052,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/ml._common.yaml#/components/schemas/PredictModelResponse'
+    ml.predict_model_stream@200:
+      content:
+        text/event-stream:
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/PredictResponse'
     ml.delete_model@200:
       content:
         application/json:
@@ -2095,6 +2146,11 @@ components:
     ml.execute_agent@200:
       content:
         application/json:
+          schema:
+            $ref: '../schemas/ml._common.yaml#/components/schemas/PredictResponse'
+    ml.execute_agent_stream@200:
+      content:
+        text/event-stream:
           schema:
             $ref: '../schemas/ml._common.yaml#/components/schemas/PredictResponse'
     ml.get_agent@200:
@@ -2456,6 +2512,12 @@ components:
       required: true
       schema:
         type: string
+    ml.predict_model_stream::path.model_id:
+      name: model_id
+      in: path
+      required: true
+      schema:
+        type: string
     ml.chunk_model::path.chunk_number:
       name: chunk_number
       in: path
@@ -2531,6 +2593,12 @@ components:
       schema:
         type: string
     ml.execute_agent::path.agent_id:
+      name: agent_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ml.execute_agent_stream::path.agent_id:
       name: agent_id
       in: path
       required: true

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -387,6 +387,17 @@ components:
         result:
           type: string
           description: The output result.
+        dataAsMap:
+          $ref: '#/components/schemas/DataAsMap'
+    DataAsMap:
+      type: object
+      properties:
+        content:
+          type: string
+          description: The streaming content chunk.
+        is_last:
+          type: boolean
+          description: Whether this is the last chunk.
     ByteOrder:
       type: string
       enum:


### PR DESCRIPTION
### Description
Add predict/execute stream APIs:
- https://docs.opensearch.org/latest/ml-commons-plugin/api/train-predict/predict-stream/
- https://docs.opensearch.org/latest/ml-commons-plugin/api/agent-apis/execute-stream-agent/

Note: Tests were not added since both require valid credentials (OpenAI API key or AWS credentials) to run

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
