### PR TITLE
Add query to TermsLookup to support terms lookup by query feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add title to `ml.predict_model_stream` and `ml.execute_agent_stream` requestBody ([#1072](https://github.com/opensearch-project/opensearch-api-specification/pull/1072))
 - Added `agentic` query type, `agentic_query_translator` request processor, and `agentic_context` response processor ([#1073](https://github.com/opensearch-project/opensearch-api-specification/pull/1073))
 - Added `allow_no_indices`, `ignore_unavailable`, and `ignore_throttled` query parameters to `create_pit` ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
+- Added `query` to TermsLookup to support terms lookup by query
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -2166,6 +2166,8 @@ components:
           $ref: '_common.yaml#/components/schemas/Field'
         routing:
           $ref: '_common.yaml#/components/schemas/Routing'
+        query:
+          $ref: '#/components/schemas/QueryContainer'
         store:
           type: boolean
       required:

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -2168,12 +2168,27 @@ components:
           $ref: '_common.yaml#/components/schemas/Routing'
         query:
           $ref: '#/components/schemas/QueryContainer'
+          x-version-added: 3.2.0
         store:
           type: boolean
       required:
-        - id
         - index
         - path
+      allOf:
+        - oneOf:
+            - type: object
+              properties:
+                id:
+                  $ref: '_common.yaml#/components/schemas/Id'
+              required:
+                - id
+            - type: object
+              properties:
+                query:
+                  $ref: '#/components/schemas/QueryContainer'
+              required:
+                - query
+              x-version-added: 3.2.0
     TermsSetQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'


### PR DESCRIPTION
### Description
This adds support for the terms lookup by query feature from OpenSearch 3.2.0

### Issues Resolved
https://github.com/opensearch-project/opensearch-api-specification/issues/1094

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
