### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/analyze-pr-changes.yml
+++ b/.github/workflows/analyze-pr-changes.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Coverage Data
         id: upload-coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-api
           path: |
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload API Changes HTML Report
         id: upload-api-changes-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: api-changes-report
           path: |
@@ -214,7 +214,7 @@ jobs:
           API_CHANGES_REPORT_URL: ${{ steps.upload-api-changes-report.outputs.artifact-url }}
 
       - name: Upload PR Comment Payload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr-comment
           path: pr-comment.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload Artifacts
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build
           path: |
@@ -38,7 +38,7 @@ jobs:
 
       - name: Release Specification to GitHub
         id: release
-        uses: marvinpinto/action-automatic-releases@v1.2.1
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: ${{ steps.branch.outputs.name }}-latest
@@ -50,14 +50,14 @@ jobs:
 
       - name: Extract Changelog
         id: changelog
-        uses: sean0x42/markdown-extract@v2
+        uses: sean0x42/markdown-extract@4178293dd16a52514b6cb2c01f4d309d264b2736 # v2
         with:
           file: CHANGELOG.md
           pattern: Unreleased
 
       - name: Update Release Description
         id: update
-        uses: tubone24/update_release@v1.3.1
+        uses: tubone24/update_release@c04c17054b939144ec8a7cba969d74992f812d66 # v1.3.1
         env:
           TAG_NAME: ${{ steps.branch.outputs.name }}-latest
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,11 +7,11 @@ jobs:
   verify-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: dangoslen/changelog-enforcer@v3
+      - uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # v3
         with:
           skipLabels: 'autocut, skip-changelog'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # v1
         with:
           fail: true
           args: --base . --verbose --no-progress './**/*.yaml' './**/*.yml' './**/*.md' './**/*.json'  './**/*.ts' --exclude-path ./package-lock.json --accept 200,429

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -37,14 +37,14 @@ jobs:
           jekyll build
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:
           folder: _site
           branch: gh-pages
 
 
       - name: Trigger Proto Convert Workflow
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.OSPT_PAT }}
           repository: opensearch-project/opensearch-protobufs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -16,14 +16,14 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: refs/heads/main
           sparse-checkout: |
             .github
 
       - name: Download PR Comment Payload
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: pr-comment
@@ -52,14 +52,14 @@ jobs:
           } | tee "$GITHUB_ENV"
 
       - name: Render Comment Template
-        uses: chuhlomin/render-template@v1
+        uses: chuhlomin/render-template@a7c644e341797d050d1cb24332d83791b9a46dae # v1
         id: render
         with:
           template: .github/pr-comment-templates/${{ env.TEMPLATE_NAME }}.template.md
           vars: ${{ env.TEMPLATE_DATA }}
 
       - name: Find Existing Comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: fc
         with:
           issue-number: ${{ env.PR_NUMBER }}
@@ -67,7 +67,7 @@ jobs:
           body-includes: ${{ env.COMMENT_IDENTIFIER }}
 
       - name: Create or Update Comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/proto-comment.yml
+++ b/.github/workflows/proto-comment.yml
@@ -15,14 +15,14 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: refs/heads/main
           sparse-checkout: |
             .github
 
       - name: Download Proto Comment Payload
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: proto-comment-payload
@@ -51,7 +51,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Find Existing Comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: fc
         with:
           issue-number: ${{ env.PR_NUMBER }}
@@ -59,7 +59,7 @@ jobs:
           body-includes: Proto Compatibility Report
 
       - name: Create or Update Comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/proto-compatibility-check.yml
+++ b/.github/workflows/proto-compatibility-check.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
@@ -24,7 +24,7 @@ jobs:
         run: npm run merge -- --source ./spec --output ./build/opensearch-openapi.yaml
 
       - name: Upload OpenAPI spec artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: openapi-spec
           path: ./build/opensearch-openapi.yaml
@@ -32,7 +32,7 @@ jobs:
 
   compatibility-report:
     needs: build-spec
-    uses: opensearch-project/opensearch-protobufs/.github/workflows/backward-compatible-report.yml@main
+    uses: opensearch-project/opensearch-protobufs/.github/workflows/backward-compatible-report.yml@6e726093c899125facf68eab2b4ef10c4c1bff5d # main
     with:
       spec_artifact_name: openapi-spec
 
@@ -63,7 +63,7 @@ jobs:
           cat reports/proto-comment-payload.json
 
       - name: Upload Report Payload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: proto-comment-payload
           path: reports/proto-comment-payload.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Get Current Version
         id: current
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload Artifacts
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build
           path: |
@@ -49,14 +49,14 @@ jobs:
 
       - name: Extract Changelog
         id: changelog
-        uses: sean0x42/markdown-extract@v2
+        uses: sean0x42/markdown-extract@4178293dd16a52514b6cb2c01f4d309d264b2736 # v2
         with:
           file: CHANGELOG.md
           pattern: Unreleased
           no-print-matched-heading: true
 
       - name: Draft a release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         id: release
         with:
           draft: true
@@ -72,7 +72,7 @@ jobs:
             build/*
 
       - name: Increment Version
-        uses: nguyenvukhang/semver-increment@v1
+        uses: nguyenvukhang/semver-increment@38a3e3f41cfd66c9b0cef7dac0370bb642371574 # v1
         id: version
         with:
           increment: patch
@@ -80,12 +80,12 @@ jobs:
           version-regex: '^version: (.*)'
 
       - name: Update CHANGELOG to the Next Developer Iteration
-        uses: thomaseizinger/keep-a-changelog-new-release@v3
+        uses: thomaseizinger/keep-a-changelog-new-release@77ac767b2f7f6edf2ee72ab3364ed26667086f96 # v3
         with:
           tag: ${{ github.ref_name }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'Preparing for next developer iteration ${{ steps.version.outputs.version }}.'

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
@@ -24,7 +24,7 @@ jobs:
         run: npm run style:prepare -- --source tests
 
       - name: Check Style
-        uses: errata-ai/vale-action@v2.1.1
+        uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
           version: 3.7.1
           vale_flags: --ignore-syntax

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -89,10 +89,10 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
@@ -128,13 +128,13 @@ jobs:
           ; done
 
       - name: Upload Test Coverage Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-${{ matrix.entry.version }}-${{ steps.tests.outputs.hash }}
           path: coverage/test-spec-coverage-${{ steps.tests.outputs.hash }}.json
 
       - name: Upload Logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: logs-${{ matrix.entry.version }}-${{ steps.tests.outputs.hash }}
@@ -144,10 +144,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-opensearch-spec
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download Spec Coverage Data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: coverage
 
@@ -214,7 +214,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Upload PR Comment Payload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: github.event_name == 'pull_request'
         with:
           name: pr-comment

--- a/.github/workflows/test-tools-integ.yml
+++ b/.github/workflows/test-tools-integ.yml
@@ -29,7 +29,7 @@ jobs:
       OPENSEARCH_URL: https://localhost:9200
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run OpenSearch Cluster
         working-directory: tests/default
@@ -38,7 +38,7 @@ jobs:
           sleep 15
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
@@ -50,6 +50,6 @@ jobs:
           npm run test:integ -- --coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-tools-unit.yml
+++ b/.github/workflows/test-tools-unit.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
@@ -40,6 +40,6 @@ jobs:
           npm run test:unit -- --coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/validate-spec-lint.yml
+++ b/.github/workflows/validate-spec-lint.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 

--- a/.github/workflows/validate-spec-py.yml
+++ b/.github/workflows/validate-spec-py.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
@@ -18,7 +18,7 @@ jobs:
         run: npm ci && npm run merge
 
       - name: Set Up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/validate-spec-ruby.yml
+++ b/.github/workflows/validate-spec-ruby.yml
@@ -9,17 +9,17 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/tools/src/validate-spec-ruby/Gemfile
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '20'
 
       - name: Build
         run: npm ci && npm run merge
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true


### PR DESCRIPTION
### Description

Pin all GitHub Action tag references to their corresponding commit SHAs.

Tags are mutable references that can be force-pushed to point to different commits, making them vulnerable to supply chain attacks. Commit SHAs are immutable and guarantee that the exact reviewed code is executed in CI workflows. This change pins all third-party actions to their current commit SHAs to prevent potential tampering.