### PR TITLE
Add provisioned_by field to connector, model, and agent API schemas

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -39,6 +39,8 @@ jobs:
           # test suites for specific plugins
           - version: 3.1.0
             tests: plugins/index_state_management
+          # TODO: Update to 3.7.0 snapshot once ml-commons provisioned_by PR is merged and snapshot is published.
+          # Use hub: opensearchstaging and ref: '@sha256:<hash>' similar to the plugins/ingestion-fs entry below.
           - version: 3.1.0
             tests: plugins/ml
           - version: 3.1.0

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -1141,6 +1141,10 @@ components:
               connector_id:
                 type: string
                 description: The connector ID.
+              provisioned_by:
+                type: string
+                x-version-added: '3.7'
+                description: An optional attribution tag identifying the plugin or client that registered the model (for example, `flow-framework`). Included in ML stats metrics.
             required:
               - name
     ml.create_model_meta:
@@ -1461,6 +1465,10 @@ components:
                 type: array
                 items:
                   $ref: '../schemas/ml._common.yaml#/components/schemas/Action'
+              provisioned_by:
+                type: string
+                x-version-added: '3.7'
+                description: An optional attribution tag identifying the plugin or client that created the connector (for example, `flow-framework`). Included in ML stats metrics. Set at creation time only; ignored by the Update Connector API.
             required:
               - actions
               - credential
@@ -1541,6 +1549,10 @@ components:
                 $ref: '../schemas/ml._common.yaml#/components/schemas/Memory'
               llm:
                 $ref: '../schemas/ml._common.yaml#/components/schemas/LLM'
+              provisioned_by:
+                type: string
+                x-version-added: '3.7'
+                description: An optional attribution tag identifying the plugin or client that registered the agent (for example, `flow-framework`). Included in ML stats metrics.
             required:
               - name
               - type

--- a/tests/plugins/ml/ml/agents.yaml
+++ b/tests/plugins/ml/ml/agents.yaml
@@ -41,6 +41,46 @@ chapters:
       status: 200
     output:
       test_agent_id: payload.agent_id
+  - synopsis: Register agent with provisioned_by field.
+    version: '>= 3.7'
+    warnings:
+      multiple-paths-detected: false
+    id: register_agent_with_provisioned_by
+    path: /_plugins/_ml/agents/_register
+    method: POST
+    request:
+      payload:
+        name: Test_Agent_With_Attribution
+        type: flow
+        description: this is a test agent with attribution
+        provisioned_by: flow-framework
+        tools:
+          - type: MLModelTool
+            description: A general tool to answer any question
+            parameters:
+              model_id: YOUR_LLM_MODEL_ID
+    response:
+      status: 200
+    output:
+      test_agent_with_provisioned_by_id: payload.agent_id
+  - synopsis: Get agent and verify provisioned_by field.
+    version: '>= 3.7'
+    path: /_plugins/_ml/agents/{agent_id}
+    method: GET
+    parameters:
+      agent_id: ${register_agent_with_provisioned_by.test_agent_with_provisioned_by_id}
+    response:
+      status: 200
+      payload:
+        provisioned_by: flow-framework
+  - synopsis: Delete agent created with provisioned_by.
+    version: '>= 3.7'
+    path: /_plugins/_ml/agents/{agent_id}
+    method: DELETE
+    parameters:
+      agent_id: ${register_agent_with_provisioned_by.test_agent_with_provisioned_by_id}
+    response:
+      status: 200
   - synopsis: Delete agent.
     path: /_plugins/_ml/agents/{agent_id}
     method: DELETE

--- a/tests/plugins/ml/ml/connectors.yaml
+++ b/tests/plugins/ml/ml/connectors.yaml
@@ -41,6 +41,54 @@ chapters:
       status: 200
     output:
       test_connector_id: payload.connector_id
+  - synopsis: Create connector with provisioned_by field.
+    version: '>= 3.7'
+    warnings:
+      multiple-paths-detected: false
+    id: create_connector_with_provisioned_by
+    path: /_plugins/_ml/connectors/_create
+    method: POST
+    request:
+      payload:
+        name: OpenAI Chat Connector With Attribution
+        description: The connector to public OpenAI model service for GPT 3.5
+        version: 1
+        protocol: http
+        provisioned_by: flow-framework
+        parameters:
+          endpoint: api.openai.com
+          model: gpt-3.5-turbo
+        credential:
+          openAI_key: test_api_key
+        actions:
+          - action_type: predict
+            method: POST
+            url: https://api.openai.com/v1/chat/completions
+            headers:
+              Authorization: Bearer Key
+            request_body: '{ "model": "model", "messages": "messages" }'
+    response:
+      status: 200
+    output:
+      test_connector_with_provisioned_by_id: payload.connector_id
+  - synopsis: Get connector and verify provisioned_by field.
+    version: '>= 3.7'
+    path: /_plugins/_ml/connectors/{connector_id}
+    method: GET
+    parameters:
+      connector_id: ${create_connector_with_provisioned_by.test_connector_with_provisioned_by_id}
+    response:
+      status: 200
+      payload:
+        provisioned_by: flow-framework
+  - synopsis: Delete connector created with provisioned_by.
+    version: '>= 3.7'
+    path: /_plugins/_ml/connectors/{connector_id}
+    method: DELETE
+    parameters:
+      connector_id: ${create_connector_with_provisioned_by.test_connector_with_provisioned_by_id}
+    response:
+      status: 200
   - synopsis: Get connector.
     path: /_plugins/_ml/connectors/{connector_id}
     method: GET

--- a/tests/plugins/ml/ml/models.yaml
+++ b/tests/plugins/ml/ml/models.yaml
@@ -34,6 +34,57 @@ prologues:
       count: 5
       wait: 30000
 chapters:
+  - synopsis: Register model with provisioned_by field.
+    version: '>= 3.7'
+    warnings:
+      multiple-paths-detected: false
+    id: register_model_with_provisioned_by
+    path: /_plugins/_ml/models/_register
+    method: POST
+    request:
+      payload:
+        name: huggingface/sentence-transformers/msmarco-distilbert-base-tas-b
+        version: 1.0.1
+        model_format: TORCH_SCRIPT
+        provisioned_by: flow-framework
+    response:
+      status: 200
+    output:
+      provisioned_by_task_id: payload.task_id
+  - synopsis: Wait for provisioned_by model registration to complete.
+    version: '>= 3.7'
+    id: get_provisioned_by_task
+    path: /_plugins/_ml/tasks/{task_id}
+    method: GET
+    parameters:
+      task_id: ${register_model_with_provisioned_by.provisioned_by_task_id}
+    response:
+      status: 200
+      payload:
+        state: COMPLETED
+    output:
+      model_id: payload.model_id
+    retry:
+      count: 5
+      wait: 30000
+  - synopsis: Get model and verify provisioned_by field.
+    version: '>= 3.7'
+    path: /_plugins/_ml/models/{model_id}
+    method: GET
+    parameters:
+      model_id: ${get_provisioned_by_task.model_id}
+    response:
+      status: 200
+      payload:
+        provisioned_by: flow-framework
+  - synopsis: Delete model registered with provisioned_by.
+    version: '>= 3.7'
+    path: /_plugins/_ml/models/{model_id}
+    method: DELETE
+    parameters:
+      model_id: ${get_provisioned_by_task.model_id}
+    response:
+      status: 200
   - synopsis: Search model.
     path: /_plugins/_ml/models/_search
     method: GET


### PR DESCRIPTION
### Description

Adds the optional `provisioned_by` field (keyword, version-added 3.7) to:
- `ml.register_model` request body
- `ml.create_connector` request body
- `ml.register_agent` request body

This field is an attribution tag identifying the plugin or client that provisioned the resource (e.g., `flow-framework`, `opensearch-dashboards`). It is included in ML stats metrics for adoption tracking.

### Integration tests

Adds test chapters that:
1. Register each resource with `provisioned_by: flow-framework`
2. GET the resource and verify the field is persisted and returned
3. Clean up (DELETE)

All tests are gated to `>= 3.7`.

### Related

- ml-commons implementation: https://github.com/opensearch-project/ml-commons/pull/4754

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.