### PR TITLE
Adding API Ref for ISM Simulate Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 - Added specs for Search Relevance Workbench plugin for scheduling endpoints ([#967](https://github.com/opensearch-project/opensearch-api-specification/pull/967))
 - Added specs for UBI plugin endpoints ([#845](https://github.com/opensearch-project/opensearch-api-specification/pull/845))
+- Adding API Ref for ISM Simulate Policy ([#1152](https://github.com/opensearch-project/opensearch-api-specification/pull/1152))
 
 ### Added
 

--- a/spec/namespaces/ism.yaml
+++ b/spec/namespaces/ism.yaml
@@ -244,6 +244,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ism.retry_index@200'
+  /_plugins/_ism/simulate:
+    post:
+      operationId: ism.simulate_policy.0
+      x-operation-group: ism.simulate_policy
+      description: Simulates how a policy would apply to one or more indexes without modifying any cluster state.
+      externalDocs:
+        url: https://opensearch.org/docs/latest/im-plugin/ism/api/#simulate-policy
+      requestBody:
+        $ref: '#/components/requestBodies/ism.simulate_policy'
+      responses:
+        '200':
+          $ref: '#/components/responses/ism.simulate_policy@200'
   /_plugins/_refresh_search_analyzers/{index}:
     post:
       operationId: ism.refresh_search_analyzers.0
@@ -283,6 +295,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/ism._common.yaml#/components/schemas/RetryIndexRequest'
+    ism.simulate_policy:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ism._common.yaml#/components/schemas/SimulatePolicyRequest'
     ism.explain_policy:
       content:
         application/json:
@@ -351,6 +368,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/ism._common.yaml#/components/schemas/RetryIndexResponse'
+    ism.simulate_policy@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ism._common.yaml#/components/schemas/SimulatePolicyResponse'
     ism.refresh_search_analyzers@200:
       content:
         application/json:

--- a/spec/schemas/ism._common.yaml
+++ b/spec/schemas/ism._common.yaml
@@ -476,6 +476,84 @@ components:
         last_updated_time:
           type: integer
           description: When the ISM template was last updated.
+    SimulatePolicyRequest:
+      type: object
+      description: Request body for the simulate policy API.
+      properties:
+        policy_id:
+          type: string
+          description: The ID of a stored ISM policy to simulate. Required when `policy` is not provided.
+        policy:
+          $ref: '#/components/schemas/Policy'
+          description: An inline policy definition to simulate. Required when `policy_id` is not provided.
+        indices:
+          type: array
+          description: The index names or wildcard patterns to simulate against.
+          items:
+            type: string
+      required:
+        - indices
+    SimulatePolicyResponse:
+      type: object
+      description: Response from the simulate policy API.
+      properties:
+        simulate_results:
+          type: array
+          description: The simulation result for each index.
+          items:
+            $ref: '#/components/schemas/IndexSimulateResult'
+    IndexSimulateResult:
+      type: object
+      description: The simulation result for a single index.
+      properties:
+        index_name:
+          type: string
+          description: The name of the index.
+        index_uuid:
+          type: ['null', string]
+          description: The UUID of the index. Null when the index was not found.
+        policy_id:
+          type: string
+          description: The ID of the policy used for simulation.
+        is_managed:
+          type: boolean
+          description: Whether the index is currently managed by ISM.
+        current_state:
+          type: [string, 'null']
+          description: The state the index is currently in or would start in. Omitted when error is present.
+        current_action:
+          type: [string, 'null']
+          description: The action that would execute next. Omitted when error is present.
+        transition_evaluation:
+          type: array
+          description: Per-transition condition evaluations. Present only when the index is in the transition phase.
+          items:
+            $ref: '#/components/schemas/TransitionSimulateResult'
+        next_state:
+          type: [string, 'null']
+          description: The state the index would transition to. Null if no condition is met.
+        error:
+          type: [string, 'null']
+          description: An index-level error message. Present when the index was not found or another error occurred.
+    TransitionSimulateResult:
+      type: object
+      description: The condition evaluation result for a single transition.
+      properties:
+        state_name:
+          type: string
+          description: The target state this transition would move the index to.
+        condition_met:
+          type: boolean
+          description: Whether the transition condition is currently satisfied.
+        condition_type:
+          type: string
+          description: The kind of condition evaluated, such as min_index_age or min_doc_count. Set to unconditional for transitions with no conditions.
+        current_value:
+          type: [string, 'null']
+          description: The human-readable current value of the metric being checked.
+        required_value:
+          type: [string, 'null']
+          description: The human-readable threshold required by the condition.
     RetryIndexRequest:
       type: object
       properties:

--- a/tests/default/ism/simulate.yaml
+++ b/tests/default/ism/simulate.yaml
@@ -1,0 +1,88 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test the ISM simulate policy API.
+prologues:
+  - id: policy
+    path: /_plugins/_ism/policies/simulate-test-policy
+    method: PUT
+    request:
+      payload:
+        policy:
+          description: A simulate test policy.
+          default_state: hot
+          states:
+            - name: hot
+              actions: []
+              transitions:
+                - state_name: warm
+                  conditions:
+                    min_index_age: 7d
+            - name: warm
+              actions: []
+              transitions: []
+    status: [201]
+    output:
+      id: payload._id
+  - path: /simulate-test-index
+    method: PUT
+chapters:
+  - synopsis: Simulate a stored policy against an index.
+    version: '>= 3.7'
+    path: /_plugins/_ism/simulate
+    method: POST
+    request:
+      payload:
+        policy_id: ${policy.id}
+        indices:
+          - simulate-test-index
+    response:
+      status: 200
+      payload:
+        simulate_results:
+          - index_name: simulate-test-index
+            is_managed: false
+            current_state: hot
+  - synopsis: Simulate an inline policy against an index.
+    version: '>= 3.7'
+    path: /_plugins/_ism/simulate
+    method: POST
+    request:
+      payload:
+        policy:
+          description: inline test
+          default_state: warm
+          states:
+            - name: warm
+              actions: []
+              transitions: []
+        indices:
+          - simulate-test-index
+    response:
+      status: 200
+      payload:
+        simulate_results:
+          - index_name: simulate-test-index
+            is_managed: false
+            current_state: warm
+  - synopsis: Simulate returns error result for non-existent index.
+    version: '>= 3.7'
+    path: /_plugins/_ism/simulate
+    method: POST
+    request:
+      payload:
+        policy_id: ${policy.id}
+        indices:
+          - no-such-index
+    response:
+      status: 200
+      payload:
+        simulate_results:
+          - index_name: no-such-index
+            is_managed: false
+epilogues:
+  - path: /_plugins/_ism/policies/simulate-test-policy
+    method: DELETE
+    status: [200, 404]
+  - path: /simulate-test-index
+    method: DELETE
+    status: [200, 404]


### PR DESCRIPTION
### Description
Add the ism.simulate_policy operation to the OpenSearch API specification:

spec/namespaces/ism.yaml — new POST /_plugins/_ism/simulate path with request body and response components following the existing ISM namespace conventions
spec/schemas/ism._common.yaml — four new schemas: SimulatePolicyRequest, SimulatePolicyResponse, IndexSimulateResult, and TransitionSimulateResult
tests/default/ism/simulate.yaml — test story covering three scenarios: simulate with a stored policy, simulate with an inline policy, and simulate against a non-existent index

### Issues Resolved
Closes #1151 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
