### PR TITLE
Add API Keys spec (create, list, revoke)

### DIFF
--- a/spec/namespaces/security.yaml
+++ b/spec/namespaces/security.yaml
@@ -339,6 +339,45 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/security.delete_action_group@200'
+  /_plugins/_security/api/apitokens:
+    get:
+      operationId: security.get_api_keys.0
+      x-operation-group: security.get_api_keys
+      x-version-added: '3.7'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
+      description: Returns all API keys, including active, expired, and revoked keys.
+      responses:
+        '200':
+          $ref: '#/components/responses/security.get_api_keys@200'
+    post:
+      operationId: security.create_api_key.0
+      x-operation-group: security.create_api_key
+      x-version-added: '3.7'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
+      description: Creates a new API key with the specified permissions and duration.
+      requestBody:
+        $ref: '#/components/requestBodies/security.create_api_key'
+      responses:
+        '200':
+          $ref: '#/components/responses/security.create_api_key@200'
+  /_plugins/_security/api/apitokens/{id}:
+    delete:
+      operationId: security.delete_api_key.0
+      x-operation-group: security.delete_api_key
+      x-version-added: '3.7'
+      x-distributions-excluded:
+        - amazon-managed
+        - amazon-serverless
+      description: Revokes an API key, making it immediately unusable for authentication.
+      parameters:
+        - $ref: '#/components/parameters/security.delete_api_key::path.id'
+      responses:
+        '200':
+          $ref: '#/components/responses/security.delete_api_key@200'
   /_plugins/_security/api/allowlist:
     get:
       operationId: security.get_allowlist.0
@@ -1367,6 +1406,12 @@ components:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/ActionGroup'
       required: true
+    security.create_api_key:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/security._common.yaml#/components/schemas/ApiKeyCreateRequest'
+      required: true
     security.create_allowlist:
       content:
         application/json:
@@ -1629,6 +1674,21 @@ components:
         application/json:
           schema:
             $ref: '../schemas/security._common.yaml#/components/schemas/Created'
+    security.create_api_key@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/security._common.yaml#/components/schemas/ApiKeyCreateResponse'
+    security.get_api_keys@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/security._common.yaml#/components/schemas/ApiKeyListResponse'
+    security.delete_api_key@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/security._common.yaml#/components/schemas/ApiKeyRevokeResponse'
     security.create_allowlist@200:
       content:
         application/json:
@@ -2336,6 +2396,13 @@ components:
       name: action_group
       in: path
       description: The name of the action group to delete.
+      schema:
+        type: string
+      required: true
+    security.delete_api_key::path.id:
+      name: id
+      in: path
+      description: The unique identifier of the API key to revoke.
       schema:
         type: string
       required: true

--- a/spec/schemas/security._common.yaml
+++ b/spec/schemas/security._common.yaml
@@ -815,3 +815,87 @@ components:
       type: object
       additionalProperties:
         type: string
+
+    ApiKeyIndexPermission:
+      type: object
+      properties:
+        index_pattern:
+          type: array
+          items:
+            type: string
+        allowed_actions:
+          type: array
+          items:
+            type: string
+      required:
+        - allowed_actions
+        - index_pattern
+
+    ApiKey:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        iat:
+          type: integer
+          format: int64
+        expires_at:
+          type: integer
+          format: int64
+        cluster_permissions:
+          type: array
+          items:
+            type: string
+        index_permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiKeyIndexPermission'
+        revoked_at:
+          type: integer
+          format: int64
+        created_by:
+          type: string
+
+    ApiKeyCreateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: A unique name for the API key.
+        cluster_permissions:
+          type: array
+          items:
+            type: string
+        index_permissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiKeyIndexPermission'
+        duration_seconds:
+          type: integer
+          format: int64
+          description: Duration in seconds until the key expires.
+      required:
+        - name
+
+    ApiKeyCreateResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique identifier for the key (used for revocation).
+        token:
+          type: string
+          description: The plaintext API key. Only returned once at creation time.
+
+    ApiKeyListResponse:
+      type: array
+      items:
+        $ref: '#/components/schemas/ApiKey'
+
+    ApiKeyRevokeResponse:
+      type: object
+      properties:
+        message:
+          type: string

--- a/tests/plugins/security/api/apitokens.yaml
+++ b/tests/plugins/security/api/apitokens.yaml
@@ -1,0 +1,39 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test API keys CRUD operations.
+epilogues:
+  - path: /_plugins/_security/api/apitokens/{id}
+    method: DELETE
+    parameters:
+      id: ${create_api_token.id}
+    status: [200, 404]
+chapters:
+  - synopsis: Create an API key.
+    id: create_api_token
+    path: /_plugins/_security/api/apitokens
+    method: POST
+    request:
+      payload:
+        name: spec-test-key
+        cluster_permissions:
+          - cluster_monitor
+        duration_seconds: 3600
+    response:
+      status: 200
+    output:
+      id: payload.id
+      token: payload.token
+  - synopsis: List all API keys.
+    path: /_plugins/_security/api/apitokens
+    method: GET
+    response:
+      status: 200
+  - synopsis: Revoke the API key.
+    path: /_plugins/_security/api/apitokens/{id}
+    method: DELETE
+    parameters:
+      id: ${create_api_token.id}
+    response:
+      status: 200
+      payload:
+        message: /revoked successfully/


### PR DESCRIPTION
### Description

Adds OpenAPI specification for the API Keys feature in the OpenSearch Security plugin.

Related to https://github.com/opensearch-project/security/pull/5443

**Operations added:**
- `security.create_api_key` — POST `/_plugins/_security/api/apitokens`
- `security.get_api_keys` — GET `/_plugins/_security/api/apitokens`
- `security.delete_api_key` — DELETE `/_plugins/_security/api/apitokens/{id}`

**Schemas added:**
- `ApiKey`, `ApiKeyIndexPermission`, `ApiKeyCreateRequest`, `ApiKeyCreateResponse`, `ApiKeyListResponse`, `ApiKeyRevokeResponse`

**Test story:** `tests/plugins/security/api/apitokens.yaml`

All operations are marked `x-version-added: '3.7'` and excluded from `amazon-managed` and `amazon-serverless` distributions.

### Issues Resolved

Related to https://github.com/opensearch-project/security/issues/4009

### Check List
- [x] Spec lint passes
- [x] Spec merger succeeds
- [x] Test story included
- [x] Commits are signed per the DCO using --signoff