### PR TITLE
Add support of BinaryFieldValues for gRPC non-source primitive array indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Split proto check and comment into separate workflows and addressing "Not Found" errors for posting proto compatibility reports.([#1023](https://github.com/opensearch-project/opensearch-api-specification/pull/1023)),([#1026](https://github.com/opensearch-project/opensearch-api-specification/pull/1026)),([#1028](https://github.com/opensearch-project/opensearch-api-specification/pull/1028))
 - Add new 3.3 ML APIs ([#1010](https://github.com/opensearch-project/opensearch-api-specification/pull/1010))
 - Add new ML stream APIs ([#1031](https://github.com/opensearch-project/opensearch-api-specification/pull/1031))
+- Add support of BinaryFieldValues for gRPC non-source primitive array indexing
 
 ### Removed
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2302,6 +2302,7 @@ components:
                 - $ref: '../schemas/_core.bulk.yaml#/components/schemas/OperationContainer'
                   x-protobuf-required: true
                 - $ref: '../schemas/_core.bulk.yaml#/components/schemas/UpdateAction'
+                - $ref: '../schemas/_core.bulk.yaml#/components/schemas/BinaryFieldValues'
                 - type: object
                   additionalProperties: true
                   x-protobuf-type: bytes

--- a/spec/schemas/_core.bulk.yaml
+++ b/spec/schemas/_core.bulk.yaml
@@ -125,6 +125,81 @@ components:
             new document. If the document exists, the `script` is executed.
           type: object
           x-protobuf-type: bytes
+    FloatBinaryLE:
+      type: object
+      properties:
+        bytes_le:
+          type: string
+          format: byte
+          x-protobuf-type: bytes
+        dimension:
+          $ref: '_common.yaml#/components/schemas/uint'
+          description: Vector dimension
+      required:
+        - bytes_le
+        - dimension
+    FloatList:
+      type: object
+      properties:
+        values:
+          type: array
+          items:
+            type: number
+            format: float
+      required:
+        - values
+    FloatArrayValue:
+      type: object
+      description: Float array value supporting binary or list representation.
+      oneOf:
+        - type: object
+          title: FloatArrayValueBinary
+          properties:
+            binary_le:
+              $ref: '#/components/schemas/FloatBinaryLE'
+              description: fast path (4 * dimension bytes, little-endian)
+          required:
+            - binary_le
+        - type: object
+          title: FloatArrayValueList
+          properties:
+            values:
+              $ref: '#/components/schemas/FloatList'
+              description: simple path, packed array
+          required:
+            - values
+    BytesValue:
+      type: object
+      title: BytesValue
+      properties:
+        bytes:
+          type: string
+          format: byte
+          x-protobuf-type: bytes
+      required:
+        - bytes
+    BinaryFieldValue:
+      title: BinaryFieldValue
+      description: Typed value (oneof).
+      oneOf:
+        - type: object
+          properties:
+            bytes_value:
+              $ref: '#/components/schemas/BytesValue'
+          required:
+            - bytes_value
+        - type: object
+          properties:
+            float_array_value:
+              $ref: '#/components/schemas/FloatArrayValue'
+          required:
+            - float_array_value
+    BinaryFieldValues:
+      title: field_values
+      description: Map of fully-qualified field path -> typed value.
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/BinaryFieldValue'
     BulkResponse:
       type: object
       properties:


### PR DESCRIPTION
Introducing new proto messages to support indexing of primitive arrays in gRPC outside of source.

Related issue: https://github.com/opensearch-project/OpenSearch/issues/19638

For now, only _float_ arrays are supported, as well as _BytesValue_.

Two options are offered:
- packed array.
- binary LE (little-endian) which is much faster (see benchmarks results in the related issue).

This is the expected proto messages

 
```
message BulkRequestBody {

  // [required]
  OperationContainer operation_container = 1;

  // [optional]
  optional UpdateAction update_action = 2;

  // [optional]
  optional bytes object = 3;

  // Map of fully-qualified field path -> typed value.
  map<string, BinaryFieldValue> field_values = 4; // <-- NEW
}

message BinaryFieldValue {
  oneof binary_field_value {
    BytesValue bytes_value = 1;

    FloatArrayValue float_array_value = 2;

  }
}

message BytesValue {

  bytes bytes = 1;
}

message FloatArrayValue {
  oneof float_array_value {
    // fast path (4 * dimension bytes, little-endian)
    FloatBinaryLE binary_le = 1;

    // simple path, packed array
    FloatList values = 2;

  }
}

message FloatBinaryLE {

  bytes bytes_le = 1;

  // Vector dimension
  int32 dimension = 2;
}

message FloatList {

  repeated float values = 1;
}

```
 
 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
