### PR TITLE
Add Search APIs for Search Relevance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Added apis for searching within search relevance objects such as search configurations, judgments, query sets, and experiments ([#1064](https://github.com/opensearch-project/opensearch-api-specification/pull/1064))
 - Added remaining APIs for LTR including store element operations, model management, feature set operations, routing support, and POST support for update operations ([#935](https://github.com/opensearch-project/opensearch-api-specification/pull/935))
 - Added specs for alert and finding endpoints of security_analytics plugin ([#907](https://github.com/opensearch-project/opensearch-api-specification/pull/907))
 - Added `template` to `QueryContainer` ([#904](https://github.com/opensearch-project/opensearch-api-specification/pull/904))

--- a/spec/namespaces/search_relevance.yaml
+++ b/spec/namespaces/search_relevance.yaml
@@ -56,15 +56,15 @@ paths:
           $ref: '#/components/responses/search_relevance.delete_query_sets@200'
   /_plugins/_search_relevance/query_sets/_search:
     post:
-      operationId: search_relevance.post_query_sets.1
-      x-operation-group: search_relevance.post_query_sets
+      operationId: search_relevance.query_sets_search.0
+      x-operation-group: search_relevance.query_sets_search
       x-version-added: '3.5'
       description: Searches for queries in the query sets.
       requestBody:
         $ref: '#/components/requestBodies/search_relevance.query_sets_search'
       responses:
         '200':
-          $ref: '#/components/responses/search_relevance.get_query_sets@200'
+          $ref: '#/components/responses/search_relevance.query_sets_search@200'
   /_plugins/_search_relevance/judgments:
     get:
       operationId: search_relevance.get_judgments.0
@@ -108,15 +108,15 @@ paths:
           $ref: '#/components/responses/search_relevance.delete_judgments@200'
   /_plugins/_search_relevance/judgments/_search:
     post:
-      operationId: search_relevance.post_judgments.1
-      x-operation-group: search_relevance.post_judgments
+      operationId: search_relevance.judgments_search.0
+      x-operation-group: search_relevance.judgments_search
       x-version-added: '3.5'
       description: Searches for judgments.
       requestBody:
         $ref: '#/components/requestBodies/search_relevance.judgments_search'
       responses:
         '200':
-          $ref: '#/components/responses/search_relevance.get_judgments@200'
+          $ref: '#/components/responses/search_relevance.judgments_search@200'
   /_plugins/_search_relevance/search_configurations:
     get:
       operationId: search_relevance.get_search_configurations.0
@@ -159,8 +159,8 @@ paths:
           $ref: '#/components/responses/search_relevance.delete_search_configurations@200'
   /_plugins/_search_relevance/search_configurations/_search:
     post:
-      operationId: search_relevance.post_search_configurations.1
-      x-operation-group: search_relevance.post_search_configurations
+      operationId: search_relevance.search_configurations_search.0
+      x-operation-group: search_relevance.search_configurations_search
       x-version-added: '3.5'
       description: Searches for search configurations.
 
@@ -168,7 +168,7 @@ paths:
         $ref: '#/components/requestBodies/search_relevance.search_configurations_search'
       responses:
         '200':
-          $ref: '#/components/responses/search_relevance.get_search_configurations@200'
+          $ref: '#/components/responses/search_relevance.search_configurations_search@200'
   /_plugins/_search_relevance/experiments:
     get:
       operationId: search_relevance.get_experiments.0
@@ -211,8 +211,8 @@ paths:
           $ref: '#/components/responses/search_relevance.delete_experiments@200'
   /_plugins/_search_relevance/experiments/_search:
     post:
-      operationId: search_relevance.post_experiments.1
-      x-operation-group: search_relevance.post_experiments
+      operationId: search_relevance.experiments_search.0
+      x-operation-group: search_relevance.experiments_search
       x-version-added: '3.5'
       description: Searches for experiments.
 
@@ -220,7 +220,7 @@ paths:
         $ref: '#/components/requestBodies/search_relevance.experiments_search'
       responses:
         '200':
-          $ref: '#/components/responses/search_relevance.get_experiments@200'
+          $ref: '#/components/responses/search_relevance.experiments_search@200'
   /_plugins/_search_relevance/{node_id}/stats:
     get:
       operationId: search_relevance.get_node_stats.0
@@ -531,7 +531,7 @@ components:
               size:
                 type: integer
                 format: int64
-                description: The number of tasks to return.
+                description: The number of queries to return.
               sort:
                 $ref: '../schemas/_common.yaml#/components/schemas/Sort'
                 description: The sort order.
@@ -554,7 +554,7 @@ components:
               size:
                 type: integer
                 format: int64
-                description: The number of tasks to return.
+                description: The number of judgments to return.
               sort:
                 $ref: '../schemas/_common.yaml#/components/schemas/Sort'
                 description: The sort order.
@@ -574,7 +574,7 @@ components:
               size:
                 type: integer
                 format: int64
-                description: The number of tasks to return.
+                description: The number of search configurations to return.
               sort:
                 $ref: '../schemas/_common.yaml#/components/schemas/Sort'
     search_relevance.put_experiments:
@@ -596,7 +596,7 @@ components:
               size:
                 type: integer
                 format: int64
-                description: The number of tasks to return.
+                description: The number of experiments to return.
               sort:
                 $ref: '../schemas/_common.yaml#/components/schemas/Sort'
     search_relevance.post_scheduled_experiments:
@@ -606,6 +606,11 @@ components:
             $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PostScheduledExperimentsRequest'
   responses:
     search_relevance.get_query_sets@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    search_relevance.query_sets_search@200:
       content:
         application/json:
           schema:
@@ -630,6 +635,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    search_relevance.judgments_search@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.put_judgments@200:
       content:
         application/json:
@@ -645,6 +655,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    search_relevance.search_configurations_search@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.put_search_configurations@200:
       content:
         application/json:
@@ -656,6 +671,11 @@ components:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
     search_relevance.get_experiments@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    search_relevance.experiments_search@200:
       content:
         application/json:
           schema:

--- a/spec/namespaces/search_relevance.yaml
+++ b/spec/namespaces/search_relevance.yaml
@@ -54,6 +54,17 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_query_sets@200'
+  /_plugins/_search_relevance/query_sets/_search:
+    post:
+      operationId: search_relevance.post_query_sets.1
+      x-operation-group: search_relevance.post_query_sets
+      x-version-added: '3.1'
+      description: Searches for queries in the query sets.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.query_sets_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.get_query_sets@200'
   /_plugins/_search_relevance/judgments:
     get:
       operationId: search_relevance.get_judgments.0
@@ -95,6 +106,17 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_judgments@200'
+  /_plugins/_search_relevance/judgments/_search:
+    post:
+      operationId: search_relevance.post_judgments.1
+      x-operation-group: search_relevance.post_judgments
+      x-version-added: '3.1'
+      description: Searches for judgments.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.judgments_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.get_judgments@200'
   /_plugins/_search_relevance/search_configurations:
     get:
       operationId: search_relevance.get_search_configurations.0
@@ -135,6 +157,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_search_configurations@200'
+  /_plugins/_search_relevance/search_configurations/_search:
+    post:
+      operationId: search_relevance.post_search_configurations.1
+      x-operation-group: search_relevance.post_search_configurations
+      x-version-added: '3.1'
+      description: Searches for search configurations.
+
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.search_configurations_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.get_search_configurations@200'
   /_plugins/_search_relevance/experiments:
     get:
       operationId: search_relevance.get_experiments.0
@@ -175,6 +209,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_experiments@200'
+  /_plugins/_search_relevance/experiments/_search:
+    post:
+      operationId: search_relevance.post_experiments.1
+      x-operation-group: search_relevance.post_experiments
+      x-version-added: '3.1'
+      description: Searches for experiments.
+
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.experiments_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.get_experiments@200'
   /_plugins/_search_relevance/{node_id}/stats:
     get:
       operationId: search_relevance.get_node_stats.0
@@ -474,6 +520,21 @@ components:
         application/json:
           schema:
             $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutQuerySetsRequest'
+    search_relevance.query_sets_search:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              query:
+                $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
+              size:
+                type: integer
+                format: int64
+                description: The number of tasks to return.
+              sort:
+                $ref: '../schemas/_common.yaml#/components/schemas/Sort'
+                description: The sort order.
     search_relevance.put_judgments:
       content:
         application/json:
@@ -482,11 +543,40 @@ components:
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutLLMJudgmentsRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutUBIJudgmentsRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutImportJudgmentsRequest'
+    search_relevance.judgments_search:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              query:
+                $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
+              size:
+                type: integer
+                format: int64
+                description: The number of tasks to return.
+              sort:
+                $ref: '../schemas/_common.yaml#/components/schemas/Sort'
+                description: The sort order.
     search_relevance.put_search_configurations:
       content:
         application/json:
           schema:
             $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutSearchConfigurationRequest'
+    search_relevance.search_configurations_search:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              query:
+                $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
+              size:
+                type: integer
+                format: int64
+                description: The number of tasks to return.
+              sort:
+                $ref: '../schemas/_common.yaml#/components/schemas/Sort'
     search_relevance.put_experiments:
       content:
         application/json:
@@ -495,6 +585,20 @@ components:
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutHybridOptimizerExperimentRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutPointwiseExperimentRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutPairwiseExperimentRequest'
+    search_relevance.experiments_search:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              query:
+                $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
+              size:
+                type: integer
+                format: int64
+                description: The number of tasks to return.
+              sort:
+                $ref: '../schemas/_common.yaml#/components/schemas/Sort'
     search_relevance.post_scheduled_experiments:
       content:
         application/json:

--- a/spec/namespaces/search_relevance.yaml
+++ b/spec/namespaces/search_relevance.yaml
@@ -54,17 +54,17 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_query_sets@200'
-  /_plugins/_search_relevance/query_sets/_search:
-    post:
-      operationId: search_relevance.query_sets_search.0
-      x-operation-group: search_relevance.query_sets_search
-      x-version-added: '3.5'
-      description: Searches for queries in the query sets.
-      requestBody:
-        $ref: '#/components/requestBodies/search_relevance.query_sets_search'
-      responses:
-        '200':
-          $ref: '#/components/responses/search_relevance.query_sets_search@200'
+  # /_plugins/_search_relevance/query_sets/_search:
+  #   post:
+  #     operationId: search_relevance.query_sets_search.0
+  #     x-operation-group: search_relevance.query_sets_search
+  #     x-version-added: '3.5'
+  #     description: Searches for queries in the query sets.
+  #     requestBody:
+  #       $ref: '#/components/requestBodies/search_relevance.query_sets_search'
+  #     responses:
+  #       '200':
+  #         $ref: '#/components/responses/search_relevance.query_sets_search@200'
   /_plugins/_search_relevance/judgments:
     get:
       operationId: search_relevance.get_judgments.0
@@ -106,17 +106,17 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_judgments@200'
-  /_plugins/_search_relevance/judgments/_search:
-    post:
-      operationId: search_relevance.judgments_search.0
-      x-operation-group: search_relevance.judgments_search
-      x-version-added: '3.5'
-      description: Searches for judgments.
-      requestBody:
-        $ref: '#/components/requestBodies/search_relevance.judgments_search'
-      responses:
-        '200':
-          $ref: '#/components/responses/search_relevance.judgments_search@200'
+  # /_plugins/_search_relevance/judgments/_search:
+  #   post:
+  #     operationId: search_relevance.judgments_search.0
+  #     x-operation-group: search_relevance.judgments_search
+  #     x-version-added: '3.5'
+  #     description: Searches for judgments.
+  #     requestBody:
+  #       $ref: '#/components/requestBodies/search_relevance.judgments_search'
+  #     responses:
+  #       '200':
+  #         $ref: '#/components/responses/search_relevance.judgments_search@200'
   /_plugins/_search_relevance/search_configurations:
     get:
       operationId: search_relevance.get_search_configurations.0
@@ -157,18 +157,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_search_configurations@200'
-  /_plugins/_search_relevance/search_configurations/_search:
-    post:
-      operationId: search_relevance.search_configurations_search.0
-      x-operation-group: search_relevance.search_configurations_search
-      x-version-added: '3.5'
-      description: Searches for search configurations.
+  # /_plugins/_search_relevance/search_configurations/_search:
+  #   post:
+  #     operationId: search_relevance.search_configurations_search.0
+  #     x-operation-group: search_relevance.search_configurations_search
+  #     x-version-added: '3.5'
+  #     description: Searches for search configurations.
 
-      requestBody:
-        $ref: '#/components/requestBodies/search_relevance.search_configurations_search'
-      responses:
-        '200':
-          $ref: '#/components/responses/search_relevance.search_configurations_search@200'
+  #     requestBody:
+  #       $ref: '#/components/requestBodies/search_relevance.search_configurations_search'
+  #     responses:
+  #       '200':
+  #         $ref: '#/components/responses/search_relevance.search_configurations_search@200'
   /_plugins/_search_relevance/experiments:
     get:
       operationId: search_relevance.get_experiments.0
@@ -209,18 +209,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_experiments@200'
-  /_plugins/_search_relevance/experiments/_search:
-    post:
-      operationId: search_relevance.experiments_search.0
-      x-operation-group: search_relevance.experiments_search
-      x-version-added: '3.5'
-      description: Searches for experiments.
+  # /_plugins/_search_relevance/experiments/_search:
+  #   post:
+  #     operationId: search_relevance.experiments_search.0
+  #     x-operation-group: search_relevance.experiments_search
+  #     x-version-added: '3.5'
+  #     description: Searches for experiments.
 
-      requestBody:
-        $ref: '#/components/requestBodies/search_relevance.experiments_search'
-      responses:
-        '200':
-          $ref: '#/components/responses/search_relevance.experiments_search@200'
+  #     requestBody:
+  #       $ref: '#/components/requestBodies/search_relevance.experiments_search'
+  #     responses:
+  #       '200':
+  #         $ref: '#/components/responses/search_relevance.experiments_search@200'
   /_plugins/_search_relevance/{node_id}/stats:
     get:
       operationId: search_relevance.get_node_stats.0
@@ -520,21 +520,21 @@ components:
         application/json:
           schema:
             $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutQuerySetsRequest'
-    search_relevance.query_sets_search:
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              query:
-                $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
-              size:
-                type: integer
-                format: int64
-                description: The number of queries to return.
-              sort:
-                $ref: '../schemas/_common.yaml#/components/schemas/Sort'
-                description: The sort order.
+    # search_relevance.query_sets_search:
+    #   content:
+    #     application/json:
+    #       schema:
+    #         type: object
+    #         properties:
+    #           query:
+    #             $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
+    #           size:
+    #             type: integer
+    #             format: int64
+    #             description: The number of queries to return.
+    #           sort:
+    #             $ref: '../schemas/_common.yaml#/components/schemas/Sort'
+    #             description: The sort order.
     search_relevance.put_judgments:
       content:
         application/json:
@@ -543,40 +543,40 @@ components:
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutLLMJudgmentsRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutUBIJudgmentsRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutImportJudgmentsRequest'
-    search_relevance.judgments_search:
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              query:
-                $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
-              size:
-                type: integer
-                format: int64
-                description: The number of judgments to return.
-              sort:
-                $ref: '../schemas/_common.yaml#/components/schemas/Sort'
-                description: The sort order.
+    # search_relevance.judgments_search:
+    #   content:
+    #     application/json:
+    #       schema:
+    #         type: object
+    #         properties:
+    #           query:
+    #             $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
+    #           size:
+    #             type: integer
+    #             format: int64
+    #             description: The number of judgments to return.
+    #           sort:
+    #             $ref: '../schemas/_common.yaml#/components/schemas/Sort'
+    #             description: The sort order.
     search_relevance.put_search_configurations:
       content:
         application/json:
           schema:
             $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutSearchConfigurationRequest'
-    search_relevance.search_configurations_search:
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              query:
-                $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
-              size:
-                type: integer
-                format: int64
-                description: The number of search configurations to return.
-              sort:
-                $ref: '../schemas/_common.yaml#/components/schemas/Sort'
+    # search_relevance.search_configurations_search:
+    #   content:
+    #     application/json:
+    #       schema:
+    #         type: object
+    #         properties:
+    #           query:
+    #             $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
+    #           size:
+    #             type: integer
+    #             format: int64
+    #             description: The number of search configurations to return.
+    #           sort:
+    #             $ref: '../schemas/_common.yaml#/components/schemas/Sort'
     search_relevance.put_experiments:
       content:
         application/json:
@@ -585,20 +585,20 @@ components:
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutHybridOptimizerExperimentRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutPointwiseExperimentRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutPairwiseExperimentRequest'
-    search_relevance.experiments_search:
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              query:
-                $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
-              size:
-                type: integer
-                format: int64
-                description: The number of experiments to return.
-              sort:
-                $ref: '../schemas/_common.yaml#/components/schemas/Sort'
+    # search_relevance.experiments_search:
+    #   content:
+    #     application/json:
+    #       schema:
+    #         type: object
+    #         properties:
+    #           query:
+    #             $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
+    #           size:
+    #             type: integer
+    #             format: int64
+    #             description: The number of experiments to return.
+    #           sort:
+    #             $ref: '../schemas/_common.yaml#/components/schemas/Sort'
     search_relevance.post_scheduled_experiments:
       content:
         application/json:
@@ -610,11 +610,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
-    search_relevance.query_sets_search@200:
-      content:
-        application/json:
-          schema:
-            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    # search_relevance.query_sets_search@200:
+    #   content:
+    #     application/json:
+    #       schema:
+    #         $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.post_query_sets@200:
       content:
         application/json:
@@ -635,11 +635,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
-    search_relevance.judgments_search@200:
-      content:
-        application/json:
-          schema:
-            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    # search_relevance.judgments_search@200:
+    #   content:
+    #     application/json:
+    #       schema:
+    #         $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.put_judgments@200:
       content:
         application/json:
@@ -655,11 +655,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
-    search_relevance.search_configurations_search@200:
-      content:
-        application/json:
-          schema:
-            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    # search_relevance.search_configurations_search@200:
+    #   content:
+    #     application/json:
+    #       schema:
+    #         $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.put_search_configurations@200:
       content:
         application/json:
@@ -675,11 +675,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
-    search_relevance.experiments_search@200:
-      content:
-        application/json:
-          schema:
-            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    # search_relevance.experiments_search@200:
+    #   content:
+    #     application/json:
+    #       schema:
+    #         $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.put_experiments@200:
       content:
         application/json:

--- a/spec/namespaces/search_relevance.yaml
+++ b/spec/namespaces/search_relevance.yaml
@@ -58,7 +58,7 @@ paths:
     post:
       operationId: search_relevance.post_query_sets.1
       x-operation-group: search_relevance.post_query_sets
-      x-version-added: '3.1'
+      x-version-added: '3.5'
       description: Searches for queries in the query sets.
       requestBody:
         $ref: '#/components/requestBodies/search_relevance.query_sets_search'
@@ -110,7 +110,7 @@ paths:
     post:
       operationId: search_relevance.post_judgments.1
       x-operation-group: search_relevance.post_judgments
-      x-version-added: '3.1'
+      x-version-added: '3.5'
       description: Searches for judgments.
       requestBody:
         $ref: '#/components/requestBodies/search_relevance.judgments_search'
@@ -161,7 +161,7 @@ paths:
     post:
       operationId: search_relevance.post_search_configurations.1
       x-operation-group: search_relevance.post_search_configurations
-      x-version-added: '3.1'
+      x-version-added: '3.5'
       description: Searches for search configurations.
 
       requestBody:
@@ -213,7 +213,7 @@ paths:
     post:
       operationId: search_relevance.post_experiments.1
       x-operation-group: search_relevance.post_experiments
-      x-version-added: '3.1'
+      x-version-added: '3.5'
       description: Searches for experiments.
 
       requestBody:

--- a/spec/namespaces/search_relevance.yaml
+++ b/spec/namespaces/search_relevance.yaml
@@ -56,7 +56,7 @@ paths:
           $ref: '#/components/responses/search_relevance.delete_query_sets@200'
   /_plugins/_search_relevance/query_sets/_search:
     get:
-      operationId: search_relevance.get_query_sets_search.0
+      operationId: search_relevance.query_sets_search.0
       x-operation-group: search_relevance.query_sets_search
       x-version-added: '3.5'
       description: Searches for queries in the query sets.
@@ -66,7 +66,7 @@ paths:
         '200':
           $ref: '#/components/responses/search_relevance.query_sets_search@200'
     post:
-      operationId: search_relevance.post_query_sets_search.0
+      operationId: search_relevance.query_sets_search.1
       x-operation-group: search_relevance.query_sets_search
       x-version-added: '3.5'
       description: Searches for queries in the query sets.
@@ -118,7 +118,7 @@ paths:
           $ref: '#/components/responses/search_relevance.delete_judgments@200'
   /_plugins/_search_relevance/judgments/_search:
     get:
-      operationId: search_relevance.get_judgments_search.0
+      operationId: search_relevance.judgments_search.0
       x-operation-group: search_relevance.judgments_search
       x-version-added: '3.5'
       description: Searches for judgments.
@@ -128,7 +128,7 @@ paths:
         '200':
           $ref: '#/components/responses/search_relevance.judgments_search@200'
     post:
-      operationId: search_relevance.post_judgments_search.0
+      operationId: search_relevance.judgments_search.1
       x-operation-group: search_relevance.judgments_search
       x-version-added: '3.5'
       description: Searches for judgments.
@@ -179,7 +179,7 @@ paths:
           $ref: '#/components/responses/search_relevance.delete_search_configurations@200'
   /_plugins/_search_relevance/search_configurations/_search:
     get:
-      operationId: search_relevance.get_search_configurations_search.0
+      operationId: search_relevance.search_configurations_search.0
       x-operation-group: search_relevance.search_configurations_search
       x-version-added: '3.5'
       description: Searches for search configurations.
@@ -189,7 +189,7 @@ paths:
         '200':
           $ref: '#/components/responses/search_relevance.search_configurations_search@200'
     post:
-      operationId: search_relevance.post_search_configurations_search.0
+      operationId: search_relevance.search_configurations_search.1
       x-operation-group: search_relevance.search_configurations_search
       x-version-added: '3.5'
       description: Searches for search configurations.
@@ -240,7 +240,7 @@ paths:
           $ref: '#/components/responses/search_relevance.delete_experiments@200'
   /_plugins/_search_relevance/experiments/_search:
     get:
-      operationId: search_relevance.get_experiments_search.0
+      operationId: search_relevance.experiments_search.0
       x-operation-group: search_relevance.experiments_search
       x-version-added: '3.5'
       description: Searches for experiments.
@@ -250,7 +250,7 @@ paths:
         '200':
           $ref: '#/components/responses/search_relevance.experiments_search@200'
     post:
-      operationId: search_relevance.post_experiments_search.0
+      operationId: search_relevance.experiments_search.1
       x-operation-group: search_relevance.experiments_search
       x-version-added: '3.5'
       description: Searches for experiments.

--- a/spec/namespaces/search_relevance.yaml
+++ b/spec/namespaces/search_relevance.yaml
@@ -54,17 +54,27 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_query_sets@200'
-  # /_plugins/_search_relevance/query_sets/_search:
-  #   post:
-  #     operationId: search_relevance.query_sets_search.0
-  #     x-operation-group: search_relevance.query_sets_search
-  #     x-version-added: '3.5'
-  #     description: Searches for queries in the query sets.
-  #     requestBody:
-  #       $ref: '#/components/requestBodies/search_relevance.query_sets_search'
-  #     responses:
-  #       '200':
-  #         $ref: '#/components/responses/search_relevance.query_sets_search@200'
+  /_plugins/_search_relevance/query_sets/_search:
+    get:
+      operationId: search_relevance.get_query_sets_search.0
+      x-operation-group: search_relevance.query_sets_search
+      x-version-added: '3.5'
+      description: Searches for queries in the query sets.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.query_sets_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.query_sets_search@200'
+    post:
+      operationId: search_relevance.post_query_sets_search.0
+      x-operation-group: search_relevance.query_sets_search
+      x-version-added: '3.5'
+      description: Searches for queries in the query sets.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.query_sets_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.query_sets_search@200'
   /_plugins/_search_relevance/judgments:
     get:
       operationId: search_relevance.get_judgments.0
@@ -106,17 +116,27 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_judgments@200'
-  # /_plugins/_search_relevance/judgments/_search:
-  #   post:
-  #     operationId: search_relevance.judgments_search.0
-  #     x-operation-group: search_relevance.judgments_search
-  #     x-version-added: '3.5'
-  #     description: Searches for judgments.
-  #     requestBody:
-  #       $ref: '#/components/requestBodies/search_relevance.judgments_search'
-  #     responses:
-  #       '200':
-  #         $ref: '#/components/responses/search_relevance.judgments_search@200'
+  /_plugins/_search_relevance/judgments/_search:
+    get:
+      operationId: search_relevance.get_judgments_search.0
+      x-operation-group: search_relevance.judgments_search
+      x-version-added: '3.5'
+      description: Searches for judgments.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.judgments_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.judgments_search@200'
+    post:
+      operationId: search_relevance.post_judgments_search.0
+      x-operation-group: search_relevance.judgments_search
+      x-version-added: '3.5'
+      description: Searches for judgments.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.judgments_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.judgments_search@200'
   /_plugins/_search_relevance/search_configurations:
     get:
       operationId: search_relevance.get_search_configurations.0
@@ -157,18 +177,27 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_search_configurations@200'
-  # /_plugins/_search_relevance/search_configurations/_search:
-  #   post:
-  #     operationId: search_relevance.search_configurations_search.0
-  #     x-operation-group: search_relevance.search_configurations_search
-  #     x-version-added: '3.5'
-  #     description: Searches for search configurations.
-
-  #     requestBody:
-  #       $ref: '#/components/requestBodies/search_relevance.search_configurations_search'
-  #     responses:
-  #       '200':
-  #         $ref: '#/components/responses/search_relevance.search_configurations_search@200'
+  /_plugins/_search_relevance/search_configurations/_search:
+    get:
+      operationId: search_relevance.get_search_configurations_search.0
+      x-operation-group: search_relevance.search_configurations_search
+      x-version-added: '3.5'
+      description: Searches for search configurations.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.search_configurations_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.search_configurations_search@200'
+    post:
+      operationId: search_relevance.post_search_configurations_search.0
+      x-operation-group: search_relevance.search_configurations_search
+      x-version-added: '3.5'
+      description: Searches for search configurations.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.search_configurations_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.search_configurations_search@200'
   /_plugins/_search_relevance/experiments:
     get:
       operationId: search_relevance.get_experiments.0
@@ -209,18 +238,27 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_experiments@200'
-  # /_plugins/_search_relevance/experiments/_search:
-  #   post:
-  #     operationId: search_relevance.experiments_search.0
-  #     x-operation-group: search_relevance.experiments_search
-  #     x-version-added: '3.5'
-  #     description: Searches for experiments.
-
-  #     requestBody:
-  #       $ref: '#/components/requestBodies/search_relevance.experiments_search'
-  #     responses:
-  #       '200':
-  #         $ref: '#/components/responses/search_relevance.experiments_search@200'
+  /_plugins/_search_relevance/experiments/_search:
+    get:
+      operationId: search_relevance.get_experiments_search.0
+      x-operation-group: search_relevance.experiments_search
+      x-version-added: '3.5'
+      description: Searches for experiments.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.experiments_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.experiments_search@200'
+    post:
+      operationId: search_relevance.post_experiments_search.0
+      x-operation-group: search_relevance.experiments_search
+      x-version-added: '3.5'
+      description: Searches for experiments.
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.experiments_search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.experiments_search@200'
   /_plugins/_search_relevance/{node_id}/stats:
     get:
       operationId: search_relevance.get_node_stats.0
@@ -520,21 +558,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutQuerySetsRequest'
-    # search_relevance.query_sets_search:
-    #   content:
-    #     application/json:
-    #       schema:
-    #         type: object
-    #         properties:
-    #           query:
-    #             $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
-    #           size:
-    #             type: integer
-    #             format: int64
-    #             description: The number of queries to return.
-    #           sort:
-    #             $ref: '../schemas/_common.yaml#/components/schemas/Sort'
-    #             description: The sort order.
+    search_relevance.query_sets_search:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/SearchRequest'
     search_relevance.put_judgments:
       content:
         application/json:
@@ -543,40 +571,21 @@ components:
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutLLMJudgmentsRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutUBIJudgmentsRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutImportJudgmentsRequest'
-    # search_relevance.judgments_search:
-    #   content:
-    #     application/json:
-    #       schema:
-    #         type: object
-    #         properties:
-    #           query:
-    #             $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
-    #           size:
-    #             type: integer
-    #             format: int64
-    #             description: The number of judgments to return.
-    #           sort:
-    #             $ref: '../schemas/_common.yaml#/components/schemas/Sort'
-    #             description: The sort order.
+    search_relevance.judgments_search:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/SearchRequest'
     search_relevance.put_search_configurations:
       content:
         application/json:
           schema:
             $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutSearchConfigurationRequest'
-    # search_relevance.search_configurations_search:
-    #   content:
-    #     application/json:
-    #       schema:
-    #         type: object
-    #         properties:
-    #           query:
-    #             $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
-    #           size:
-    #             type: integer
-    #             format: int64
-    #             description: The number of search configurations to return.
-    #           sort:
-    #             $ref: '../schemas/_common.yaml#/components/schemas/Sort'
+    search_relevance.search_configurations_search:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/SearchRequest'
     search_relevance.put_experiments:
       content:
         application/json:
@@ -585,20 +594,11 @@ components:
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutHybridOptimizerExperimentRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutPointwiseExperimentRequest'
               - $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PutPairwiseExperimentRequest'
-    # search_relevance.experiments_search:
-    #   content:
-    #     application/json:
-    #       schema:
-    #         type: object
-    #         properties:
-    #           query:
-    #             $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
-    #           size:
-    #             type: integer
-    #             format: int64
-    #             description: The number of experiments to return.
-    #           sort:
-    #             $ref: '../schemas/_common.yaml#/components/schemas/Sort'
+    search_relevance.experiments_search:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/SearchRequest'
     search_relevance.post_scheduled_experiments:
       content:
         application/json:
@@ -610,11 +610,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
-    # search_relevance.query_sets_search@200:
-    #   content:
-    #     application/json:
-    #       schema:
-    #         $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    search_relevance.query_sets_search@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.post_query_sets@200:
       content:
         application/json:
@@ -635,11 +635,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
-    # search_relevance.judgments_search@200:
-    #   content:
-    #     application/json:
-    #       schema:
-    #         $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    search_relevance.judgments_search@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.put_judgments@200:
       content:
         application/json:
@@ -655,11 +655,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
-    # search_relevance.search_configurations_search@200:
-    #   content:
-    #     application/json:
-    #       schema:
-    #         $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    search_relevance.search_configurations_search@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.put_search_configurations@200:
       content:
         application/json:
@@ -675,11 +675,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
-    # search_relevance.experiments_search@200:
-    #   content:
-    #     application/json:
-    #       schema:
-    #         $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
+    search_relevance.experiments_search@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_core.search.yaml#/components/schemas/SearchResult'
     search_relevance.put_experiments@200:
       content:
         application/json:

--- a/spec/schemas/search_relevance._common.yaml
+++ b/spec/schemas/search_relevance._common.yaml
@@ -176,9 +176,9 @@ components:
           type: string
         index:
           type: string
-        description:
-          type: string
-          x-version-added: 3.5.0
+        # description:
+        #   type: string
+        #   x-version-added: 3.5.0
         query:
           type: string
         searchPipeline:

--- a/spec/schemas/search_relevance._common.yaml
+++ b/spec/schemas/search_relevance._common.yaml
@@ -176,6 +176,9 @@ components:
           type: string
         index:
           type: string
+        description:
+          type: string
+          x-version-added: 3.5.0
         query:
           type: string
         searchPipeline:

--- a/spec/schemas/search_relevance._common.yaml
+++ b/spec/schemas/search_relevance._common.yaml
@@ -176,9 +176,9 @@ components:
           type: string
         index:
           type: string
-        # description:
-        #   type: string
-        #   x-version-added: 3.5.0
+        description:
+          type: string
+          x-version-added: '3.5'
         query:
           type: string
         searchPipeline:
@@ -198,3 +198,20 @@ components:
           type: string
         job_result:
           type: string
+    SearchRequest:
+      type: object
+      description: A search request body delegated to SearchSourceBuilder.
+      properties:
+        query:
+          $ref: '_common.query_dsl.yaml#/components/schemas/QueryContainer'
+        size:
+          type: integer
+          format: int32
+          description: The maximum number of results to return.
+        from:
+          type: integer
+          format: int32
+          description: The starting offset for the results.
+        sort:
+          $ref: '_common.yaml#/components/schemas/Sort'
+          description: The sort order.

--- a/tests/plugins/search_relevance/experiments.yaml
+++ b/tests/plugins/search_relevance/experiments.yaml
@@ -188,6 +188,20 @@ chapters:
     method: GET
     response:
       status: 200 
+  - synopsis: List the experiments created using search api.
+    path: /_plugins/_search_relevance/experiments/_search
+    method: POST
+    request:
+      payload:
+        query:
+          match_all: {}
+        size: 1000
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _score: 1
   - synopsis: Retrieve a specific experiment.
     path: /_plugins/_search_relevance/experiments/{experiment_id}
     method: GET

--- a/tests/plugins/search_relevance/experiments.yaml
+++ b/tests/plugins/search_relevance/experiments.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of experiments.
-version: '>= 3.5.0'
+# version: '>= 3.5.0'
 
 prologues:
   - path: /_plugins/ubi/initialize

--- a/tests/plugins/search_relevance/experiments.yaml
+++ b/tests/plugins/search_relevance/experiments.yaml
@@ -189,22 +189,22 @@ chapters:
     method: GET
     response:
       status: 200 
-  - synopsis: List the experiments created using search api.
-    path: /_plugins/_search_relevance/experiments/_search
-    method: POST
-    warnings:
-      multiple-paths-detected: false
-    request:
-      payload:
-        query:
-          match_all: {}
-        size: 1000
-    response:
-      status: 200
-      payload:
-        hits:
-          hits:
-            - _score: 1
+  # - synopsis: List the experiments created using search api.
+  #   path: /_plugins/_search_relevance/experiments/_search
+  #   method: POST
+  #   warnings:
+  #     multiple-paths-detected: false
+  #   request:
+  #     payload:
+  #       query:
+  #         match_all: {}
+  #       size: 1000
+  #   response:
+  #     status: 200
+  #     payload:
+  #       hits:
+  #         hits:
+  #           - _score: 1
   - synopsis: Retrieve a specific experiment.
     path: /_plugins/_search_relevance/experiments/{experiment_id}
     method: GET

--- a/tests/plugins/search_relevance/experiments.yaml
+++ b/tests/plugins/search_relevance/experiments.yaml
@@ -1,6 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of experiments.
+version: '>= 3.5.0'
 
 prologues:
   - path: /_plugins/ubi/initialize

--- a/tests/plugins/search_relevance/experiments.yaml
+++ b/tests/plugins/search_relevance/experiments.yaml
@@ -191,6 +191,8 @@ chapters:
   - synopsis: List the experiments created using search api.
     path: /_plugins/_search_relevance/experiments/_search
     method: POST
+    warnings:
+      multiple-paths-detected: false
     request:
       payload:
         query:

--- a/tests/plugins/search_relevance/experiments.yaml
+++ b/tests/plugins/search_relevance/experiments.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of experiments.
-# version: '>= 3.5.0'
+version: '>= 3.5.0'
 
 prologues:
   - path: /_plugins/ubi/initialize
@@ -189,22 +189,34 @@ chapters:
     method: GET
     response:
       status: 200 
-  # - synopsis: List the experiments created using search api.
-  #   path: /_plugins/_search_relevance/experiments/_search
-  #   method: POST
-  #   warnings:
-  #     multiple-paths-detected: false
-  #   request:
-  #     payload:
-  #       query:
-  #         match_all: {}
-  #       size: 1000
-  #   response:
-  #     status: 200
-  #     payload:
-  #       hits:
-  #         hits:
-  #           - _score: 1
+  - synopsis: List the experiments created using search api.
+    path: /_plugins/_search_relevance/experiments/_search
+    method: POST
+    warnings:
+      multiple-paths-detected: false
+    request:
+      payload:
+        query:
+          ids:
+            values:
+              - ${pairwise_experiment.experiment_id}
+        size: 1
+    response:
+      status: 200
+      payload:
+        hits:
+          total:
+            value: 1
+            relation: eq
+          hits:
+            - _id: ${pairwise_experiment.experiment_id}
+              _source:
+                querySetId: ${query_set_sampling.query_set_id}
+                searchConfigurationList:
+                  - ${search_configuration1.search_configuration_id}
+                  - ${search_configuration2.search_configuration_id}
+                size: 10
+                type: PAIRWISE_COMPARISON
   - synopsis: Retrieve a specific experiment.
     path: /_plugins/_search_relevance/experiments/{experiment_id}
     method: GET

--- a/tests/plugins/search_relevance/judgments.yaml
+++ b/tests/plugins/search_relevance/judgments.yaml
@@ -152,6 +152,20 @@ chapters:
     method: GET
     response:
       status: 200 
+  - synopsis: List all the judgments created using search api.
+    path: /_plugins/_search_relevance/judgments/_search
+    method: POST
+    request:
+      payload:
+        query:
+          match_all: {}
+        size: 1000
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _score: 1
   - synopsis: Retrieve a specific judgment.
     path: /_plugins/_search_relevance/judgments/{judgment_id}
     method: GET

--- a/tests/plugins/search_relevance/judgments.yaml
+++ b/tests/plugins/search_relevance/judgments.yaml
@@ -153,22 +153,22 @@ chapters:
     method: GET
     response:
       status: 200 
-  - synopsis: List all the judgments created using search api.
-    path: /_plugins/_search_relevance/judgments/_search
-    method: POST
-    warnings:
-      multiple-paths-detected: false
-    request:
-      payload:
-        query:
-          match_all: {}
-        size: 1000
-    response:
-      status: 200
-      payload:
-        hits:
-          hits:
-            - _score: 1
+  # - synopsis: List all the judgments created using search api.
+  #   path: /_plugins/_search_relevance/judgments/_search
+  #   method: POST
+  #   warnings:
+  #     multiple-paths-detected: false
+  #   request:
+  #     payload:
+  #       query:
+  #         match_all: {}
+  #       size: 1000
+  #   response:
+  #     status: 200
+  #     payload:
+  #       hits:
+  #         hits:
+  #           - _score: 1
   - synopsis: Retrieve a specific judgment.
     path: /_plugins/_search_relevance/judgments/{judgment_id}
     method: GET

--- a/tests/plugins/search_relevance/judgments.yaml
+++ b/tests/plugins/search_relevance/judgments.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of judgments.
-version: '>= 3.5.0'
+# version: '>= 3.5.0'
 
 prologues:
   - path: /_plugins/ubi/initialize

--- a/tests/plugins/search_relevance/judgments.yaml
+++ b/tests/plugins/search_relevance/judgments.yaml
@@ -1,6 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of judgments.
+version: '>= 3.5.0'
 
 prologues:
   - path: /_plugins/ubi/initialize

--- a/tests/plugins/search_relevance/judgments.yaml
+++ b/tests/plugins/search_relevance/judgments.yaml
@@ -155,6 +155,8 @@ chapters:
   - synopsis: List all the judgments created using search api.
     path: /_plugins/_search_relevance/judgments/_search
     method: POST
+    warnings:
+      multiple-paths-detected: false
     request:
       payload:
         query:

--- a/tests/plugins/search_relevance/judgments.yaml
+++ b/tests/plugins/search_relevance/judgments.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of judgments.
-# version: '>= 3.5.0'
+version: '>= 3.5.0'
 
 prologues:
   - path: /_plugins/ubi/initialize
@@ -153,22 +153,33 @@ chapters:
     method: GET
     response:
       status: 200 
-  # - synopsis: List all the judgments created using search api.
-  #   path: /_plugins/_search_relevance/judgments/_search
-  #   method: POST
-  #   warnings:
-  #     multiple-paths-detected: false
-  #   request:
-  #     payload:
-  #       query:
-  #         match_all: {}
-  #       size: 1000
-  #   response:
-  #     status: 200
-  #     payload:
-  #       hits:
-  #         hits:
-  #           - _score: 1
+  - synopsis: List all the judgments created using search api.
+    path: /_plugins/_search_relevance/judgments/_search
+    method: POST
+    warnings:
+      multiple-paths-detected: false
+    request:
+      payload:
+        query:
+          ids:
+            values:
+              - ${judgment1.judgment_id}
+        size: 1
+    response:
+      status: 200
+      payload:
+        hits:
+          total:
+            value: 1
+            relation: eq
+          hits:
+            - _id: ${judgment1.judgment_id}
+              _source:
+                name: UBIbaseline
+                description: UBI judgment
+                type: UBI_JUDGMENT
+                clickModel: coec
+                maxRank: 10
   - synopsis: Retrieve a specific judgment.
     path: /_plugins/_search_relevance/judgments/{judgment_id}
     method: GET

--- a/tests/plugins/search_relevance/query_sets.yaml
+++ b/tests/plugins/search_relevance/query_sets.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of query sets.
-version: '>= 3.5.0'
+# version: '>= 3.5.0'
 
 prologues:
   - path: /_plugins/ubi/initialize

--- a/tests/plugins/search_relevance/query_sets.yaml
+++ b/tests/plugins/search_relevance/query_sets.yaml
@@ -1,6 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of query sets.
+version: '>= 3.5.0'
 
 prologues:
   - path: /_plugins/ubi/initialize

--- a/tests/plugins/search_relevance/query_sets.yaml
+++ b/tests/plugins/search_relevance/query_sets.yaml
@@ -92,6 +92,8 @@ chapters:
   - synopsis: List all the query sets created using search api.
     path: /_plugins/_search_relevance/query_sets/_search
     method: POST
+    warnings:
+      multiple-paths-detected: false
     request:
       payload:
         query:

--- a/tests/plugins/search_relevance/query_sets.yaml
+++ b/tests/plugins/search_relevance/query_sets.yaml
@@ -90,22 +90,22 @@ chapters:
     method: GET
     response:
       status: 200
-  - synopsis: List all the query sets created using search api.
-    path: /_plugins/_search_relevance/query_sets/_search
-    method: POST
-    warnings:
-      multiple-paths-detected: false
-    request:
-      payload:
-        query:
-          match_all: {}
-        size: 1000
-    response:
-      status: 200
-      payload:
-        hits:
-          hits:
-            - _score: 1
+  # - synopsis: List all the query sets created using search api.
+  #   path: /_plugins/_search_relevance/query_sets/_search
+  #   method: POST
+  #   warnings:
+  #     multiple-paths-detected: false
+  #   request:
+  #     payload:
+  #       query:
+  #         match_all: {}
+  #       size: 1000
+  #   response:
+  #     status: 200
+  #     payload:
+  #       hits:
+  #         hits:
+  #           - _score: 1
   - synopsis: Retrieve a specific query set.
     path: /_plugins/_search_relevance/query_sets/{query_set_id}
     method: GET

--- a/tests/plugins/search_relevance/query_sets.yaml
+++ b/tests/plugins/search_relevance/query_sets.yaml
@@ -89,6 +89,20 @@ chapters:
     method: GET
     response:
       status: 200
+  - synopsis: List all the query sets created using search api.
+    path: /_plugins/_search_relevance/query_sets/_search
+    method: POST
+    request:
+      payload:
+        query:
+          match_all: {}
+        size: 1000
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _score: 1
   - synopsis: Retrieve a specific query set.
     path: /_plugins/_search_relevance/query_sets/{query_set_id}
     method: GET

--- a/tests/plugins/search_relevance/query_sets.yaml
+++ b/tests/plugins/search_relevance/query_sets.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of query sets.
-# version: '>= 3.5.0'
+version: '>= 3.5.0'
 
 prologues:
   - path: /_plugins/ubi/initialize
@@ -90,22 +90,34 @@ chapters:
     method: GET
     response:
       status: 200
-  # - synopsis: List all the query sets created using search api.
-  #   path: /_plugins/_search_relevance/query_sets/_search
-  #   method: POST
-  #   warnings:
-  #     multiple-paths-detected: false
-  #   request:
-  #     payload:
-  #       query:
-  #         match_all: {}
-  #       size: 1000
-  #   response:
-  #     status: 200
-  #     payload:
-  #       hits:
-  #         hits:
-  #           - _score: 1
+  - synopsis: List all the query sets created using search api.
+    path: /_plugins/_search_relevance/query_sets/_search
+    method: POST
+    warnings:
+      multiple-paths-detected: false
+    request:
+      payload:
+        query:
+          ids:
+            values:
+              - ${query_set_manual_input.query_set_id}
+        size: 1
+    response:
+      status: 200
+      payload:
+        hits:
+          total:
+            value: 1
+            relation: eq
+          hits:
+            - _id: ${query_set_manual_input.query_set_id}
+              _source:
+                name: test01
+                description: test01
+                sampling: manual
+                querySetQueries:
+                  - queryText: apple
+                  - queryText: banana
   - synopsis: Retrieve a specific query set.
     path: /_plugins/_search_relevance/query_sets/{query_set_id}
     method: GET

--- a/tests/plugins/search_relevance/search_configurations.yaml
+++ b/tests/plugins/search_relevance/search_configurations.yaml
@@ -1,6 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of search configurations.
+version: '>= 3.5.0'
 
 prologues:
   - path: /_cluster/settings

--- a/tests/plugins/search_relevance/search_configurations.yaml
+++ b/tests/plugins/search_relevance/search_configurations.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of search configurations.
-version: '>= 3.5.0'
+# version: '>= 3.5.0'
 
 prologues:
   - path: /_cluster/settings

--- a/tests/plugins/search_relevance/search_configurations.yaml
+++ b/tests/plugins/search_relevance/search_configurations.yaml
@@ -74,22 +74,22 @@ chapters:
     method: GET
     response:
       status: 200
-  - synopsis: List all the search configurations created using search api.
-    path: /_plugins/_search_relevance/search_configurations/_search
-    method: POST
-    warnings:
-      multiple-paths-detected: false
-    request:
-      payload:
-        query:
-          match_all: {}
-        size: 1000
-    response:
-      status: 200
-      payload:
-        hits:
-          hits:
-            - _score: 1
+  # - synopsis: List all the search configurations created using search api.
+  #   path: /_plugins/_search_relevance/search_configurations/_search
+  #   method: POST
+  #   warnings:
+  #     multiple-paths-detected: false
+  #   request:
+  #     payload:
+  #       query:
+  #         match_all: {}
+  #       size: 1000
+  #   response:
+  #     status: 200
+  #     payload:
+  #       hits:
+  #         hits:
+  #           - _score: 1
   - synopsis: Retrieve a specific search configuration.
     path: /_plugins/_search_relevance/search_configurations/{search_configuration_id}
     method: GET

--- a/tests/plugins/search_relevance/search_configurations.yaml
+++ b/tests/plugins/search_relevance/search_configurations.yaml
@@ -76,6 +76,8 @@ chapters:
   - synopsis: List all the search configurations created using search api.
     path: /_plugins/_search_relevance/search_configurations/_search
     method: POST
+    warnings:
+      multiple-paths-detected: false
     request:
       payload:
         query:

--- a/tests/plugins/search_relevance/search_configurations.yaml
+++ b/tests/plugins/search_relevance/search_configurations.yaml
@@ -73,6 +73,20 @@ chapters:
     method: GET
     response:
       status: 200
+  - synopsis: List all the search configurations created using search api.
+    path: /_plugins/_search_relevance/search_configurations/_search
+    method: POST
+    request:
+      payload:
+        query:
+          match_all: {}
+        size: 1000
+    response:
+      status: 200
+      payload:
+        hits:
+          hits:
+            - _score: 1
   - synopsis: Retrieve a specific search configuration.
     path: /_plugins/_search_relevance/search_configurations/{search_configuration_id}
     method: GET

--- a/tests/plugins/search_relevance/search_configurations.yaml
+++ b/tests/plugins/search_relevance/search_configurations.yaml
@@ -1,7 +1,7 @@
 $schema: ../../../json_schemas/test_story.schema.yaml
 
 description: Tests the creation and deletion of search configurations.
-# version: '>= 3.5.0'
+version: '>= 3.5.0'
 
 prologues:
   - path: /_cluster/settings
@@ -74,22 +74,31 @@ chapters:
     method: GET
     response:
       status: 200
-  # - synopsis: List all the search configurations created using search api.
-  #   path: /_plugins/_search_relevance/search_configurations/_search
-  #   method: POST
-  #   warnings:
-  #     multiple-paths-detected: false
-  #   request:
-  #     payload:
-  #       query:
-  #         match_all: {}
-  #       size: 1000
-  #   response:
-  #     status: 200
-  #     payload:
-  #       hits:
-  #         hits:
-  #           - _score: 1
+  - synopsis: List all the search configurations created using search api.
+    path: /_plugins/_search_relevance/search_configurations/_search
+    method: POST
+    warnings:
+      multiple-paths-detected: false
+    request:
+      payload:
+        query:
+          ids:
+            values:
+              - ${search_configuration.search_configuration_id}
+        size: 1
+    response:
+      status: 200
+      payload:
+        hits:
+          total:
+            value: 1
+            relation: eq
+          hits:
+            - _id: ${search_configuration.search_configuration_id}
+              _source:
+                name: simple
+                index: sample_index
+                searchPipeline: test_pipeline
   - synopsis: Retrieve a specific search configuration.
     path: /_plugins/_search_relevance/search_configurations/{search_configuration_id}
     method: GET

--- a/tools/src/OpenSearchHttpClient.ts
+++ b/tools/src/OpenSearchHttpClient.ts
@@ -15,7 +15,7 @@ import { sleep } from './helpers'
 import { Logger } from './Logger'
 import { aws4Interceptor } from 'aws4-axios'
 
-const DEFAULT_URL = 'http://localhost:9200'
+const DEFAULT_URL = 'https://localhost:9200'
 const DEFAULT_USER = 'admin'
 const DEFAULT_INSECURE = false
 

--- a/tools/src/OpenSearchHttpClient.ts
+++ b/tools/src/OpenSearchHttpClient.ts
@@ -15,7 +15,7 @@ import { sleep } from './helpers'
 import { Logger } from './Logger'
 import { aws4Interceptor } from 'aws4-axios'
 
-const DEFAULT_URL = 'https://localhost:9200'
+const DEFAULT_URL = 'http://localhost:9200'
 const DEFAULT_USER = 'admin'
 const DEFAULT_INSECURE = false
 


### PR DESCRIPTION
### Description
This change adds the recently-created search apis for the search relevance repository. These include:

- /_plugins/_search-relevance/search_configurations/_search
- /_plugins/_search-relevance/experiments/_search
- /_plugins/_search-relevance/query_sets/_search
- /_plugins/_search-relevance/judgments/_search

These give more flexibility in searching through the objects needed for search relevance. The issue and linked PRs are here: https://github.com/opensearch-project/search-relevance/issues/351

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
