### PR TITLE
Mark create_pit keep_alive query parameter as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unused dependencies: `eslint-config-standard-with-typescript`, `eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-promise`, `@eslint/eslintrc`
 
 ### Fixed
+- Fixed `create_pit` `keep_alive` query parameter to be required ([#1102](https://github.com/opensearch-project/opensearch-api-specification/pull/1102))
 - Fixed ISM index parameters to use `Indices` type instead of `IndexName` for multi-index support ([#1097](https://github.com/opensearch-project/opensearch-api-specification/issues/1097))
 - Fixed the default parameters for `data_stream/_stats` and `shard_stores/status` ([#931](https://github.com/opensearch-project/opensearch-api-specification/pull/931))
 - Fixed the type of `SearchStats`'s `concurrent_avg_slice_count` to be a double ([#942](https://github.com/opensearch-project/opensearch-api-specification/pull/942))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -3775,6 +3775,7 @@ components:
     create_pit::query.keep_alive:
       name: keep_alive
       in: query
+      required: true
       description: Specify the keep alive for point in time.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/Duration'


### PR DESCRIPTION
The [`RestCreatePitAction`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/search/RestCreatePitAction.java#L43) parses `keep_alive` with a `null` default, passing it directly to `CreatePitRequest`. [`CreatePitRequest.validate()`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/action/search/CreatePitRequest.java#L127-L133) then rejects the request with HTTP 400 ("keep alive not specified") when the value is null.

The validation has been present since the PIT API was first introduced (PR #2745 / #3921), shipped in OpenSearch 2.4.0 (2.x backport via #4616). All OpenSearch versions that support `create_pit` require `keep_alive`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
