### PR TITLE
Fix segment sort response schema

### DIFF
--- a/spec/schemas/indices.segments.yaml
+++ b/spec/schemas/indices.segments.yaml
@@ -94,6 +94,11 @@ components:
         compound:
           type: boolean
           description: Whether the segment is compound.
+        sort:
+          type: array
+          description: The index sort metadata for the segment.
+          items:
+            $ref: '#/components/schemas/SegmentSort'
         attributes:
           type: object
           description: The attributes of the segment.
@@ -109,3 +114,28 @@ components:
         - search
         - size_in_bytes
         - version
+    SegmentSort:
+      description: The index sort metadata for a segment field.
+      type: object
+      properties:
+        field:
+          type: string
+          description: The sorted field name.
+        mode:
+          $ref: '#/components/schemas/SegmentSortMode'
+        missing:
+          type: string
+          description: The missing-value sort behavior or replacement value.
+        reverse:
+          type: boolean
+          description: Whether the field is sorted in reverse order.
+      required:
+        - field
+        - mode
+        - reverse
+    SegmentSortMode:
+      description: The segment sort selector.
+      type: string
+      enum:
+        - max
+        - min


### PR DESCRIPTION
Fixes #882.

The segments response can include per-segment `sort` metadata when an index has index sorting enabled. OpenSearch writes this as an array of objects containing `field`, `mode`, optional `missing`, and `reverse`, but `indices.segments.Segment` did not declare the `sort` property. That makes response-schema validation fail whenever a segment exposes index sort metadata.

This adds a dedicated `SegmentSort` schema for the response shape emitted by `IndicesSegmentResponse.toXContent()`.

Validation:
- `npm run lint:spec`
- `npm run merge`
- `npx eslint spec/schemas/indices.segments.yaml --report-unused-disable-directives`
- `git diff --check`

Notes:
- `npm run lint` currently also lints the generated `build/opensearch-openapi.yaml` and reports existing generated-spec ordering/plain-scalar violations unrelated to this change.
- `npm run test:unit` has existing Windows path/CRLF expectation failures in tooling tests unrelated to this schema-only change.

Assisted-by: OpenAI Codex