### PR TITLE
Fix ISM index parameters to use Indices type instead of IndexName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove redundant `type:object` from `*Aggregate` types ([#1083](https://github.com/opensearch-project/opensearch-api-specification/pull/1083))
 
 ### Fixed
+- Fixed ISM index parameters to use `Indices` type instead of `IndexName` for multi-index support ([#1097](https://github.com/opensearch-project/opensearch-api-specification/issues/1097))
 - Fixed the default parameters for `data_stream/_stats` and `shard_stores/status` ([#931](https://github.com/opensearch-project/opensearch-api-specification/pull/931))
 - Fixed the type of `SearchStats`'s `concurrent_avg_slice_count` to be a double ([#942](https://github.com/opensearch-project/opensearch-api-specification/pull/942))
 - Fixed name and metadata missing from metric aggregations ([#969](https://github.com/opensearch-project/opensearch-api-specification/pull/969))

--- a/spec/namespaces/ism.yaml
+++ b/spec/namespaces/ism.yaml
@@ -400,66 +400,66 @@ components:
       in: query
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
     ism.add_policy::path.index:
       name: index
       in: path
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
       style: simple
     ism.change_policy::query.index:
       name: index
       in: query
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
     ism.remove_policy::query.index:
       name: index
       in: query
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
     ism.remove_policy::path.index:
       name: index
       in: path
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
       style: simple
     ism.change_policy::path.index:
       name: index
       in: path
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
       style: simple
     ism.explain_policy::path.index:
       name: index
       in: path
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
       style: simple
     ism.retry_index::query.index:
       name: index
       in: query
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
     ism.retry_index::path.index:
       name: index
       in: path
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
       style: simple
     ism.refresh_search_analyzers::path.index:
       name: index
       in: path
       required: true
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/IndexName'
+        $ref: '../schemas/_common.yaml#/components/schemas/Indices'
       style: simple
     ism.put_policies::query.policyID:
       name: policyID


### PR DESCRIPTION
The ISM path and query parameters for `add_policy`, `change_policy`, `explain`, `remove_policy`, `retry`, and `refresh_search_analyzers` accept comma-separated index lists and wildcards, but were incorrectly
typed as `IndexName` (scalar string). Change them to reference `Indices`, which supports both single index names and arrays.

Every ISM REST handler parses the `index` parameter with [`Strings.splitStringByCommaToArray`](https://github.com/opensearch-project/index-management/blob/36eb525dabe1265b5e27559952233d49cf63cf5e/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyAction.kt#L45), splitting the input into an array before passing it to the transport action:
- [`RestAddPolicyAction`](https://github.com/opensearch-project/index-management/blob/36eb525dabe1265b5e27559952233d49cf63cf5e/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestAddPolicyAction.kt#L45)
- [`RestChangePolicyAction`](https://github.com/opensearch-project/index-management/blob/36eb525dabe1265b5e27559952233d49cf63cf5e/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyAction.kt#L46)
- [`RestExplainAction`](https://github.com/opensearch-project/index-management/blob/36eb525dabe1265b5e27559952233d49cf63cf5e/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestExplainAction.kt#L71)
- [`RestRemovePolicyAction`](https://github.com/opensearch-project/index-management/blob/36eb525dabe1265b5e27559952233d49cf63cf5e/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRemovePolicyAction.kt#L43)
- [`RestRetryFailedManagedIndexAction`](https://github.com/opensearch-project/index-management/blob/36eb525dabe1265b5e27559952233d49cf63cf5e/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt#L45)
- [`RestRefreshSearchAnalyzerAction`](https://github.com/opensearch-project/index-management/blob/36eb525dabe1265b5e27559952233d49cf63cf5e/src/main/kotlin/org/opensearch/indexmanagement/refreshanalyzer/RestRefreshSearchAnalyzerAction.kt#L41)

This is consistent with how other namespaces (`cluster`, `cat`) type their multi-index parameters.

Present since the ISM plugin's first OpenSearch release (1.0.0.0); the original Open Distro commit used the same `splitStringByCommaToArray` pattern.

Fixes: https://github.com/opensearch-project/opensearch-api-specification/issues/1097

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
