### PR TITLE
Add max_score to HitsMetadata required fields

### DIFF
--- a/.github/workflows/analyze-pr-changes.yml
+++ b/.github/workflows/analyze-pr-changes.yml
@@ -144,8 +144,9 @@ jobs:
       - name: Generate API Changes Summary
         shell: bash -eo pipefail {0}
         run: |
-          if ! openapi-changes summary --no-logo --no-color --markdown $BEFORE_SPEC $AFTER_SPEC >output.md ; then
-            if ! grep -q 'breaking changes discovered' output.md ; then
+          if ! openapi-changes summary --no-logo --no-color --markdown $BEFORE_SPEC $AFTER_SPEC >output.md 2>error.log ; then
+            if ! grep -q 'breaking changes discovered' error.log ; then
+              cat error.log >/dev/stderr
               cat output.md >/dev/stderr
               exit 1
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unused dependencies: `eslint-config-standard-with-typescript`, `eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-promise`, `@eslint/eslintrc`
 
 ### Fixed
+- Fixed `HitsMetadata` to mark `max_score` as required ([#1103](https://github.com/opensearch-project/opensearch-api-specification/pull/1103))
 - Fixed `create_pit` `keep_alive` query parameter to be required ([#1102](https://github.com/opensearch-project/opensearch-api-specification/pull/1102))
 - Fixed ISM index parameters to use `Indices` type instead of `IndexName` for multi-index support ([#1097](https://github.com/opensearch-project/opensearch-api-specification/issues/1097))
 - Fixed the default parameters for `data_stream/_stats` and `shard_stores/status` ([#931](https://github.com/opensearch-project/opensearch-api-specification/pull/931))

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -31,6 +31,7 @@ components:
               format: float
       required:
         - hits
+        - max_score
     HitsMetadataJsonValue:
       allOf:
         - $ref: '#/components/schemas/HitsMetadata'


### PR DESCRIPTION
Add `max_score` to the `required` list of `HitsMetadata`.

The OpenSearch server **unconditionally** serializes `max_score` in every search response — emitting `null` when the value is `NaN`, or the float value otherwise.  This behavior has been present since the initial 1.0 fork and has never changed, but the spec incorrectly marked the field as optional.

**Server reference:** [`SearchHits.java#L247-L251`](https://github.com/opensearch-project/OpenSearch/blob/f1cbbba360e92384448104a14adcafc88ec6854b/server/src/main/java/org/opensearch/search/SearchHits.java#L247-L251)

```java
if (Float.isNaN(maxScore)) {
    builder.nullField(Fields.MAX_SCORE);
} else {
    builder.field(Fields.MAX_SCORE, maxScore);
}
```

The field was already declared as `nullable: true` with `type: number` in the spec but wasn't listed under `required`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
