### PR TITLE
Mark plural `_aliases` URL forms of put_alias and delete_alias as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add title to `ml.predict_model_stream` and `ml.execute_agent_stream` requestBody ([#1072](https://github.com/opensearch-project/opensearch-api-specification/pull/1072))
 - Added `agentic` query type, `agentic_query_translator` request processor, and `agentic_context` response processor ([#1073](https://github.com/opensearch-project/opensearch-api-specification/pull/1073))
 
+### Deprecated
+- Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))
+
 ### Removed
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))
 - Remove unsupported `PinnedQuery` and mark x-version-deprecated to field `cutoff_frequency` in `MultiMatchQuery` ([#1000](https://github.com/opensearch-project/opensearch-api-specification/pull/1000))

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -130,7 +130,10 @@ paths:
     post:
       operationId: indices.put_alias.3
       x-operation-group: indices.put_alias
+      deprecated: true
+      x-deprecation-message: Use the singular `_alias` form. The plural `_aliases` is retained as a back-compat alias and is structurally equivalent.
       x-version-added: '1.0'
+      x-version-deprecated: '1.0'
       description: Creates or updates an alias.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
@@ -147,7 +150,10 @@ paths:
     put:
       operationId: indices.put_alias.4
       x-operation-group: indices.put_alias
+      deprecated: true
+      x-deprecation-message: Use the singular `_alias` form. The plural `_aliases` is retained as a back-compat alias and is structurally equivalent.
       x-version-added: '1.0'
+      x-version-deprecated: '1.0'
       description: Creates or updates an alias.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
@@ -1181,7 +1187,10 @@ paths:
     put:
       operationId: indices.put_alias.8
       x-operation-group: indices.put_alias
+      deprecated: true
+      x-deprecation-message: Use the singular `_alias` form. The plural `_aliases` is retained as a back-compat alias and is structurally equivalent.
       x-version-added: '1.0'
+      x-version-deprecated: '1.0'
       description: Creates or updates an alias.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
@@ -1199,7 +1208,10 @@ paths:
     post:
       operationId: indices.put_alias.9
       x-operation-group: indices.put_alias
+      deprecated: true
+      x-deprecation-message: Use the singular `_alias` form. The plural `_aliases` is retained as a back-compat alias and is structurally equivalent.
       x-version-added: '1.0'
+      x-version-deprecated: '1.0'
       description: Creates or updates an alias.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
@@ -1217,7 +1229,10 @@ paths:
     put:
       operationId: indices.put_alias.10
       x-operation-group: indices.put_alias
+      deprecated: true
+      x-deprecation-message: Use the singular `_alias` form. The plural `_aliases` is retained as a back-compat alias and is structurally equivalent.
       x-version-added: '1.0'
+      x-version-deprecated: '1.0'
       description: Creates or updates an alias.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/update-alias/
@@ -1235,7 +1250,10 @@ paths:
     delete:
       operationId: indices.delete_alias.1
       x-operation-group: indices.delete_alias
+      deprecated: true
+      x-deprecation-message: Use the singular `_alias` form. The plural `_aliases` is retained as a back-compat alias and is structurally equivalent.
       x-version-added: '1.0'
+      x-version-deprecated: '1.0'
       description: Deletes an alias.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/index-alias/#delete-aliases


### PR DESCRIPTION
The OpenSearch alias REST handlers register both `_alias` (singular) and `_aliases` (plural) URL forms for the same operations. The singular form is the canonical path; the plural form is kept only for back-compat. Without an explicit deprecation flag in the spec, code generators see two equally-valid paths per operation and have to pick one arbitrarily, which produces surprising and inconsistent client surface area.

Mark the six redundant plural variants as `deprecated: true` so generators have a single canonical path per operation. The bulk `POST /_aliases` endpoint (`indices.update_aliases`) is a distinct handler and is unaffected.

Operations marked deprecated:
- `POST /_aliases/{name}`           (indices.put_alias.3)
- `PUT  /_aliases/{name}`           (indices.put_alias.4)
- `PUT  /{index}/_aliases`          (indices.put_alias.8)
- `POST /{index}/_aliases/{name}`   (indices.put_alias.9)
- `PUT  /{index}/_aliases/{name}`   (indices.put_alias.10)
- `DELETE /{index}/_aliases/{name}` (indices.delete_alias.1)

Server references (OpenSearch 27333365):
- [`RestIndexPutAliasAction`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java#L63-L78) registers the singular `_alias` routes first ([L66-L69](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java#L66-L69), [L74](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java#L74), [L76](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java#L76)) with the plural `_aliases` routes ([L70-L73](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java#L70-L73), [L75](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexPutAliasAction.java#L75)) registered identically afterwards as compatibility aliases.
- [`RestIndexDeleteAliasesAction`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndexDeleteAliasesAction.java#L61) registers `DELETE /{index}/_alias/{name}` first, with `DELETE /{index}/_aliases/{name}` second on the same line.
- [`RestIndicesAliasesAction`](https://github.com/opensearch-project/OpenSearch/blob/27333365da0d55a16bea2ebaf34f6f2a691f6d50/server/src/main/java/org/opensearch/rest/action/admin/indices/RestIndicesAliasesAction.java#L65) is a separate handler exposing only `POST /_aliases` for bulk `update_aliases`; it is intentionally not deprecated.

Documentation references (documentation-website 4c70a381):
- [`_api-reference/alias/create-alias.md`](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_api-reference/alias/create-alias.md#L23-L33) lists the singular `_alias` endpoint forms first ([L23-L26](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_api-reference/alias/create-alias.md#L23-L26)) and the plural `_aliases` forms second ([L27-L30](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_api-reference/alias/create-alias.md#L27-L30)); every example in the file uses only the singular form ([L74](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_api-reference/alias/create-alias.md#L74), [L102](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_api-reference/alias/create-alias.md#L102), [L187](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_api-reference/alias/create-alias.md#L187), [L199](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_api-reference/alias/create-alias.md#L199)).
- [`_api-reference/alias/delete-alias.md`](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_api-reference/alias/delete-alias.md#L18-L19) lists `DELETE /{index}/_alias/{alias}` first and uses only the singular form in its example ([L46](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_api-reference/alias/delete-alias.md#L46)).
- [`_im-plugin/index-alias.md`](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_im-plugin/index-alias.md) uses `POST /_aliases` only in the bulk `update_aliases` sense (with an `actions` body) ([L36](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_im-plugin/index-alias.md#L36), [L55](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_im-plugin/index-alias.md#L55), [L80](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_im-plugin/index-alias.md#L80), [L114](https://github.com/opensearch-project/documentation-website/blob/4c70a3811d532f7ff24980c1a8db0d3d08e1c6ad/_im-plugin/index-alias.md#L114)), confirming the no-name plural path is reserved for the bulk endpoint.

Both URL forms have been simultaneously routable since the OpenSearch 1.0.0 fork from Elasticsearch, so `x-version-deprecated: '1.0'` reflects the floor at which the plural forms were already non-canonical. There is no upstream deprecation-logger annotation; the deprecation here is a spec-level signal to code generators, not a runtime warning.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
