### PR TITLE
Require DeletedPit fields in PIT schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unused dependencies: `eslint-config-standard-with-typescript`, `eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-promise`, `@eslint/eslintrc`
 
 ### Fixed
+- Fixed `DeletedPit` to mark `pit_id` and `successful` as required ([#TBD](https://github.com/opensearch-project/opensearch-api-specification/pull/TBD))
 - Fixed `HitsMetadata` to mark `max_score` as required ([#1103](https://github.com/opensearch-project/opensearch-api-specification/pull/1103))
 - Fixed `create_pit` to mark `pit_id`, `_shards`, and `creation_time` as required in the PIT response ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
 - Fixed `create_pit` `keep_alive` query parameter to be required ([#1102](https://github.com/opensearch-project/opensearch-api-specification/pull/1102))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unused dependencies: `eslint-config-standard-with-typescript`, `eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-promise`, `@eslint/eslintrc`
 
 ### Fixed
-- Fixed `DeletedPit` to mark `pit_id` and `successful` as required ([#TBD](https://github.com/opensearch-project/opensearch-api-specification/pull/TBD))
+- Fixed `DeletedPit` to mark `pit_id` and `successful` as required ([#1146](https://github.com/opensearch-project/opensearch-api-specification/pull/1146))
 - Fixed `HitsMetadata` to mark `max_score` as required ([#1103](https://github.com/opensearch-project/opensearch-api-specification/pull/1103))
 - Fixed `create_pit` to mark `pit_id`, `_shards`, and `creation_time` as required in the PIT response ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
 - Fixed `create_pit` `keep_alive` query parameter to be required ([#1102](https://github.com/opensearch-project/opensearch-api-specification/pull/1102))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2941,6 +2941,7 @@ components:
       content:
         application/json:
           schema:
+            title: DeletePITResponse
             type: object
             properties:
               pits:

--- a/spec/schemas/_core.pit.yaml
+++ b/spec/schemas/_core.pit.yaml
@@ -9,10 +9,13 @@ components:
     DeletedPit:
       type: object
       properties:
-        successful:
-          type: boolean
         pit_id:
           type: string
+        successful:
+          type: boolean
+      required:
+        - pit_id
+        - successful
     PitDetail:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- mark `pit_id` and `successful` as required in `DeletedPit`

## Why this change is needed
`DeletePitInfo.toXContent()` always serializes both `successful` and `pit_id` for each PIT delete result entry, so the `DeletedPit` schema should mark both fields as required.

## Core source
- `server/src/main/java/org/opensearch/action/search/DeletePitInfo.java`
- `server/src/main/java/org/opensearch/action/search/DeletePitResponse.java`

## Validation
- `npm run lint:spec`
