### PR TITLE
Add missing create PIT index option params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add msearch `allow_partial_results` flag ([#1061](https://github.com/opensearch-project/opensearch-api-specification/pull/1061))
 - Add title to `ml.predict_model_stream` and `ml.execute_agent_stream` requestBody ([#1072](https://github.com/opensearch-project/opensearch-api-specification/pull/1072))
 - Added `agentic` query type, `agentic_query_translator` request processor, and `agentic_context` response processor ([#1073](https://github.com/opensearch-project/opensearch-api-specification/pull/1073))
-- Fixed `create_pit` to include the `allow_no_indices`, `ignore_unavailable`, and `ignore_throttled` query parameters, and to mark `pit_id` as required in the create response, matching the core REST handler ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
+- Added `allow_no_indices`, `ignore_unavailable`, and `ignore_throttled` query parameters to `create_pit` ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))
@@ -56,6 +56,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fixed `HitsMetadata` to mark `max_score` as required ([#1103](https://github.com/opensearch-project/opensearch-api-specification/pull/1103))
+- Fixed `create_pit` to mark `pit_id` as required in the create response ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
 - Fixed `create_pit` `keep_alive` query parameter to be required ([#1102](https://github.com/opensearch-project/opensearch-api-specification/pull/1102))
 - Fixed ISM index parameters to use `Indices` type instead of `IndexName` for multi-index support ([#1097](https://github.com/opensearch-project/opensearch-api-specification/issues/1097))
 - Fixed `failures` field type in `PauseIngestionResponse` and `ResumeIngestionResponse` from array to map keyed by index name, matching server serialization ([#1107](https://github.com/opensearch-project/opensearch-api-specification/pull/1107))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fixed `HitsMetadata` to mark `max_score` as required ([#1103](https://github.com/opensearch-project/opensearch-api-specification/pull/1103))
-- Fixed `create_pit` to mark `pit_id`, `_shards`, and `creation_time` as required in the create response ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
+- Fixed `create_pit` to mark `pit_id`, `_shards`, and `creation_time` as required in the PIT response ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
 - Fixed `create_pit` `keep_alive` query parameter to be required ([#1102](https://github.com/opensearch-project/opensearch-api-specification/pull/1102))
 - Fixed ISM index parameters to use `Indices` type instead of `IndexName` for multi-index support ([#1097](https://github.com/opensearch-project/opensearch-api-specification/issues/1097))
 - Fixed `failures` field type in `PauseIngestionResponse` and `ResumeIngestionResponse` from array to map keyed by index name, matching server serialization ([#1107](https://github.com/opensearch-project/opensearch-api-specification/pull/1107))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add msearch `allow_partial_results` flag ([#1061](https://github.com/opensearch-project/opensearch-api-specification/pull/1061))
 - Add title to `ml.predict_model_stream` and `ml.execute_agent_stream` requestBody ([#1072](https://github.com/opensearch-project/opensearch-api-specification/pull/1072))
 - Added `agentic` query type, `agentic_query_translator` request processor, and `agentic_context` response processor ([#1073](https://github.com/opensearch-project/opensearch-api-specification/pull/1073))
+- Fixed `create_pit` to include the `allow_no_indices`, `ignore_unavailable`, and `ignore_throttled` query parameters, and to mark `pit_id` as required in the create response, matching the core REST handler ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fixed `HitsMetadata` to mark `max_score` as required ([#1103](https://github.com/opensearch-project/opensearch-api-specification/pull/1103))
-- Fixed `create_pit` to mark `pit_id` as required in the create response ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
+- Fixed `create_pit` to mark `pit_id`, `_shards`, and `creation_time` as required in the create response ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
 - Fixed `create_pit` `keep_alive` query parameter to be required ([#1102](https://github.com/opensearch-project/opensearch-api-specification/pull/1102))
 - Fixed ISM index parameters to use `Indices` type instead of `IndexName` for multi-index support ([#1097](https://github.com/opensearch-project/opensearch-api-specification/issues/1097))
 - Fixed `failures` field type in `PauseIngestionResponse` and `ResumeIngestionResponse` from array to map keyed by index name, matching server serialization ([#1107](https://github.com/opensearch-project/opensearch-api-specification/pull/1107))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2900,6 +2900,8 @@ components:
                 format: int64
             required:
               - pit_id
+              - _shards
+              - creation_time
     delete@200:
       content:
         application/json:

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2899,9 +2899,9 @@ components:
                 type: integer
                 format: int64
             required:
-              - pit_id
               - _shards
               - creation_time
+              - pit_id
     delete@200:
       content:
         application/json:

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -1953,8 +1953,11 @@ paths:
         url: https://opensearch.org/docs/latest/search-plugins/point-in-time-api/#create-a-pit
       parameters:
         - $ref: '#/components/parameters/create_pit::path.index'
+        - $ref: '#/components/parameters/create_pit::query.allow_no_indices'
         - $ref: '#/components/parameters/create_pit::query.allow_partial_pit_creation'
         - $ref: '#/components/parameters/create_pit::query.expand_wildcards'
+        - $ref: '#/components/parameters/create_pit::query.ignore_throttled'
+        - $ref: '#/components/parameters/create_pit::query.ignore_unavailable'
         - $ref: '#/components/parameters/create_pit::query.keep_alive'
         - $ref: '#/components/parameters/create_pit::query.preference'
         - $ref: '#/components/parameters/create_pit::query.routing'
@@ -2885,6 +2888,7 @@ components:
       content:
         application/json:
           schema:
+            title: CreatePITResponse
             type: object
             properties:
               pit_id:
@@ -2894,6 +2898,8 @@ components:
               creation_time:
                 type: integer
                 format: int64
+            required:
+              - pit_id
     delete@200:
       content:
         application/json:
@@ -3760,6 +3766,15 @@ components:
           type: string
       required: true
       style: simple
+    create_pit::query.allow_no_indices:
+      in: query
+      name: allow_no_indices
+      description: |-
+        If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes.
+        This behavior applies even if the request targets other open indexes.
+      schema:
+        type: boolean
+      style: form
     create_pit::query.allow_partial_pit_creation:
       name: allow_partial_pit_creation
       in: query
@@ -3773,6 +3788,21 @@ components:
       description: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
       schema:
         $ref: '../schemas/_common.yaml#/components/schemas/ExpandWildcards'
+      style: form
+    create_pit::query.ignore_throttled:
+      in: query
+      name: ignore_throttled
+      description: If `true`, concrete, expanded or aliased indexes will be ignored when frozen.
+      schema:
+        type: boolean
+      style: form
+    create_pit::query.ignore_unavailable:
+      in: query
+      name: ignore_unavailable
+      description: If `false`, the request returns an error if it targets a missing or closed index.
+      schema:
+        type: boolean
+      style: form
     create_pit::query.keep_alive:
       name: keep_alive
       in: query


### PR DESCRIPTION
## Summary
Added allow_no_indices, ignore_unavailable, and ignore_throttled query parameters to create_pit.
Marked pit_id, _shards, and creation_time as required in the create_pit response.
Kept keep_alive required for create_pit.

## Why this change is needed
The current spec was incomplete relative to the core implementation.

In OpenSearch core, `RestCreatePitAction` builds the PIT request with:
- `createPitRequest.setIndicesOptions(IndicesOptions.fromRequest(request, createPitRequest.indicesOptions()));`

`IndicesOptions.fromRequest(...)` reads these query parameters from the REST request:
- `expand_wildcards`
- `ignore_unavailable`
- `allow_no_indices`
- `ignore_throttled`

For the response, `CreatePitResponse` 
`pit_id` is always written by CreatePitResponse.toXContent()
`_shards` is always emitted by RestActions.buildBroadcastShardsHeader(...)
`creation_time` is always written by CreatePitResponse.toXContent()

## Core source
- `server/src/main/java/org/opensearch/rest/action/search/RestCreatePitAction.java`
- `server/src/main/java/org/opensearch/action/support/IndicesOptions.java`
- `server/src/main/java/org/opensearch/action/search/CreatePitResponse.java`
- `server/src/main/java/org/opensearch/action/search/CreatePitController.java`

## Validation
- `npm run lint:spec`
