### PR TITLE
Fix ltr CacheStatsResponse to use NodesResponseBase via allOf

### DIFF
--- a/spec/schemas/ltr._common.yaml
+++ b/spec/schemas/ltr._common.yaml
@@ -160,22 +160,22 @@ components:
           $ref: '#/components/schemas/NodeStatsDetails'
 
     CacheStatsResponse:
-      type: object
-      properties:
-        _nodes:
-          $ref: '_common.yaml#/components/schemas/NodeStatistics'
-        cluster_name:
-          $ref: '_common.yaml#/components/schemas/Name'
-        all:
-          $ref: '#/components/schemas/CacheAllStats'
-        stores:
-          type: object
-          description: Cache statistics by store.
-        nodes:
-          type: object
-          description: Cache statistics per node.
-          additionalProperties:
-            $ref: '#/components/schemas/NodeDetails'
+      allOf:
+        - $ref: 'nodes._common.yaml#/components/schemas/NodesResponseBase'
+        - type: object
+          properties:
+            cluster_name:
+              $ref: '_common.yaml#/components/schemas/Name'
+            all:
+              $ref: '#/components/schemas/CacheAllStats'
+            stores:
+              type: object
+              description: Cache statistics by store.
+            nodes:
+              type: object
+              description: Cache statistics per node.
+              additionalProperties:
+                $ref: '#/components/schemas/NodeDetails'
 
     NotFoundResponse:
       type: object


### PR DESCRIPTION
`CacheStatsResponse` is served by [`RestFeatureStoreCaches.getStats`](https://github.com/opensearch-project/opensearch-learning-to-rank-base/blob/4318b045a5466fa563df336edacfe18c97a07933/src/main/java/com/o19s/es/ltr/rest/RestFeatureStoreCaches.java#L80-L82), which wraps the response with [`NodesResponseRestListener`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/RestActions.java#L267-L278). That listener calls [`RestActions.nodesResponse`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/RestActions.java#L215-L227), which renders the [`_nodes` header via `buildNodesHeader`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/RestActions.java#L171-L179) and then delegates body rendering to [`CachesStatsNodesResponse.toXContent`](https://github.com/opensearch-project/opensearch-learning-to-rank-base/blob/4318b045a5466fa563df336edacfe18c97a07933/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java#L98-L115) (which itself extends [`BaseNodesResponse`](https://github.com/opensearch-project/opensearch-learning-to-rank-base/blob/4318b045a5466fa563df336edacfe18c97a07933/src/main/java/com/o19s/es/ltr/action/CachesStatsAction.java#L60)).

The previous schema declared `_nodes` as an inline property alongside `nodes`, but the server renders `_nodes` outside the response class via the `NodesResponseRestListener` framework. Replacing the inline property with an `allOf` composition against `NodesResponseBase` makes the schema accurately mirror the server's class hierarchy. This also resolves a name collision (`_nodes` and `nodes` normalize to the same identifier in typed code generators), but that is a consequence of the correctness fix, not the motivation.

This pattern matches `ltr.Stats` (same file), `nodes.info`, `nodes.stats`, `nodes.usage`, `cluster.stats`, and 6 other schemas already in the spec.

Present since the LTR plugin's first OpenSearch release (1.0.0-alpha1).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
