### PR TITLE
Add x-error-responses extension for partial-failure response shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Added `x-error-responses` vendor extension and `_common.errors.yaml` wrapper schemas catalog for declaring auxiliary partial-failure response shapes per operation ([#1137](https://github.com/opensearch-project/opensearch-api-specification/pull/1137))
 - Added apis for searching within search relevance objects such as search configurations, judgments, query sets, and experiments ([#1064](https://github.com/opensearch-project/opensearch-api-specification/pull/1064))
 - Added remaining APIs for LTR including store element operations, model management, feature set operations, routing support, and POST support for update operations ([#935](https://github.com/opensearch-project/opensearch-api-specification/pull/935))
 - Added specs for alert and finding endpoints of security_analytics plugin ([#907](https://github.com/opensearch-project/opensearch-api-specification/pull/907))

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -144,6 +144,7 @@ This repository includes several OpenAPI Specification Extensions to fill in any
 - `x-default`: Contains the default value of a parameter. This is often used to override the default value specified in the schema, or to avoid accidentally changing the default value when updating a shared schema.
 - `x-distributions-included`: Contains a list of distributions known to include the API.
 - `x-distributions-excluded`: Contains a list of distributions known to exclude the API.
+- `x-error-responses`: An array of `$ref` objects on an operation declaring auxiliary partial-failure shapes the response may carry in addition to its primary response schema. Each entry references a wrapper schema in [`spec/schemas/_common.errors.yaml`](spec/schemas/_common.errors.yaml) (e.g. `BulkItems`, `SearchShards`, `TaskFailures`). Wrapper schemas describe the shape of the embedded failure content (arity, grouping, version) using ordinary JSON Schema; client generators walk the array to emit one typed handler per wrapper and wire it into the operation's response post-processor. Operations with no auxiliary partial-failure shapes omit the extension.
 
 Use `opensearch.org` for the official distribution in `x-distributions-*`, `amazon-managed` for Amazon Managed OpenSearch, and `amazon-serverless` for Amazon OpenSearch Serverless.
 

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -34,6 +34,9 @@ paths:
       operationId: bulk.0
       x-operation-group: bulk
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkItems'
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Allows to perform multiple index/update/delete operations in a single request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/bulk/
@@ -58,6 +61,9 @@ paths:
       operationId: bulk.1
       x-operation-group: bulk
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkItems'
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Allows to perform multiple index/update/delete operations in a single request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/bulk/
@@ -83,6 +89,9 @@ paths:
       operationId: bulk_stream.0
       x-operation-group: bulk_stream
       x-version-added: '2.17'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkItems'
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Allows to perform multiple index/update/delete operations using request response streaming.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/bulk-streaming/
@@ -108,6 +117,9 @@ paths:
       operationId: bulk_stream.1
       x-operation-group: bulk_stream
       x-version-added: '2.17'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkItems'
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Allows to perform multiple index/update/delete operations using request response streaming.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/bulk-streaming/
@@ -134,6 +146,8 @@ paths:
       operationId: count.0
       x-operation-group: count
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Returns number of documents matching a query.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/count/
@@ -161,6 +175,8 @@ paths:
       operationId: count.1
       x-operation-group: count
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Returns number of documents matching a query.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/count/
@@ -240,6 +256,8 @@ paths:
       operationId: mget.0
       x-operation-group: mget
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiDocItems'
       description: Allows to get multiple documents in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/multi-get/
@@ -261,6 +279,8 @@ paths:
       operationId: mget.1
       x-operation-group: mget
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiDocItems'
       description: Allows to get multiple documents in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/multi-get/
@@ -283,6 +303,8 @@ paths:
       operationId: msearch.0
       x-operation-group: msearch
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiSearchItems'
       description: Allows to execute several search operations in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/multi-search/
@@ -304,6 +326,8 @@ paths:
       operationId: msearch.1
       x-operation-group: msearch
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiSearchItems'
       description: Allows to execute several search operations in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/multi-search/
@@ -326,6 +350,8 @@ paths:
       operationId: msearch_template.0
       x-operation-group: msearch_template
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiSearchItems'
       description: Allows to execute several search template operations in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/search-template/
@@ -344,6 +370,8 @@ paths:
       operationId: msearch_template.1
       x-operation-group: msearch_template
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiSearchItems'
       description: Allows to execute several search template operations in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/search-template/
@@ -363,6 +391,8 @@ paths:
       operationId: mtermvectors.0
       x-operation-group: mtermvectors
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiDocItems'
       description: Returns multiple termvectors in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -388,6 +418,8 @@ paths:
       operationId: mtermvectors.1
       x-operation-group: mtermvectors
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiDocItems'
       description: Returns multiple termvectors in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -414,6 +446,8 @@ paths:
       operationId: rank_eval.0
       x-operation-group: rank_eval
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/RankEvalFailures'
       description: Allows to evaluate the quality of ranked search results over a set of typical search queries.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/rank-eval/
@@ -431,6 +465,8 @@ paths:
       operationId: rank_eval.1
       x-operation-group: rank_eval
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/RankEvalFailures'
       description: Allows to evaluate the quality of ranked search results over a set of typical search queries.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/rank-eval/
@@ -449,6 +485,8 @@ paths:
       operationId: reindex.0
       x-operation-group: reindex
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkByScrollFailures'
       description: |-
         Allows to copy documents from one index to another, optionally filtering the source
         documents by a query, changing the destination index settings, or fetching the
@@ -701,6 +739,8 @@ paths:
       operationId: search.0
       x-operation-group: search
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Returns results matching a query.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/search/
@@ -766,6 +806,8 @@ paths:
       operationId: search.1
       x-operation-group: search
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Returns results matching a query.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/search/
@@ -845,6 +887,8 @@ paths:
       operationId: get_all_pits.0
       x-operation-group: get_all_pits
       x-version-added: '2.4'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/PitNodeFailures'
       description: Lists all active point in time searches.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/point-in-time-api/#list-all-pits
@@ -866,6 +910,8 @@ paths:
       operationId: scroll.0
       x-operation-group: scroll
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Allows to retrieve a large numbers of results from a single search request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/scroll/#path-and-http-methods
@@ -882,6 +928,8 @@ paths:
       operationId: scroll.1
       x-operation-group: scroll
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Allows to retrieve a large numbers of results from a single search request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/scroll/#path-and-http-methods
@@ -974,6 +1022,8 @@ paths:
       operationId: search_template.0
       x-operation-group: search_template
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Allows to use the Mustache language to pre-render a search definition.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/search-template/
@@ -1002,6 +1052,8 @@ paths:
       operationId: search_template.1
       x-operation-group: search_template
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Allows to use the Mustache language to pre-render a search definition.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/search-template/
@@ -1084,6 +1136,9 @@ paths:
       operationId: bulk.2
       x-operation-group: bulk
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkItems'
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Allows to perform multiple index/update/delete operations in a single request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/bulk/
@@ -1109,6 +1164,9 @@ paths:
       operationId: bulk.3
       x-operation-group: bulk
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkItems'
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Allows to perform multiple index/update/delete operations in a single request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/bulk/
@@ -1135,6 +1193,9 @@ paths:
       operationId: bulk_stream.2
       x-operation-group: bulk_stream
       x-version-added: '2.17'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkItems'
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Allows to perform multiple index/update/delete operations using request response streaming.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/bulk-streaming/
@@ -1161,6 +1222,9 @@ paths:
       operationId: bulk_stream.3
       x-operation-group: bulk_stream
       x-version-added: '2.17'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkItems'
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Allows to perform multiple index/update/delete operations using request response streaming.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/bulk-streaming/
@@ -1188,6 +1252,8 @@ paths:
       operationId: count.2
       x-operation-group: count
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Returns number of documents matching a query.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/count/
@@ -1216,6 +1282,8 @@ paths:
       operationId: count.3
       x-operation-group: count
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Returns number of documents matching a query.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/count/
@@ -1245,6 +1313,8 @@ paths:
       operationId: create.0
       x-operation-group: create
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: |-
         Creates a new document in the index.
 
@@ -1270,6 +1340,8 @@ paths:
       operationId: create.1
       x-operation-group: create
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: |-
         Creates a new document in the index.
 
@@ -1296,6 +1368,8 @@ paths:
       operationId: delete_by_query.0
       x-operation-group: delete_by_query
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkByScrollFailures'
       description: Deletes documents matching the provided query.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/delete-by-query/
@@ -1344,6 +1418,8 @@ paths:
       operationId: index.0
       x-operation-group: index
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Creates or updates a document in an index.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/index-document/
@@ -1422,6 +1498,8 @@ paths:
       operationId: index.1
       x-operation-group: index
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Creates or updates a document in an index.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/index-document/
@@ -1450,6 +1528,8 @@ paths:
       operationId: index.2
       x-operation-group: index
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Creates or updates a document in an index.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/index-document/
@@ -1478,6 +1558,8 @@ paths:
       operationId: delete.0
       x-operation-group: delete
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Removes a document from the index.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/delete-document/
@@ -1596,6 +1678,8 @@ paths:
       operationId: mget.2
       x-operation-group: mget
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiDocItems'
       description: Allows to get multiple documents in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/multi-get/
@@ -1618,6 +1702,8 @@ paths:
       operationId: mget.3
       x-operation-group: mget
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiDocItems'
       description: Allows to get multiple documents in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/multi-get/
@@ -1641,6 +1727,8 @@ paths:
       operationId: msearch.2
       x-operation-group: msearch
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiSearchItems'
       description: Allows to execute several search operations in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/multi-search/
@@ -1663,6 +1751,8 @@ paths:
       operationId: msearch.3
       x-operation-group: msearch
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiSearchItems'
       description: Allows to execute several search operations in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/multi-search/
@@ -1686,6 +1776,8 @@ paths:
       operationId: msearch_template.2
       x-operation-group: msearch_template
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiSearchItems'
       description: Allows to execute several search template operations in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/search-template/
@@ -1705,6 +1797,8 @@ paths:
       operationId: msearch_template.3
       x-operation-group: msearch_template
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiSearchItems'
       description: Allows to execute several search template operations in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/search-template/
@@ -1725,6 +1819,8 @@ paths:
       operationId: mtermvectors.2
       x-operation-group: mtermvectors
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiDocItems'
       description: Returns multiple termvectors in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -1751,6 +1847,8 @@ paths:
       operationId: mtermvectors.3
       x-operation-group: mtermvectors
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/MultiDocItems'
       description: Returns multiple termvectors in one request.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -1778,6 +1876,8 @@ paths:
       operationId: rank_eval.2
       x-operation-group: rank_eval
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/RankEvalFailures'
       description: Allows to evaluate the quality of ranked search results over a set of typical search queries.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/rank-eval/
@@ -1796,6 +1896,8 @@ paths:
       operationId: rank_eval.3
       x-operation-group: rank_eval
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/RankEvalFailures'
       description: Allows to evaluate the quality of ranked search results over a set of typical search queries.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/rank-eval/
@@ -1815,6 +1917,8 @@ paths:
       operationId: search.2
       x-operation-group: search
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Returns results matching a query.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/search/
@@ -1881,6 +1985,8 @@ paths:
       operationId: search.3
       x-operation-group: search
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Returns results matching a query.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/search/
@@ -1948,6 +2054,8 @@ paths:
       operationId: create_pit.0
       x-operation-group: create_pit
       x-version-added: '2.4'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Creates point in time context.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/point-in-time-api/#create-a-pit
@@ -1966,6 +2074,8 @@ paths:
       operationId: search_template.2
       x-operation-group: search_template
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Allows to use the Mustache language to pre-render a search definition.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/search-template/
@@ -1995,6 +2105,8 @@ paths:
       operationId: search_template.3
       x-operation-group: search_template
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Allows to use the Mustache language to pre-render a search definition.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/search-template/
@@ -2219,6 +2331,8 @@ paths:
       operationId: update.0
       x-operation-group: update
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/WriteShards'
       description: Updates a document with a script or partial document.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/document-apis/update-document/
@@ -2247,6 +2361,8 @@ paths:
       operationId: update_by_query.0
       x-operation-group: update_by_query
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BulkByScrollFailures'
       description: |-
         Performs an update on every document in the index without changing the source,
         for example to pick up a mapping change.

--- a/spec/namespaces/asynchronous_search.yaml
+++ b/spec/namespaces/asynchronous_search.yaml
@@ -9,6 +9,8 @@ paths:
       operationId: asynchronous_search.search.0
       x-operation-group: asynchronous_search.search
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Performs an asynchronous search.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/async/index/#rest-api
@@ -27,6 +29,8 @@ paths:
       operationId: asynchronous_search.get.0
       x-operation-group: asynchronous_search.get
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SearchShards'
       description: Gets partial responses from an asynchronous search.
       externalDocs:
         url: https://opensearch.org/docs/latest/search-plugins/async/index/#get-partial-results

--- a/spec/namespaces/cluster.yaml
+++ b/spec/namespaces/cluster.yaml
@@ -307,6 +307,8 @@ paths:
       operationId: cluster.stats.0
       x-operation-group: cluster.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns a high-level overview of cluster statistics.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/
@@ -321,6 +323,8 @@ paths:
       operationId: cluster.stats.1
       x-operation-group: cluster.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns a high-level overview of cluster statistics.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/
@@ -336,6 +340,8 @@ paths:
       operationId: cluster.stats.2
       x-operation-group: cluster.stats
       x-version-added: '2.18'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns a high-level overview of cluster statistics.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/
@@ -352,6 +358,8 @@ paths:
       operationId: cluster.stats.3
       x-operation-group: cluster.stats
       x-version-added: '2.18'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns a high-level overview of cluster statistics.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/

--- a/spec/namespaces/dangling_indices.yaml
+++ b/spec/namespaces/dangling_indices.yaml
@@ -9,6 +9,8 @@ paths:
       operationId: dangling_indices.list_dangling_indices.0
       x-operation-group: dangling_indices.list_dangling_indices
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns all dangling indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/dangling-index/

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -201,6 +201,8 @@ paths:
       operationId: indices.clear_cache.0
       x-operation-group: indices.clear_cache
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       x-distributions-excluded:
         - amazon-managed
         - amazon-serverless
@@ -237,6 +239,8 @@ paths:
       operationId: indices.data_streams_stats.0
       x-operation-group: indices.data_streams_stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Provides statistics on operations happening in a data stream.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/data-streams/
@@ -288,6 +292,8 @@ paths:
       operationId: indices.data_streams_stats.1
       x-operation-group: indices.data_streams_stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Provides statistics on operations happening in a data stream.
       externalDocs:
         url: https://opensearch.org/docs/latest/im-plugin/data-streams/
@@ -301,6 +307,8 @@ paths:
       operationId: indices.flush.0
       x-operation-group: indices.flush
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Performs the flush operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -317,6 +325,8 @@ paths:
       operationId: indices.flush.1
       x-operation-group: indices.flush
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Performs the flush operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -334,6 +344,8 @@ paths:
       operationId: indices.forcemerge.0
       x-operation-group: indices.forcemerge
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       x-distributions-excluded:
         - amazon-managed
         - amazon-serverless
@@ -562,6 +574,8 @@ paths:
       operationId: indices.refresh.0
       x-operation-group: indices.refresh
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Performs the refresh operation in one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
@@ -576,6 +590,8 @@ paths:
       operationId: indices.refresh.1
       x-operation-group: indices.refresh
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Performs the refresh operation in one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
@@ -605,6 +621,8 @@ paths:
       operationId: indices.segments.0
       x-operation-group: indices.segments
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       x-distributions-excluded:
         - amazon-managed
         - amazon-serverless
@@ -705,6 +723,8 @@ paths:
       operationId: indices.stats.0
       x-operation-group: indices.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Provides statistics on operations happening in an index.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -726,6 +746,8 @@ paths:
       operationId: indices.stats.1
       x-operation-group: indices.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Provides statistics on operations happening in an index.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -863,6 +885,8 @@ paths:
       operationId: indices.upgrade.0
       x-operation-group: indices.upgrade
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       x-version-deprecated: '1.0'
       description: The `_upgrade` API is no longer useful and will be removed.
       externalDocs:
@@ -881,6 +905,8 @@ paths:
       operationId: indices.validate_query.0
       x-operation-group: indices.validate_query
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Allows a user to validate a potentially expensive query without executing it.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -906,6 +932,8 @@ paths:
       operationId: indices.validate_query.1
       x-operation-group: indices.validate_query
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Allows a user to validate a potentially expensive query without executing it.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -1322,6 +1350,8 @@ paths:
       operationId: indices.clear_cache.1
       x-operation-group: indices.clear_cache
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Clears all or specific caches for one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/index-apis/clear-index-cache/
@@ -1407,6 +1437,8 @@ paths:
       operationId: indices.flush.2
       x-operation-group: indices.flush
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Performs the flush operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -1424,6 +1456,8 @@ paths:
       operationId: indices.flush.3
       x-operation-group: indices.flush
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Performs the flush operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -1442,6 +1476,8 @@ paths:
       operationId: indices.forcemerge.1
       x-operation-group: indices.forcemerge
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Performs the force merge operation on one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -1581,6 +1617,8 @@ paths:
       operationId: indices.refresh.2
       x-operation-group: indices.refresh
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Performs the refresh operation in one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
@@ -1596,6 +1634,8 @@ paths:
       operationId: indices.refresh.3
       x-operation-group: indices.refresh
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Performs the refresh operation in one or more indexes.
       externalDocs:
         url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
@@ -1612,6 +1652,8 @@ paths:
       operationId: indices.segments.1
       x-operation-group: indices.segments
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       x-distributions-excluded:
         - amazon-managed
         - amazon-serverless
@@ -1804,6 +1846,8 @@ paths:
       operationId: indices.stats.2
       x-operation-group: indices.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Provides statistics on operations happening in an index.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -1826,6 +1870,8 @@ paths:
       operationId: indices.stats.3
       x-operation-group: indices.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Provides statistics on operations happening in an index.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -1865,6 +1911,8 @@ paths:
       operationId: indices.upgrade.1
       x-operation-group: indices.upgrade
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       x-version-deprecated: '1.0'
       description: The `_upgrade` API is no longer useful and will be removed.
       externalDocs:
@@ -1884,6 +1932,8 @@ paths:
       operationId: indices.validate_query.2
       x-operation-group: indices.validate_query
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Allows a user to validate a potentially expensive query without executing it.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -1910,6 +1960,8 @@ paths:
       operationId: indices.validate_query.3
       x-operation-group: indices.validate_query
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Allows a user to validate a potentially expensive query without executing it.
       externalDocs:
         url: https://opensearch.org/docs/latest

--- a/spec/namespaces/ingest.yaml
+++ b/spec/namespaces/ingest.yaml
@@ -23,6 +23,8 @@ paths:
       operationId: ingest.simulate.0
       x-operation-group: ingest.simulate
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SimulateDocFailures'
       description: Simulates an ingest pipeline with example documents.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/
@@ -37,6 +39,8 @@ paths:
       operationId: ingest.simulate.1
       x-operation-group: ingest.simulate
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SimulateDocFailures'
       description: Simulates an ingest pipeline with example documents.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/
@@ -99,6 +103,8 @@ paths:
       operationId: ingest.simulate.2
       x-operation-group: ingest.simulate
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SimulateDocFailures'
       description: Simulates an ingest pipeline with example documents.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/
@@ -114,6 +120,8 @@ paths:
       operationId: ingest.simulate.3
       x-operation-group: ingest.simulate
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SimulateDocFailures'
       description: Simulates an ingest pipeline with example documents.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/ingest-apis/simulate-ingest/

--- a/spec/namespaces/ingestion.yaml
+++ b/spec/namespaces/ingestion.yaml
@@ -11,6 +11,8 @@ paths:
       operationId: ingestion.pause.0
       x-operation-group: ingestion.pause
       x-version-added: '3.1'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/IngestionShardFailures'
       description: Use this API to pause ingestion for a given index.
       externalDocs:
         url: https://docs.opensearch.org/docs/latest/api-reference/document-apis/pull-based-ingestion-management/
@@ -27,6 +29,8 @@ paths:
       operationId: ingestion.resume.0
       x-operation-group: ingestion.resume
       x-version-added: '3.1'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/IngestionShardFailures'
       description: Use this API to resume ingestion for the given index.
       externalDocs:
         url: https://docs.opensearch.org/docs/latest/api-reference/document-apis/pull-based-ingestion-management/
@@ -45,6 +49,8 @@ paths:
       operationId: ingestion.get_state.0
       x-operation-group: ingestion.get_state
       x-version-added: '3.1'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/BroadcastShards'
       description: Use this API to retrieve the ingestion state for a given index.
       externalDocs:
         url: https://docs.opensearch.org/docs/latest/api-reference/document-apis/pull-based-ingestion-management/

--- a/spec/namespaces/nodes.yaml
+++ b/spec/namespaces/nodes.yaml
@@ -54,6 +54,8 @@ paths:
       operationId: nodes.info.0
       x-operation-group: nodes.info
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns information about nodes in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/
@@ -86,6 +88,8 @@ paths:
       operationId: nodes.reload_secure_settings.0
       x-operation-group: nodes.reload_secure_settings
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Reloads secure settings.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/
@@ -101,6 +105,8 @@ paths:
       operationId: nodes.stats.0
       x-operation-group: nodes.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns statistical information about nodes in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/
@@ -121,6 +127,8 @@ paths:
       operationId: nodes.stats.1
       x-operation-group: nodes.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns statistical information about nodes in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/
@@ -142,6 +150,8 @@ paths:
       operationId: nodes.stats.2
       x-operation-group: nodes.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns statistical information about nodes in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/
@@ -164,6 +174,8 @@ paths:
       operationId: nodes.usage.0
       x-operation-group: nodes.usage
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns low-level information about REST actions usage on nodes.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -177,6 +189,8 @@ paths:
       operationId: nodes.usage.1
       x-operation-group: nodes.usage
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns low-level information about REST actions usage on nodes.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -191,6 +205,8 @@ paths:
       operationId: nodes.info.1
       x-operation-group: nodes.info
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns information about nodes in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/
@@ -225,6 +241,8 @@ paths:
       operationId: nodes.reload_secure_settings.1
       x-operation-group: nodes.reload_secure_settings
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Reloads secure settings.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-reload-secure/
@@ -241,6 +259,8 @@ paths:
       operationId: nodes.stats.3
       x-operation-group: nodes.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns statistical information about nodes in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/
@@ -262,6 +282,8 @@ paths:
       operationId: nodes.stats.4
       x-operation-group: nodes.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns statistical information about nodes in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/
@@ -284,6 +306,8 @@ paths:
       operationId: nodes.stats.5
       x-operation-group: nodes.stats
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns statistical information about nodes in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-usage/
@@ -307,6 +331,8 @@ paths:
       operationId: nodes.usage.2
       x-operation-group: nodes.usage
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns low-level information about REST actions usage on nodes.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -321,6 +347,8 @@ paths:
       operationId: nodes.usage.3
       x-operation-group: nodes.usage
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns low-level information about REST actions usage on nodes.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -336,6 +364,8 @@ paths:
       operationId: nodes.info.3
       x-operation-group: nodes.info
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/NodeFailures'
       description: Returns information about nodes in the cluster.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/nodes-apis/nodes-info/

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -154,6 +154,8 @@ paths:
       operationId: snapshot.get.0
       x-operation-group: snapshot.get
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SnapshotGetShardFailures'
       description: Returns information about a snapshot.
       externalDocs:
         url: https://opensearch.org/docs/latest
@@ -171,6 +173,8 @@ paths:
       operationId: snapshot.create.0
       x-operation-group: snapshot.create
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SnapshotCreateShardFailures'
       description: Creates a snapshot within an existing repository.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/snapshots/create-snapshot/
@@ -189,6 +193,8 @@ paths:
       operationId: snapshot.create.1
       x-operation-group: snapshot.create
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/SnapshotCreateShardFailures'
       description: Creates a snapshot within an existing repository.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/snapshots/create-snapshot/

--- a/spec/namespaces/tasks.yaml
+++ b/spec/namespaces/tasks.yaml
@@ -9,6 +9,8 @@ paths:
       operationId: tasks.list.0
       x-operation-group: tasks.list
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/TaskFailures'
       description: Returns a list of tasks.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/tasks/
@@ -28,6 +30,8 @@ paths:
       operationId: tasks.cancel.0
       x-operation-group: tasks.cancel
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/TaskFailures'
       description: Cancels a task, if it can be cancelled through an API.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling
@@ -59,6 +63,8 @@ paths:
       operationId: tasks.cancel.1
       x-operation-group: tasks.cancel
       x-version-added: '1.0'
+      x-error-responses:
+        - $ref: '../schemas/_common.errors.yaml#/components/schemas/TaskFailures'
       description: Cancels a task, if it can be cancelled through an API.
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling

--- a/spec/schemas/_common.errors.yaml
+++ b/spec/schemas/_common.errors.yaml
@@ -1,0 +1,263 @@
+openapi: 3.1.0
+info:
+  title: Schemas of `_common.errors` Category
+  description: |-
+    Wrapper schemas describing the auxiliary partial-failure shapes that
+    OpenSearch endpoints may include in otherwise-successful responses.
+    Operations reference these wrappers via `x-error-responses` to declare
+    which auxiliary failure types a client may need to handle in addition
+    to the primary response shape. See `DEVELOPER_GUIDE.md` for details.
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    BulkItems:
+      description: |-
+        Bulk-style response surfaces failures via an `errors: true` flag plus
+        a per-item `error` object inside each entry of `items[]`.
+        Carried by `_core.bulk` and `_core.bulk_stream`.
+      type: object
+      properties:
+        errors:
+          type: boolean
+          description: True when at least one sub-operation in `items` failed.
+        items:
+          type: array
+          items:
+            $ref: '_core.bulk.yaml#/components/schemas/ResponseItem'
+      x-version-added: '1.0'
+
+    SearchShards:
+      description: |-
+        Search-family response with one or more shards failing while the
+        overall query still returned partial results. Failures appear at
+        `_shards.failures[]` of `ShardSearchFailure`.
+      type: object
+      properties:
+        _shards:
+          $ref: '_common.yaml#/components/schemas/ShardStatistics'
+      x-version-added: '1.0'
+
+    WriteShards:
+      description: |-
+        Single-doc write response where the primary acked but one or more
+        replicas failed. Failures appear at `_shards.failures[]` of
+        `ShardFailure`. Document is durable.
+      type: object
+      properties:
+        _shards:
+          $ref: '_common.yaml#/components/schemas/ShardInfo'
+      x-version-added: '1.0'
+
+    BroadcastShards:
+      description: |-
+        Index-broadcast response where one or more shards failed the
+        operation while others succeeded. Failures appear at
+        `_shards.failures[]`. The element schema in this spec collapses
+        with the search-family failure type, but the wrapper is kept
+        distinct so clients can opt in to broadcast vs search shard
+        handling independently.
+      type: object
+      properties:
+        _shards:
+          $ref: '_common.yaml#/components/schemas/ShardStatistics'
+      x-version-added: '1.0'
+
+    NodeFailures:
+      description: |-
+        Cluster/nodes operation where one or more nodes failed to respond.
+        Renders the standard `_nodes.failures[]` envelope via
+        `RestActions.buildNodesHeader`.
+      type: object
+      properties:
+        _nodes:
+          $ref: '_common.yaml#/components/schemas/NodeStatistics'
+      x-version-added: '1.0'
+
+    BulkByScrollFailures:
+      description: |-
+        Long-running scroll-bulk operation (reindex, update_by_query,
+        delete_by_query). Top-level `failures[]` mixes bulk-write and
+        shard-search failure element types in one polymorphic array.
+      type: object
+      properties:
+        failures:
+          type: array
+          items:
+            $ref: '_common.yaml#/components/schemas/BulkByScrollFailure'
+      x-version-added: '1.0'
+
+    TaskFailures:
+      description: |-
+        Tasks-API response. Two parallel top-level arrays — `task_failures[]`
+        (per-task) and `node_failures[]` (per-node) — both populated
+        independently. Distinct from the `_nodes`-wrapped `NodeFailures`
+        shape: here both arrays sit at the response root.
+      type: object
+      properties:
+        task_failures:
+          type: array
+          items:
+            $ref: '_common.yaml#/components/schemas/TaskFailure'
+        node_failures:
+          type: array
+          items:
+            $ref: '_common.yaml#/components/schemas/ErrorCause'
+      x-version-added: '1.0'
+
+    MultiSearchItems:
+      description: |-
+        Multi-search-style response (`_msearch`). Each entry in `responses[]`
+        is either a successful search body or an error object with an injected
+        `status`. Per-item search-shard failures may appear inside successful
+        items.
+      type: object
+      properties:
+        responses:
+          type: array
+          items:
+            $ref: '_core.msearch.yaml#/components/schemas/ResponseItem'
+      x-version-added: '1.0'
+
+    MultiDocItems:
+      description: |-
+        Multi-document-style response (`_mget` / `_mtermvectors`). Each entry
+        in `docs[]` is either a doc body or an error object.
+      type: object
+      properties:
+        docs:
+          type: array
+          items:
+            $ref: '_core.mget.yaml#/components/schemas/ResponseItem'
+      x-version-added: '1.0'
+
+    SnapshotCreateShardFailures:
+      description: |-
+        Snapshot-create response (`snapshot.create` with
+        `wait_for_completion=true`) where individual shards failed to
+        snapshot. Failures appear at `snapshot.failures[]`. State `PARTIAL`
+        indicates partial completion.
+      type: object
+      properties:
+        snapshot:
+          $ref: '#/components/schemas/SnapshotCreateFailureContainer'
+      x-version-added: '1.0'
+
+    SnapshotCreateFailureContainer:
+      description: |-
+        Container for `snapshot.create` partial-failure shape: holds the
+        `failures[]` array of per-shard failure entries.
+      type: object
+      properties:
+        failures:
+          type: array
+          items:
+            $ref: 'snapshot._common.yaml#/components/schemas/SnapshotShardFailure'
+      x-version-added: '1.0'
+
+    SnapshotGetShardFailures:
+      description: |-
+        Snapshot-get response (`snapshot.get`) listing snapshots where
+        individual snapshots had shards fail to capture. Failures appear
+        per-snapshot at `snapshots[].failures[]`.
+      type: object
+      properties:
+        snapshots:
+          type: array
+          items:
+            $ref: '#/components/schemas/SnapshotGetFailureItem'
+      x-version-added: '1.0'
+
+    SnapshotGetFailureItem:
+      description: |-
+        Per-snapshot entry in the `snapshot.get` partial-failure shape,
+        carrying any `failures[]` collected while reading that snapshot.
+      type: object
+      properties:
+        failures:
+          type: array
+          items:
+            $ref: 'snapshot._common.yaml#/components/schemas/SnapshotShardFailure'
+      x-version-added: '1.0'
+
+    SimulateDocFailures:
+      description: |-
+        Ingest-simulate response (`ingest.simulate`). Failures may appear at
+        two layers: per document at `docs[].error`, and per processor at
+        `docs[].processor_results[].error`.
+      type: object
+      properties:
+        docs:
+          type: array
+          items:
+            $ref: '#/components/schemas/SimulateDocFailureItem'
+      x-version-added: '1.0'
+
+    SimulateDocFailureItem:
+      description: |-
+        Per-document entry in the `ingest.simulate` partial-failure shape.
+        Carries a top-level `error` and a `processor_results[]` array of
+        per-processor outcomes that may themselves carry an `error`.
+      type: object
+      properties:
+        error:
+          $ref: '_common.yaml#/components/schemas/ErrorCause'
+        processor_results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SimulateProcessorResult'
+      x-version-added: '1.0'
+
+    SimulateProcessorResult:
+      description: |-
+        Per-processor entry in the `ingest.simulate` partial-failure shape,
+        carrying an `error` populated when that processor failed for the
+        enclosing document.
+      type: object
+      properties:
+        error:
+          $ref: '_common.yaml#/components/schemas/ErrorCause'
+      x-version-added: '1.0'
+
+    RankEvalFailures:
+      description: |-
+        Rank-eval response (`_rank_eval`). Returns failures as a top-level
+        object map keyed by queryId rather than as a positional array.
+      type: object
+      properties:
+        failures:
+          type: object
+          additionalProperties:
+            $ref: '_common.yaml#/components/schemas/ErrorCause'
+      x-version-added: '1.0'
+
+    IngestionShardFailures:
+      description: |-
+        Ingestion pause/resume responses (`ingestion.pause` /
+        `ingestion.resume`) surface per-shard failures keyed by index name at
+        the top-level `failures` map. Each value is an array of shard-keyed
+        failure objects.
+      type: object
+      properties:
+        failures:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: 'ingestion._common.yaml#/components/schemas/IngestionStateShardFailure'
+      x-version-added: '2.17'
+
+    PitNodeFailures:
+      description: |-
+        PIT-list response (`_core.get_all_pits`) returns per-node failures at
+        the top level without the standard `_nodes` envelope. This is a
+        server inconsistency relative to other `BaseNodesResponse`-derived
+        endpoints (see `NodeFailures`); kept as its own wrapper until the
+        server convergence is sorted out.
+      type: object
+      properties:
+        failures:
+          type: array
+          items:
+            $ref: '_common.yaml#/components/schemas/ErrorCause'
+      x-version-added: '1.0'

--- a/tools/src/linter/SchemaRefsValidator.ts
+++ b/tools/src/linter/SchemaRefsValidator.ts
@@ -29,7 +29,7 @@ export default class SchemaRefsValidator {
   #find_refs_in_namespaces_folder (): void {
     const search = (obj: any): void => {
       const ref: string = obj?.$ref ?? ''
-      if (ref !== '') {
+      if (ref !== '' && !ref.startsWith('#/')) {
         const file = ref.split('#')[0].replace('../', '')
         const name = ref.split('/').pop() ?? ''
         if (name === '') throw new Error(`Invalid schema reference: ${ref}`)
@@ -39,7 +39,7 @@ export default class SchemaRefsValidator {
       for (const key in obj) { if (typeof obj[key] === 'object') search(obj[key]) }
     }
 
-    this.namespaces_folder.files.forEach((file) => { search(file.spec().components ?? {}) })
+    this.namespaces_folder.files.forEach((file) => { search(file.spec()) })
   }
 
   #find_refs_in_schemas_folder (): void {

--- a/tools/src/linter/components/NamespaceFile.ts
+++ b/tools/src/linter/components/NamespaceFile.ts
@@ -71,7 +71,7 @@ export default class NamespaceFile extends FileValidator {
     this._refs = new Set<string>()
     const find_refs = (obj: Record<string, any>): void => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      if (obj.$ref != null) this._refs!.add(obj.$ref as string)
+      if (obj.$ref != null && (obj.$ref as string).startsWith('#/')) this._refs!.add(obj.$ref as string)
       _.values(obj).forEach((value) => { if (typeof value === 'object') find_refs(value as Record<string, any>) })
     }
     find_refs(this.spec().paths ?? {})


### PR DESCRIPTION
Introduce a per-operation `x-error-responses` vendor extension whose value is an array of `$ref` objects pointing at wrapper schemas in `spec/schemas/_common.errors.yaml`. Each wrapper describes one auxiliary failure shape an endpoint may carry alongside its primary 2xx response — including arity (array vs object vs map) and any parallel-array grouping (e.g. `task_failures[]` + `node_failures[]` together for the Tasks API) — using ordinary JSON Schema. Client generators walk an operation's `x-error-responses` array, look up each wrapper, and emit one typed handler per wrapper that detects and extracts the embedded failure content.

The new `_common.errors.yaml` defines 15 wrappers covering the distinct partial-failure encodings present in OpenSearch today: BulkItems, SearchShards, WriteShards, BroadcastShards, NodeFailures, BulkByScrollFailures, TaskFailures, MultiSearchItems, MultiDocItems, SnapshotCreateShardFailures, SnapshotGetShardFailures, SimulateDocFailures, RankEvalFailures, IngestionShardFailures, and PitNodeFailures. Each wrapper composes existing element schemas (`ShardSearchFailure`, `ShardFailure`, `NodeStatistics`, `TaskFailure`, `SnapshotShardFailure`, `IngestionStateShardFailure`, `BulkByScrollFailure`, etc.) — no new element types are added.

Annotate 115 operation variants across 10 namespace files (_core, asynchronous_search, cluster, dangling_indices, indices, ingest, ingestion, nodes, snapshot, tasks). `indices.recovery` and `indices.get_upgrade` are intentionally not annotated: their response classes extend `BroadcastResponse` but suppress the `_shards` block in their `toXContent` overrides.

Document the extension in DEVELOPER_GUIDE.md alongside the existing vendor extensions list.

Motivated by `opensearch-go`'s port of partial-failure error handling into its generated `v5preview/opensearchapi/` package, which needs a generator-driven mapping from operation to auxiliary failure types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
