### PR TITLE
Clarify by-query source parameter descriptions

### DIFF
--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -3890,7 +3890,7 @@ components:
     delete_by_query::query._source:
       name: _source
       in: query
-      description: Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
+      description: Controls source fetching for the internal search request used to find matching documents. The response does not include document sources.
       style: form
       schema:
         $ref: '../schemas/_core.search.yaml#/components/schemas/SourceConfigParam'
@@ -3898,24 +3898,24 @@ components:
     delete_by_query::query._source_excludes:
       name: _source_excludes
       in: query
-      description: List of fields to exclude from the returned `_source` field.
+      description: List of source fields to exclude from the internal search request used to find matching documents.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: List of fields to exclude from the returned `_source` field.
+        description: List of source fields to exclude from the internal search request used to find matching documents.
       explode: true
     delete_by_query::query._source_includes:
       name: _source_includes
       in: query
-      description: List of fields to extract and return from the `_source` field.
+      description: List of source fields to include in the internal search request used to find matching documents.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: List of fields to extract and return from the `_source` field.
+        description: List of source fields to include in the internal search request used to find matching documents.
       explode: true
     delete_by_query::query.allow_no_indices:
       in: query
@@ -6294,7 +6294,7 @@ components:
     update_by_query::query._source:
       name: _source
       in: query
-      description: Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
+      description: Controls source fetching for the internal search request used to find matching documents. The response does not include document sources, but source filtering can affect update scripts that read `ctx._source`.
       style: form
       schema:
         $ref: '../schemas/_core.search.yaml#/components/schemas/SourceConfigParam'
@@ -6302,24 +6302,24 @@ components:
     update_by_query::query._source_excludes:
       name: _source_excludes
       in: query
-      description: List of fields to exclude from the returned `_source` field.
+      description: List of source fields to exclude from the internal search request used to find matching documents. Source filtering can affect update scripts that read `ctx._source`.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: List of fields to exclude from the returned `_source` field.
+        description: List of source fields to exclude from the internal search request used to find matching documents.
       explode: true
     update_by_query::query._source_includes:
       name: _source_includes
       in: query
-      description: List of fields to extract and return from the `_source` field.
+      description: List of source fields to include in the internal search request used to find matching documents. Source filtering can affect update scripts that read `ctx._source`.
       style: form
       schema:
         type: array
         items:
           type: string
-        description: List of fields to extract and return from the `_source` field.
+        description: List of source fields to include in the internal search request used to find matching documents.
       explode: true
     update_by_query::query.allow_no_indices:
       in: query


### PR DESCRIPTION
### Description

Clarifies the `_source`, `_source_excludes`, and `_source_includes` descriptions for `delete_by_query` and `update_by_query`.

OpenSearch accepts these parameters because both APIs build an internal search request, but their bulk-by-scroll responses do not return search hits or document `_source` fields. The previous descriptions said these parameters controlled returned `_source`, which made the generated API spec/docs look like the response should contain sources.

For `update_by_query`, the descriptions now also note that source filtering can affect update scripts that read `ctx._source`.

Closes #548.

### Issues Resolved

#548

### Check List

- [x] `npm run lint:spec`
- [x] `npm run merge`
- [x] `npm run lint`
- [x] `git diff --check`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.