### PR TITLE
Define typed enum schemas for `format` query parameter on cat, list, sql, ppl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix `AggregationContainer`  for all bucket aggregations so that `aggs`/`aggregations` are siblings of the aggregation type([#1069](https://github.com/opensearch-project/opensearch-api-specification/pull/1069))
 
 ### Changed
+- Replace inline `format` query response parameter schemas across cat, list, sql, and ppl operations with typed enums (`CatResponseFormat`, `ListResponseFormat`, `SQLResponseFormat`, `PPLResponseFormat`) in `_common`, including server-truthful `default` values ([#1133](https://github.com/opensearch-project/opensearch-api-specification/pull/1133))
 - Changed schema of `NodeInfoSearchPipelines`'s `response_processors` & `request_processors` to use `NodeInfoSearchPipelineProcessor` instead of `NodeInfoIngestProcessor` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))
 - Changed knn stats response types to use int64s instead of numbers ([#942](https://github.com/opensearch-project/opensearch-api-specification/pull/942))
 - Moved sub aggregations into `BucketAggregationBase` as their usage is only valid here ([#971](https://github.com/opensearch-project/opensearch-api-specification/pull/971))

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -1079,8 +1079,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.aliases::query.h:
       name: h
       in: query
@@ -1138,8 +1137,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.all_pit_segments::query.h:
       name: h
       in: query
@@ -1205,8 +1203,7 @@ components:
       in: query
       description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.allocation::query.h:
       name: h
       in: query
@@ -1274,8 +1271,7 @@ components:
       in: query
       description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.cluster_manager::query.h:
       name: h
       in: query
@@ -1346,8 +1342,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.count::query.h:
       name: h
       in: query
@@ -1415,8 +1410,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.fielddata::query.h:
       name: h
       in: query
@@ -1460,8 +1454,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.health::query.h:
       name: h
       in: query
@@ -1550,8 +1543,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.indices::query.h:
       name: h
       in: query
@@ -1649,8 +1641,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.master::query.h:
       name: h
       in: query
@@ -1718,8 +1709,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.nodeattrs::query.h:
       name: h
       in: query
@@ -1794,8 +1784,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.nodes::query.full_id:
       in: query
       name: full_id
@@ -1880,8 +1869,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.pending_tasks::query.h:
       name: h
       in: query
@@ -1954,8 +1942,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.pit_segments::query.h:
       name: h
       in: query
@@ -2006,8 +1993,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.plugins::query.h:
       name: h
       in: query
@@ -2101,8 +2087,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.recovery::query.h:
       name: h
       in: query
@@ -2174,8 +2159,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.repositories::query.h:
       name: h
       in: query
@@ -2292,8 +2276,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.segment_replication::query.h:
       name: h
       in: query
@@ -2414,8 +2397,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.segments::query.h:
       name: h
       in: query
@@ -2489,8 +2471,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.shards::query.h:
       name: h
       in: query
@@ -2586,8 +2567,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.snapshots::query.h:
       name: h
       in: query
@@ -2671,8 +2651,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.tasks::query.h:
       name: h
       in: query
@@ -2760,8 +2739,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.templates::query.h:
       name: h
       in: query
@@ -2839,8 +2817,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        type: string
-        description: A short version of the `Accept` header, such as `json` or `yaml`.
+        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
     cat.thread_pool::query.h:
       name: h
       in: query

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -1079,7 +1079,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.aliases::query.h:
       name: h
       in: query
@@ -1137,7 +1137,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.all_pit_segments::query.h:
       name: h
       in: query
@@ -1203,7 +1203,7 @@ components:
       in: query
       description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.allocation::query.h:
       name: h
       in: query
@@ -1271,7 +1271,7 @@ components:
       in: query
       description: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.cluster_manager::query.h:
       name: h
       in: query
@@ -1342,7 +1342,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.count::query.h:
       name: h
       in: query
@@ -1410,7 +1410,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.fielddata::query.h:
       name: h
       in: query
@@ -1454,7 +1454,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.health::query.h:
       name: h
       in: query
@@ -1543,7 +1543,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.indices::query.h:
       name: h
       in: query
@@ -1641,7 +1641,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.master::query.h:
       name: h
       in: query
@@ -1709,7 +1709,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.nodeattrs::query.h:
       name: h
       in: query
@@ -1784,7 +1784,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.nodes::query.full_id:
       in: query
       name: full_id
@@ -1869,7 +1869,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.pending_tasks::query.h:
       name: h
       in: query
@@ -1942,7 +1942,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.pit_segments::query.h:
       name: h
       in: query
@@ -1993,7 +1993,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.plugins::query.h:
       name: h
       in: query
@@ -2087,7 +2087,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.recovery::query.h:
       name: h
       in: query
@@ -2159,7 +2159,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.repositories::query.h:
       name: h
       in: query
@@ -2276,7 +2276,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.segment_replication::query.h:
       name: h
       in: query
@@ -2397,7 +2397,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.segments::query.h:
       name: h
       in: query
@@ -2471,7 +2471,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.shards::query.h:
       name: h
       in: query
@@ -2567,7 +2567,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.snapshots::query.h:
       name: h
       in: query
@@ -2651,7 +2651,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.tasks::query.h:
       name: h
       in: query
@@ -2739,7 +2739,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.templates::query.h:
       name: h
       in: query
@@ -2817,7 +2817,7 @@ components:
       in: query
       description: A short version of the `Accept` header, such as `json` or `yaml`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/CatResponseFormat'
+        $ref: '../schemas/cat._common.yaml#/components/schemas/ResponseFormat'
     cat.thread_pool::query.h:
       name: h
       in: query

--- a/spec/namespaces/list.yaml
+++ b/spec/namespaces/list.yaml
@@ -259,8 +259,7 @@ components:
       in: query
       description: A short version of the Accept header, such as `JSON`, `YAML`.
       schema:
-        type: string
-        description: A short version of the Accept header, such as `JSON`, `YAML`.
+        $ref: '../schemas/_common.yaml#/components/schemas/ListResponseFormat'
     list.indices::query.h:
       name: h
       in: query
@@ -396,8 +395,7 @@ components:
       in: query
       description: A short version of the Accept header, such as `JSON`, `YAML`.
       schema:
-        type: string
-        description: A short version of the Accept header, such as `JSON`, `YAML`.
+        $ref: '../schemas/_common.yaml#/components/schemas/ListResponseFormat'
     list.shards::query.h:
       name: h
       in: query

--- a/spec/namespaces/list.yaml
+++ b/spec/namespaces/list.yaml
@@ -259,7 +259,7 @@ components:
       in: query
       description: A short version of the Accept header, such as `JSON`, `YAML`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/ListResponseFormat'
+        $ref: '../schemas/list._common.yaml#/components/schemas/ResponseFormat'
     list.indices::query.h:
       name: h
       in: query
@@ -395,7 +395,7 @@ components:
       in: query
       description: A short version of the Accept header, such as `JSON`, `YAML`.
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/ListResponseFormat'
+        $ref: '../schemas/list._common.yaml#/components/schemas/ResponseFormat'
     list.shards::query.h:
       name: h
       in: query

--- a/spec/namespaces/ppl.yaml
+++ b/spec/namespaces/ppl.yaml
@@ -72,7 +72,7 @@ components:
       in: query
       description: Specifies the response format (JSON OR YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/PPLResponseFormat'
     ppl.query::query.sanitize:
       name: sanitize
       in: query
@@ -85,7 +85,7 @@ components:
       in: query
       description: Specifies the response format (JSON, YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/PPLResponseFormat'
     ppl.explain::query.sanitize:
       name: sanitize
       in: query
@@ -98,7 +98,7 @@ components:
       in: query
       description: Specifies the response format (JSON, YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/PPLResponseFormat'
     ppl.get_stats::query.sanitize:
       name: sanitize
       in: query
@@ -111,7 +111,7 @@ components:
       in: query
       description: Specifies the response format (JSON, YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/PPLResponseFormat'
     ppl.post_stats::query.sanitize:
       name: sanitize
       in: query

--- a/spec/namespaces/ppl.yaml
+++ b/spec/namespaces/ppl.yaml
@@ -72,7 +72,7 @@ components:
       in: query
       description: Specifies the response format (JSON OR YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/PPLResponseFormat'
+        $ref: '../schemas/ppl._common.yaml#/components/schemas/ResponseFormat'
     ppl.query::query.sanitize:
       name: sanitize
       in: query
@@ -85,7 +85,7 @@ components:
       in: query
       description: Specifies the response format (JSON, YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/PPLResponseFormat'
+        $ref: '../schemas/ppl._common.yaml#/components/schemas/ResponseFormat'
     ppl.explain::query.sanitize:
       name: sanitize
       in: query
@@ -98,7 +98,7 @@ components:
       in: query
       description: Specifies the response format (JSON, YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/PPLResponseFormat'
+        $ref: '../schemas/ppl._common.yaml#/components/schemas/ResponseFormat'
     ppl.get_stats::query.sanitize:
       name: sanitize
       in: query
@@ -111,7 +111,7 @@ components:
       in: query
       description: Specifies the response format (JSON, YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/PPLResponseFormat'
+        $ref: '../schemas/ppl._common.yaml#/components/schemas/ResponseFormat'
     ppl.post_stats::query.sanitize:
       name: sanitize
       in: query

--- a/spec/namespaces/sql.yaml
+++ b/spec/namespaces/sql.yaml
@@ -103,13 +103,13 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
     sql.query::query.format:
       name: format
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
     sql.query::query.sanitize:
       name: sanitize
       in: query
@@ -122,7 +122,7 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
     sql.explain::query.sanitize:
       name: sanitize
       in: query
@@ -135,7 +135,7 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
     sql.close::query.sanitize:
       name: sanitize
       in: query
@@ -148,7 +148,7 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
     sql.get_stats::query.sanitize:
       name: sanitize
       in: query
@@ -161,7 +161,7 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        type: string
+        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
     sql.post_stats::query.sanitize:
       name: sanitize
       in: query

--- a/spec/namespaces/sql.yaml
+++ b/spec/namespaces/sql.yaml
@@ -103,13 +103,13 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
+        $ref: '../schemas/sql._common.yaml#/components/schemas/ResponseFormat'
     sql.query::query.format:
       name: format
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
+        $ref: '../schemas/sql._common.yaml#/components/schemas/ResponseFormat'
     sql.query::query.sanitize:
       name: sanitize
       in: query
@@ -122,7 +122,7 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
+        $ref: '../schemas/sql._common.yaml#/components/schemas/ResponseFormat'
     sql.explain::query.sanitize:
       name: sanitize
       in: query
@@ -135,7 +135,7 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
+        $ref: '../schemas/sql._common.yaml#/components/schemas/ResponseFormat'
     sql.close::query.sanitize:
       name: sanitize
       in: query
@@ -148,7 +148,7 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
+        $ref: '../schemas/sql._common.yaml#/components/schemas/ResponseFormat'
     sql.get_stats::query.sanitize:
       name: sanitize
       in: query
@@ -161,7 +161,7 @@ components:
       in: query
       description: Specifies the response format (JSON or YAML).
       schema:
-        $ref: '../schemas/_common.yaml#/components/schemas/SQLResponseFormat'
+        $ref: '../schemas/sql._common.yaml#/components/schemas/ResponseFormat'
     sql.post_stats::query.sanitize:
       name: sanitize
       in: query

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -828,65 +828,6 @@ components:
     DateFormat:
       type: string
       description: The date format pattern.
-    CatResponseFormat:
-      type: string
-      description: |-
-        The response format returned by `_cat` operations. Equivalent to the HTTP `Accept` header but expressed as a query parameter.
-        When the parameter is omitted the server responds with `text`.
-      default: text
-      enum:
-        - cbor
-        - json
-        - smile
-        - text
-        - yaml
-    ListResponseFormat:
-      type: string
-      description: |-
-        The response format returned by `_list` operations. Equivalent to the HTTP `Accept` header but expressed as a query parameter.
-        When the parameter is omitted the server responds with `text`.
-      default: text
-      enum:
-        - cbor
-        - json
-        - smile
-        - text
-        - yaml
-    SQLResponseFormat:
-      type: string
-      description: |-
-        The response format selector for SQL plugin operations. The valid set is the union of values accepted across `_plugins/_sql/*` endpoints:
-        query responses use `jdbc` (default), `csv`, `raw`, or `viz`; explain responses use `json`, `yaml`, `simple`, `standard`, `extended`, or `cost`.
-        Not every endpoint accepts every value.
-      default: jdbc
-      enum:
-        - cost
-        - csv
-        - extended
-        - jdbc
-        - json
-        - raw
-        - simple
-        - standard
-        - viz
-        - yaml
-    PPLResponseFormat:
-      type: string
-      description: |-
-        The response format selector for PPL plugin operations. The valid set is the union of values accepted across `_plugins/_ppl/*` endpoints;
-        defaults and per-endpoint subsets mirror the SQL plugin.
-      default: jdbc
-      enum:
-        - cost
-        - csv
-        - extended
-        - jdbc
-        - json
-        - raw
-        - simple
-        - standard
-        - viz
-        - yaml
     GeoHashPrecision:
       description: The level of geohash precision, which can be expressed as a geohash length between 1 and 12 or as a distance measure, such as "1km" or "10m".
       oneOf:

--- a/spec/schemas/_common.yaml
+++ b/spec/schemas/_common.yaml
@@ -828,6 +828,65 @@ components:
     DateFormat:
       type: string
       description: The date format pattern.
+    CatResponseFormat:
+      type: string
+      description: |-
+        The response format returned by `_cat` operations. Equivalent to the HTTP `Accept` header but expressed as a query parameter.
+        When the parameter is omitted the server responds with `text`.
+      default: text
+      enum:
+        - cbor
+        - json
+        - smile
+        - text
+        - yaml
+    ListResponseFormat:
+      type: string
+      description: |-
+        The response format returned by `_list` operations. Equivalent to the HTTP `Accept` header but expressed as a query parameter.
+        When the parameter is omitted the server responds with `text`.
+      default: text
+      enum:
+        - cbor
+        - json
+        - smile
+        - text
+        - yaml
+    SQLResponseFormat:
+      type: string
+      description: |-
+        The response format selector for SQL plugin operations. The valid set is the union of values accepted across `_plugins/_sql/*` endpoints:
+        query responses use `jdbc` (default), `csv`, `raw`, or `viz`; explain responses use `json`, `yaml`, `simple`, `standard`, `extended`, or `cost`.
+        Not every endpoint accepts every value.
+      default: jdbc
+      enum:
+        - cost
+        - csv
+        - extended
+        - jdbc
+        - json
+        - raw
+        - simple
+        - standard
+        - viz
+        - yaml
+    PPLResponseFormat:
+      type: string
+      description: |-
+        The response format selector for PPL plugin operations. The valid set is the union of values accepted across `_plugins/_ppl/*` endpoints;
+        defaults and per-endpoint subsets mirror the SQL plugin.
+      default: jdbc
+      enum:
+        - cost
+        - csv
+        - extended
+        - jdbc
+        - json
+        - raw
+        - simple
+        - standard
+        - viz
+        - yaml
     GeoHashPrecision:
       description: The level of geohash precision, which can be expressed as a geohash length between 1 and 12 or as a distance measure, such as "1km" or "10m".
       oneOf:

--- a/spec/schemas/cat._common.yaml
+++ b/spec/schemas/cat._common.yaml
@@ -1,0 +1,20 @@
+openapi: 3.1.0
+info:
+  title: Schemas of `cat._common` Category.
+  description: Schemas of `cat._common` category.
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ResponseFormat:
+      type: string
+      description: |-
+        The response format returned by `_cat` operations. Equivalent to the HTTP `Accept` header but expressed as a query parameter.
+        When the parameter is omitted the server responds with `text`.
+      default: text
+      enum:
+        - cbor
+        - json
+        - smile
+        - text
+        - yaml

--- a/spec/schemas/list._common.yaml
+++ b/spec/schemas/list._common.yaml
@@ -1,0 +1,20 @@
+openapi: 3.1.0
+info:
+  title: Schemas of `list._common` Category.
+  description: Schemas of `list._common` category.
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ResponseFormat:
+      type: string
+      description: |-
+        The response format returned by `_list` operations. Equivalent to the HTTP `Accept` header but expressed as a query parameter.
+        When the parameter is omitted the server responds with `text`.
+      default: text
+      enum:
+        - cbor
+        - json
+        - smile
+        - text
+        - yaml

--- a/spec/schemas/ppl._common.yaml
+++ b/spec/schemas/ppl._common.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: Schemas of `ppl._common` Category.
+  description: Schemas of `ppl._common` category.
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ResponseFormat:
+      type: string
+      description: |-
+        The response format selector for PPL plugin operations. The valid set is the union of values accepted across `_plugins/_ppl/*` endpoints;
+        defaults and per-endpoint subsets mirror the SQL plugin.
+      default: jdbc
+      enum:
+        - cost
+        - csv
+        - extended
+        - jdbc
+        - json
+        - raw
+        - simple
+        - standard
+        - viz
+        - yaml

--- a/spec/schemas/sql._common.yaml
+++ b/spec/schemas/sql._common.yaml
@@ -6,6 +6,25 @@ info:
 paths: {}
 components:
   schemas:
+    ResponseFormat:
+      type: string
+      description: |-
+        The response format selector for SQL plugin operations. The valid set is the union of values accepted across `_plugins/_sql/*` endpoints:
+        query responses use `jdbc` (default), `csv`, `raw`, or `viz`; explain responses use `json`, `yaml`, `simple`, `standard`, `extended`, or `cost`.
+        Not every endpoint accepts every value.
+      default: jdbc
+      enum:
+        - cost
+        - csv
+        - extended
+        - jdbc
+        - json
+        - raw
+        - simple
+        - standard
+        - viz
+        - yaml
+
     Query:
       type: object
       properties:


### PR DESCRIPTION
Today every `*::query.format` query parameter on cat, list, ppl, and sql operations is declared as a free-form `type: string` with no `enum`. This forces every code-generator to either accept an open string and surface invalid values at runtime, or special-case format validation per operation. It also obscures that these four operation families accept different sets of values and have different server-side defaults.

Add four typed enum schemas under `_common` and replace 35 inline schemas with `$ref`s to them. Each schema is scoped per surface so it accurately describes what its server actually accepts:

- `CatResponseFormat`  — `[cbor, json, smile, text, yaml]`, default `text`
- `ListResponseFormat` — `[cbor, json, smile, text, yaml]`, default `text`
- `SQLResponseFormat`  — `[cost, csv, extended, jdbc, json, raw, simple, standard, viz, yaml]`, default `jdbc`
- `PPLResponseFormat`  — same value set as SQL, default `jdbc`

Source-of-truth references:

- Cat formats: [`RestTable.MediaType.fromFormat`](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/rest/action/cat/RestTable.java#L83) — the omit-format default routes through `MediaType` to `text/plain`
- SQL/PPL formats: [`Format.java`](https://github.com/opensearch-project/sql/blob/main/protocol/src/main/java/org/opensearch/sql/protocol/response/format/Format.java) enumerates `JDBC`, `CSV`, `RAW`, `VIZ`, `JSON`, `YAML`, `SIMPLE`, `STANDARD`, `EXTENDED`, `COST`
- SQL/PPL default: [`PPLQueryRequestFactory`](https://github.com/opensearch-project/sql/blob/main/plugin/src/main/java/org/opensearch/sql/plugin/request/PPLQueryRequestFactory.java#L28) and [`SqlRequestParam`](https://github.com/opensearch-project/sql/blob/main/legacy/src/main/java/org/opensearch/sql/legacy/request/SqlRequestParam.java#L18) both define `DEFAULT_RESPONSE_FORMAT = "jdbc"`

Concrete downstream impact: in `opensearch-project/opensearch-go`, the regenerated `osapi/` package emits `Format string` for cat operations with no default. Calling `client.Cat.Indices(ctx, nil)` produces a `text/plain` response (the cat server's default) which then fails JSON parsing. The hand-written predecessor hardcoded `format=json` per cat op; the regenerated client lost that behavior because the spec did not encode the enum or the default. With typed enums and explicit defaults, generators can emit a typed Go enum (or equivalent) and pick a sensible client-side default that matches the response struct shape.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
