### PR TITLE
fixed search_pipeline for request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
-- Fixed `search_pipeline` in `SearchRequestBody` to accept either a pipeline name (string) or an inline pipeline definition (`SearchPipelineStructure` object)
+- Fixed `search_pipeline` in `SearchRequestBody` to accept either a pipeline name (string) or an inline pipeline definition (`SearchPipelineStructure` object) ([#1091](https://github.com/opensearch-project/opensearch-api-specification/pull/1091))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added specs for Search Relevance Workbench plugin for scheduling endpoints ([#967](https://github.com/opensearch-project/opensearch-api-specification/pull/967))
 - Added specs for UBI plugin endpoints ([#845](https://github.com/opensearch-project/opensearch-api-specification/pull/845))
 
+### Fixed
+
+- Fixed `search_pipeline` in `SearchRequestBody` to accept either a pipeline name (string) or an inline pipeline definition (`SearchPipelineStructure` object)
+
 ### Added
 
 - Added remaining APIs for LTR including store element operations, model management, feature set operations, routing support, and POST support for update operations ([#935](https://github.com/opensearch-project/opensearch-api-specification/pull/935))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2634,8 +2634,7 @@ components:
                   NOTE: This is a debugging tool and adds significant overhead to search execution.
                 type: boolean
               search_pipeline:
-                description: Customizable sequence of processing stages applied to search queries.
-                type: string
+                $ref: '../schemas/search_pipeline._common.yaml#/components/schemas/SearchPipelineRef'
               verbose_pipeline:
                 description: Enables or disables verbose mode for the search pipeline.
                 type: boolean

--- a/spec/schemas/search_pipeline._common.yaml
+++ b/spec/schemas/search_pipeline._common.yaml
@@ -10,6 +10,15 @@ components:
       type: object
       additionalProperties:
         $ref: '#/components/schemas/SearchPipelineStructure'
+    SearchPipelineRef:
+      description: |-
+        A search pipeline specified either as the name of a stored pipeline
+        or as an inline pipeline definition.
+      oneOf:
+        - title: pipeline_name
+          type: string
+        - title: pipeline_definition
+          $ref: '#/components/schemas/SearchPipelineStructure'
     SearchPipelineStructure:
       type: object
       properties:

--- a/tests/default/_core/search/pipeline/inline_pipeline.yaml
+++ b/tests/default/_core/search/pipeline/inline_pipeline.yaml
@@ -1,0 +1,55 @@
+$schema: ../../../../../../json_schemas/test_story.schema.yaml
+
+description: |-
+  Test using search_pipeline as an inline pipeline definition in the request body,
+  without creating a stored pipeline.
+warnings:
+  invalid-path-detected: false
+version: '>= 2.8'
+prologues:
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: 'true'
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {create: {_index: movies}}
+        - {director: Bennett Miller, title: Moneyball, year: 2011}
+        - {create: {_index: movies}}
+        - {director: Nicolas Winding Refn, title: Drive, year: 1960}
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Search with an inline search_pipeline definition in the request body.
+    warnings:
+      multiple-paths-detected: false
+    path: /{index}/_search
+    method: POST
+    parameters:
+      index: movies
+    request:
+      payload:
+        search_pipeline:
+          request_processors:
+            - filter_query:
+                tag: tag
+                description: This processor restricts searches to 20th century movies.
+                query:
+                  range:
+                    year:
+                      lte: 2000
+    response:
+      status: 200
+      payload:
+        hits:
+          total:
+            value: 1
+          hits:
+            - _index: movies
+              _source:
+                title: Drive
+                director: Nicolas Winding Refn
+                year: 1960


### PR DESCRIPTION
### Description
Root cause: search_pipeline in `SearchRequestBody` is typed as type: string (pipeline name only), but OpenSearch also supports passing an inline pipeline definition as object form directly in the request body.

Fixed:  
Added a new `SearchPipelineRef` union type that accepts either:
- A string: the name of an existing stored pipeline
- A `SearchPipelineStructure` object: an inline pipeline definition with `request_processors,` `response_processors,` and/or `phase_results_processors`

Related PR: #1011 
### Issues Resolved
- #875 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
