### PR TITLE
Add native_memory fields to nodes.stats spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add title to `ml.predict_model_stream` and `ml.execute_agent_stream` requestBody ([#1072](https://github.com/opensearch-project/opensearch-api-specification/pull/1072))
 - Added `agentic` query type, `agentic_query_translator` request processor, and `agentic_context` response processor ([#1073](https://github.com/opensearch-project/opensearch-api-specification/pull/1073))
 - Added `allow_no_indices`, `ignore_unavailable`, and `ignore_throttled` query parameters to `create_pit` ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
+- Added `native_memory` and the `native_memory_utilization_percent`, `global_native_memory_usage`, and `native_memory_usage_tracker` fields to `nodes.stats` ([#1145](https://github.com/opensearch-project/opensearch-api-specification/pull/1145))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/schemas/nodes.stats.yaml
+++ b/spec/schemas/nodes.stats.yaml
@@ -88,6 +88,9 @@ components:
                 $ref: '_common.yaml#/components/schemas/Ip'
         jvm:
           $ref: '#/components/schemas/Jvm'
+        native_memory:
+          x-version-added: 3.7.0
+          $ref: '#/components/schemas/NativeMemory'
         name:
           $ref: '_common.yaml#/components/schemas/Name'
         os:
@@ -437,6 +440,9 @@ components:
           $ref: '_common.yaml#/components/schemas/PercentageString'
         memory_utilization_percent:
           $ref: '_common.yaml#/components/schemas/PercentageString'
+        native_memory_utilization_percent:
+          x-version-added: 3.7.0
+          $ref: '_common.yaml#/components/schemas/PercentageString'
         io_usage_stats:
           $ref: '#/components/schemas/ShardResourceUsageStatsIoUsageStats'
     ShardResourceUsageStatsIoUsageStats:
@@ -505,6 +511,9 @@ components:
         global_io_usage:
           $ref: '#/components/schemas/UsageStats'
         global_cpu_usage:
+          $ref: '#/components/schemas/UsageStats'
+        global_native_memory_usage:
+          x-version-added: 3.7.0
           $ref: '#/components/schemas/UsageStats'
     UsageStats:
       type: object
@@ -930,6 +939,40 @@ components:
           description: Highest number of threads used by JVM.
           type: integer
           format: int64
+    NativeMemory:
+      type: object
+      properties:
+        total_estimated_bytes:
+          $ref: '_common.yaml#/components/schemas/ByteCount'
+        analytics_backend:
+          $ref: '#/components/schemas/NativeMemoryAnalyticsBackend'
+        native_allocator:
+          $ref: '#/components/schemas/NativeMemoryAllocator'
+    NativeMemoryAnalyticsBackend:
+      type: object
+      properties:
+        allocated_bytes:
+          $ref: '_common.yaml#/components/schemas/ByteCount'
+        resident_bytes:
+          $ref: '_common.yaml#/components/schemas/ByteCount'
+    NativeMemoryAllocator:
+      type: object
+      properties:
+        root:
+          $ref: '#/components/schemas/NativeMemoryAllocatorPool'
+        pools:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/NativeMemoryAllocatorPool'
+    NativeMemoryAllocatorPool:
+      type: object
+      properties:
+        allocated_bytes:
+          $ref: '_common.yaml#/components/schemas/ByteCount'
+        peak_bytes:
+          $ref: '_common.yaml#/components/schemas/ByteCount'
+        limit_bytes:
+          $ref: '_common.yaml#/components/schemas/ByteCount'
     OperatingSystem:
       type: object
       properties:
@@ -1410,6 +1453,9 @@ components:
           $ref: '#/components/schemas/ShardSearchBackpressureTaskResourceTrackerElapsedTimeTrackerStats'
         cpu_usage_tracker:
           $ref: '#/components/schemas/ShardSearchBackpressureTaskResourceTrackerCpuUsageTrackerStats'
+        native_memory_usage_tracker:
+          x-version-added: 3.7.0
+          $ref: '#/components/schemas/ShardSearchBackpressureTaskResourceTrackerNativeMemoryUsageTrackerStats'
     ShardSearchBackpressureTaskResourceTrackerHeapUsageTrackerStats:
       type: object
       properties:
@@ -1456,6 +1502,20 @@ components:
           $ref: '_common.yaml#/components/schemas/Duration'
         current_avg_millis:
           $ref: '_common.yaml#/components/schemas/DurationValueUnitMillis'
+    ShardSearchBackpressureTaskResourceTrackerNativeMemoryUsageTrackerStats:
+      type: object
+      properties:
+        cancellation_count:
+          type: integer
+          format: int64
+        current_max:
+          $ref: '_common.yaml#/components/schemas/HumanReadableByteCount'
+        current_max_bytes:
+          $ref: '_common.yaml#/components/schemas/ByteCount'
+        current_avg:
+          $ref: '_common.yaml#/components/schemas/HumanReadableByteCount'
+        current_avg_bytes:
+          $ref: '_common.yaml#/components/schemas/ByteCount'
     ShardSearchBackpressureTaskCancellationStats:
       type: object
       properties:


### PR DESCRIPTION
OpenSearch 3.7.0 extended the `_nodes/stats` response with native-memory reporting. This adds the four corresponding fields to the `nodes.stats` spec. The [opensearch-go client (#867)](https://github.com/opensearch-project/opensearch-go/pull/867) already models these locally; upstreaming them here lets that local patch be dropped.

All additions are gated on `x-version-added: 3.7.0`, matching the server's `Version.V_3_7_0` gates. `V_3_7_0` is a defined release constant below `CURRENT = V_3_8_0`, so the full `3.7.0` is the correct annotation:
[`Version.java#L174-L177`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/libs/core/src/main/java/org/opensearch/Version.java#L174-L177).

#### Changes to `spec/schemas/nodes.stats.yaml`

- **`native_memory_utilization_percent`** on `ShardResourceUsageStatsDetail`. Emitted as a `String.format("%.1f", …)` value, so `PercentageString` (not `PercentageNumber`) is correct — matching its `memory_utilization_percent` sibling.
  [`NodeResourceUsageStats.java#L145`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/node/NodeResourceUsageStats.java#L145) · gate [`L67-L68`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/node/NodeResourceUsageStats.java#L67-L68)

- **`global_native_memory_usage`** on `ShardAdmissionControlStats`. The controller name is the JSON key, a sibling of `global_cpu_usage`/`global_io_usage`.  [`NativeMemoryBasedAdmissionController.java#L30`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/ratelimitting/admissioncontrol/controllers/NativeMemoryBasedAdmissionController.java#L30)

- **`native_memory_usage_tracker`** on the search-backpressure resource tracker, plus a new `ShardSearchBackpressureTaskResourceTrackerNativeMemoryUsageTrackerStats` schema. It intentionally omits `rolling_avg`/`rolling_avg_bytes` (unlike the heap tracker) — the server keeps no rolling baseline for native memory, per the source comment.  [`TaskResourceUsageTrackerType.java#L18`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/search/backpressure/trackers/TaskResourceUsageTrackerType.java#L18) · [`NativeMemoryUsageTracker.java#L213-L237`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/search/backpressure/trackers/NativeMemoryUsageTracker.java#L213-L237) · [`SearchShardTaskStats.java#L63-L66`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/search/backpressure/stats/SearchShardTaskStats.java#L63-L66)

- **`native_memory`** top-level, plus new `NativeMemory`, `NativeMemoryAnalyticsBackend`, `NativeMemoryAllocator`, and `NativeMemoryAllocatorPool` schemas.
  [`NodeStats.java#L777-L787`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java#L777-L787) · gates [`L288-L298`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/action/admin/cluster/node/stats/NodeStats.java#L288-L298) · [`AnalyticsBackendNativeMemoryStats.java#L78-L80`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/plugin/stats/AnalyticsBackendNativeMemoryStats.java#L78-L80) · [`NativeAllocatorPoolStats.java#L92-L98`](https://github.com/opensearch-project/OpenSearch/blob/3cd77ad835ab0f655782d3c6a0617cca09e2ca27/server/src/main/java/org/opensearch/plugin/stats/NativeAllocatorPoolStats.java#L92-L98)

Field shapes verified against [`opensearch-project/OpenSearch@3cd77ad`](https://github.com/opensearch-project/OpenSearch/commit/3cd77ad835ab0f655782d3c6a0617cca09e2ca27). No released tag contains this yet — latest tag is `3.6.0`; `3.7.0` is unreleased.

### Issues Resolved

- https://github.com/opensearch-project/opensearch-go/issues/870
- Part of upstreaming the native-memory stats modeled in [opensearch-project/opensearch-go#867](https://github.com/opensearch-project/opensearch-go/pull/867).
