### PR TITLE
Add `style: simple` to 13 path parameters with array schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix `AggregationContainer`  for all bucket aggregations so that `aggs`/`aggregations` are siblings of the aggregation type([#1069](https://github.com/opensearch-project/opensearch-api-specification/pull/1069))
 
 ### Changed
+- Add explicit `style: simple` to 13 path parameters whose schema is an array (or `oneOf` with an array branch) so code generators no longer have to infer the OpenAPI 3 default ([#1134](https://github.com/opensearch-project/opensearch-api-specification/pull/1134))
 - Changed schema of `NodeInfoSearchPipelines`'s `response_processors` & `request_processors` to use `NodeInfoSearchPipelineProcessor` instead of `NodeInfoIngestProcessor` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))
 - Changed knn stats response types to use int64s instead of numbers ([#942](https://github.com/opensearch-project/opensearch-api-specification/pull/942))
 - Moved sub aggregations into `BucketAggregationBase` as their usage is only valid here ([#971](https://github.com/opensearch-project/opensearch-api-specification/pull/971))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -3759,6 +3759,7 @@ components:
         items:
           type: string
       required: true
+      style: simple
     create_pit::query.allow_partial_pit_creation:
       name: allow_partial_pit_creation
       in: query

--- a/spec/namespaces/cat.yaml
+++ b/spec/namespaces/cat.yaml
@@ -2245,6 +2245,7 @@ components:
         items:
           type: string
       required: true
+      style: simple
     cat.segment_replication::query.active_only:
       name: active_only
       in: query

--- a/spec/namespaces/geospatial.yaml
+++ b/spec/namespaces/geospatial.yaml
@@ -128,6 +128,7 @@ components:
       required: true
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/StringOrStringArray'
+      style: simple
     geospatial.put_ip2geo_datasource::path.name:
       name: name
       in: path

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -4186,6 +4186,7 @@ components:
         items:
           type: string
       required: true
+      style: simple
     indices.get_upgrade::query.allow_no_indices:
       name: allow_no_indices
       in: query
@@ -5188,6 +5189,7 @@ components:
         items:
           type: string
       required: true
+      style: simple
     indices.upgrade::query.allow_no_indices:
       name: allow_no_indices
       in: query

--- a/spec/namespaces/knn.yaml
+++ b/spec/namespaces/knn.yaml
@@ -651,6 +651,7 @@ components:
         items:
           type: string
       required: true
+      style: simple
     knn.stats::path.stat:
       name: stat
       in: path
@@ -663,6 +664,7 @@ components:
             items:
               $ref: '../schemas/knn._common.yaml#/components/schemas/KnnStatName'
       required: true
+      style: simple
     knn.stats::query.timeout:
       name: timeout
       in: query
@@ -694,3 +696,4 @@ components:
         items:
           type: string
       required: true
+      style: simple

--- a/spec/namespaces/ltr.yaml
+++ b/spec/namespaces/ltr.yaml
@@ -775,6 +775,7 @@ components:
             items:
               $ref: '../schemas/ltr._common.yaml#/components/schemas/LtrStatName'
       required: true
+      style: simple
     ltr.stats::path.node_id:
       name: node_id
       in: path
@@ -785,6 +786,7 @@ components:
         items:
           type: string
       required: true
+      style: simple
     ltr.clear_cache::path.store:
       name: store
       in: path

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -2752,6 +2752,7 @@ components:
           - type: array
             items:
               $ref: '../schemas/ml._common.yaml#/components/schemas/MlStatName'
+      style: simple
     ml.get_stats::path.node_id:
       name: node_id
       in: path

--- a/spec/namespaces/neural.yaml
+++ b/spec/namespaces/neural.yaml
@@ -95,6 +95,7 @@ components:
             items:
               $ref: '../schemas/neural._common.yaml#/components/schemas/NeuralStatName'
       required: true
+      style: simple
     neural.stats::query.flat_stat_paths:
       in: query
       name: flat_stat_paths

--- a/spec/namespaces/nodes.yaml
+++ b/spec/namespaces/nodes.yaml
@@ -444,6 +444,7 @@ components:
         items:
           type: string
       required: true
+      style: simple
     nodes.hot_threads::query.ignore_idle_threads:
       name: ignore_idle_threads
       in: query


### PR DESCRIPTION
OpenAPI 3 mandates `style:` for path parameters whose schema is an array (or `oneOf` containing an array branch). The implicit default for path params is `simple`, but several code generators interpret the absence of `style:` as a hint that the parameter is a single value, then mishandle the comma-separated list at the wire level.

Make the style explicit on the 13 affected parameters:

- `cat.segment_replication::path.index`
- `create_pit::path.index`
- `geospatial.get_ip2geo_datasource::path.name`
- `indices.get_upgrade::path.index`
- `indices.upgrade::path.index`
- `knn.stats::path.node_id`, `knn.stats::path.stat`
- `knn.warmup::path.index`
- `ltr.stats::path.node_id`, `ltr.stats::path.stat`
- `ml.get_stats::path.stat`
- `neural.stats::path.stat`
- `nodes.hot_threads::path.node_id`

Reference: [OpenAPI 3.1 Parameter Object — Style Examples](https://spec.openapis.org/oas/v3.1.0#style-examples).

Same change has already been carried locally in `opensearch-project/opensearch-go`'s bundled spec for PR #804; this commit lifts it upstream.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
