### PR TITLE
fixed async search_pipeline for SearchPipelineRef

### DIFF
--- a/spec/schemas/asynchronous_search._common.yaml
+++ b/spec/schemas/asynchronous_search._common.yaml
@@ -161,6 +161,8 @@ components:
           type: array
           items:
             type: string
+        search_pipeline:
+          $ref: '../schemas/search_pipeline._common.yaml#/components/schemas/SearchPipelineRef'
       description: The search definition using the Query DSL.
     AsynchronousSearchStats:
       type: object


### PR DESCRIPTION
### Description
Added `search_pipeline` field to the async search Search request body schema in `asynchronous_search._common.yaml`.  Previously the field was missing entirely, meaning the schema rejected any async search request that included a search pipeline.

The field accepts either:
  - A string: the name of a stored pipeline
  - An object `SearchPipelineStructure`: an inline pipeline definition, e.g. using a score-normalization-processor alongside a hybrid query

### Issues Resolved
- #875 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
