### PR TITLE
Fix ingestion failures field type from array to map

### DIFF
--- a/.github/workflows/analyze-pr-changes.yml
+++ b/.github/workflows/analyze-pr-changes.yml
@@ -144,8 +144,9 @@ jobs:
       - name: Generate API Changes Summary
         shell: bash -eo pipefail {0}
         run: |
-          if ! openapi-changes summary --no-logo --no-color --markdown $BEFORE_SPEC $AFTER_SPEC >output.md ; then
-            if ! grep -q 'breaking changes discovered' output.md ; then
+          if ! openapi-changes summary --no-logo --no-color --markdown $BEFORE_SPEC $AFTER_SPEC >output.md 2>error.log ; then
+            if ! grep -q 'breaking changes discovered' error.log ; then
+              cat error.log >/dev/stderr
               cat output.md >/dev/stderr
               exit 1
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed `create_pit` `keep_alive` query parameter to be required ([#1102](https://github.com/opensearch-project/opensearch-api-specification/pull/1102))
 - Fixed ISM index parameters to use `Indices` type instead of `IndexName` for multi-index support ([#1097](https://github.com/opensearch-project/opensearch-api-specification/issues/1097))
+- Fixed `failures` field type in `PauseIngestionResponse` and `ResumeIngestionResponse` from array to map keyed by index name, matching server serialization ([#1107](https://github.com/opensearch-project/opensearch-api-specification/pull/1107))
 - Fixed the default parameters for `data_stream/_stats` and `shard_stores/status` ([#931](https://github.com/opensearch-project/opensearch-api-specification/pull/931))
 - Fixed the type of `SearchStats`'s `concurrent_avg_slice_count` to be a double ([#942](https://github.com/opensearch-project/opensearch-api-specification/pull/942))
 - Fixed name and metadata missing from metric aggregations ([#969](https://github.com/opensearch-project/opensearch-api-specification/pull/969))

--- a/spec/schemas/ingestion._common.yaml
+++ b/spec/schemas/ingestion._common.yaml
@@ -16,9 +16,12 @@ components:
           type: boolean
           description: Indicates if the pause request has been acknowledged by individual shards.
         failures:
-          type: array
-          items:
-            $ref: '#/components/schemas/IngestionStateShardFailure'
+          type: object
+          description: Shard-level failures grouped by index name.
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/IngestionStateShardFailure'
         error:
           type: string
       required:
@@ -42,9 +45,12 @@ components:
           type: boolean
           description: Indicates if the resume request has been acknowledged by individual shards.
         failures:
-          type: array
-          items:
-            $ref: '#/components/schemas/IngestionStateShardFailure'
+          type: object
+          description: Shard-level failures grouped by index name.
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/IngestionStateShardFailure'
         error:
           type: string
       required:


### PR DESCRIPTION
The `PauseIngestionResponse` and `ResumeIngestionResponse` schemas incorrectly declare `failures` as `type: array`. The server's [`IngestionUpdateStateResponse.addCustomFields`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/IngestionUpdateStateResponse.java#L74-L87) groups shard failures by index name via [`IngestionStateShardFailure.groupShardFailuresByIndex`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/IngestionStateShardFailure.java#L57-L66) and serializes the result as a JSON object keyed by index name, with each value being an array of [`IngestionStateShardFailure`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/action/admin/indices/streamingingestion/IngestionStateShardFailure.java#L47-L52) objects (`{"shard": N, "error": "..."}`):

```json
"failures": {"index-name": [{"shard": 0, "error": "..."}]}
```

This map-based serialization has been present since the ingestion management APIs were first introduced (PR #17631), shipped in OpenSearch 3.0.0-beta1 (experimental) and promoted to `@PublicApi` in 3.6.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
