### PR TITLE
Fix ISM last_updated_time fields to use int64 format

### DIFF
--- a/spec/schemas/ism._common.yaml
+++ b/spec/schemas/ism._common.yaml
@@ -30,6 +30,7 @@ components:
           description: The description of the policy.
         last_updated_time:
           type: integer
+          format: int64
           description: When the policy was last updated.
         schema_version:
           type: number
@@ -411,6 +412,7 @@ components:
           description: The name of the notification destination.
         last_update_time:
           type: integer
+          format: int64
           description: When the notification destination was last updated.
       additionalProperties:
         anyOf:
@@ -475,6 +477,7 @@ components:
           description: The priority of the ISM template.
         last_updated_time:
           type: integer
+          format: int64
           description: When the ISM template was last updated.
     RetryIndexRequest:
       type: object


### PR DESCRIPTION
Fixes opensearch-project/opensearch-api-specification#953

## Problem
Three ISM schema fields use `type: integer` without `format: int64`, causing Jackson deserialization overflow on timestamps > Integer.MAX_VALUE (~2.1 billion ms = ~24 days uptime). Any long-running cluster hits this silently.

## Fix
Added `format: int64` to three fields in `spec/schemas/ism._common.yaml`:
- `Policy.last_updated_time`
- `ErrorNotificationDestination.last_update_time`
- `IsmTemplate.last_updated_time`

## Impact
Fix propagates to all generated clients (Java, Python, Go, etc.) on next spec regeneration cycle.