### PR TITLE
Add missing properties to nodes.info settings schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))
+- Add `host`, `publish_host`, and `publish_port` to `NodeInfoSettingsHttp`; `host` to `NodeInfoSettingsTransport`; `roles` to `NodeInfoSettingsNode`; and updated `NodeInfoSettingsNetwork.host` to `StringOrStringArray` ([#1101](https://github.com/opensearch-project/opensearch-api-specification/pull/1101))
 
 ### Removed
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add msearch `allow_partial_results` flag ([#1061](https://github.com/opensearch-project/opensearch-api-specification/pull/1061))
 - Add title to `ml.predict_model_stream` and `ml.execute_agent_stream` requestBody ([#1072](https://github.com/opensearch-project/opensearch-api-specification/pull/1072))
 - Added `agentic` query type, `agentic_query_translator` request processor, and `agentic_context` response processor ([#1073](https://github.com/opensearch-project/opensearch-api-specification/pull/1073))
+- Add `host`, `publish_host`, and `publish_port` to `NodeInfoSettingsHttp`; `host` to `NodeInfoSettingsTransport`; `roles` to `NodeInfoSettingsNode`; and updated `NodeInfoSettingsNetwork.host` to `StringOrStringArray` ([#1101](https://github.com/opensearch-project/opensearch-api-specification/pull/1101))
 
 ### Removed
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))

--- a/spec/schemas/nodes.info.yaml
+++ b/spec/schemas/nodes.info.yaml
@@ -456,6 +456,8 @@ components:
         max_local_storage_nodes:
           type: string
           description: The maximum number of nodes allowed to store data locally
+        roles:
+          $ref: '_common.yaml#/components/schemas/StringOrStringArray'
       required:
         - name
     NodeInfoPath:
@@ -539,6 +541,12 @@ components:
           $ref: '_common.yaml#/components/schemas/StringifiedBoolean'
         port:
           $ref: '_common.yaml#/components/schemas/StringifiedInteger'
+        host:
+          $ref: '_common.yaml#/components/schemas/StringOrStringArray'
+        publish_host:
+          $ref: '_common.yaml#/components/schemas/StringOrStringArray'
+        publish_port:
+          $ref: '_common.yaml#/components/schemas/StringifiedInteger'
       required:
         - type
     NodeInfoSettingsHttpType:
@@ -573,6 +581,8 @@ components:
         type.default:
           type: string
           description: The default transport type.
+        host:
+          $ref: '_common.yaml#/components/schemas/StringOrStringArray'
       required:
         - type
     NodeInfoSettingsTransportType:


### PR DESCRIPTION
[`NodesInfoResponse.toXContent`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/action/admin/cluster/node/info/NodesInfoResponse.java#L119-L121) serializes node settings via raw [`Settings.toXContent`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/common/settings/Settings.java#L624-L635), which preserves the internal storage format. The following settings were missing from the spec:

- **`node.roles`** ([`NODE_ROLES_SETTING`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/node/NodeRoleSettings.java#L50-L51)): `Setting<List<DiscoveryNodeRole>>`, serialized as a JSON array when configured via YAML list, or a comma-separated string when set via `-E`, env var, or flat YAML scalar.
- **`http.host`**, **`http.publish_host`** ([`SETTING_HTTP_HOST`, `SETTING_HTTP_PUBLISH_HOST`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/http/HttpTransportSettings.java#L94-L102)): `Setting<List<String>>`, same polymorphic serialization.
- **`http.publish_port`** ([`SETTING_HTTP_PUBLISH_PORT`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/http/HttpTransportSettings.java#L119)): `Setting<Integer>`.
- **`transport.host`** ([`HOST`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/transport/TransportSettings.java#L62-L67)): `Setting<List<String>>`, same polymorphic serialization.

The string-or-array polymorphism occurs because [`Settings.fromXContent`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/common/settings/Settings.java#L692-L717) is format-preserving: YAML arrays hit the [`START_ARRAY` branch](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/common/settings/Settings.java#L692) (stored as `List`, serialized as JSON array), while flat scalars hit the [`VALUE_STRING` branch](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/common/settings/Settings.java#L712) (stored as `String`, serialized as JSON string). Uses the existing `StringOrStringArray` ref per reviewer suggestion.

All settings present since OpenSearch 1.0.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
