### PR TITLE
Add any_of grouped rollover conditions to ISM ActionRollover schema

### DIFF
--- a/spec/schemas/ism._common.yaml
+++ b/spec/schemas/ism._common.yaml
@@ -226,6 +226,33 @@ components:
         copy_alias:
           type: boolean
           description: Whether to copy the alias to the new index.
+        prevent_empty_rollover:
+          type: boolean
+          description: Whether to prevent rollover of an empty index.
+          x-version-added: '3.4'
+        any_of:
+          type: array
+          description: A list of rollover condition groups; any satisfied group triggers rollover.
+          x-version-added: '3.7'
+          items:
+            $ref: '#/components/schemas/RolloverConditionGroup'
+    RolloverConditionGroup:
+      type: object
+      description: A group of rollover conditions that must all be met to trigger rollover.
+      minProperties: 1
+      properties:
+        min_size:
+          type: string
+          description: The minimum size to trigger rollover.
+        min_index_age:
+          type: string
+          description: The minimum index age to trigger rollover.
+        min_doc_count:
+          type: number
+          description: The minimum document count to trigger rollover.
+        min_primary_shard_size:
+          type: string
+          description: The minimum primary shard size to trigger rollover.
     ActionNotification:
       type: object
       additionalProperties: true


### PR DESCRIPTION
### Description
Models the ISM rollover action's grouped `any_of` conditions in the `ActionRollover` schema, companion to the plugin change in opensearch-project/index-management#1667.

Changes to `spec/schemas/ism._common.yaml`:
- Add `any_of` to `ActionRollover` — a list of condition groups (`x-version-added: '3.7'`). All conditions within a group must be met (AND) and any satisfied group triggers rollover (OR).
- Add a new `RolloverConditionGroup` schema (min `1` property) holding the four rollover conditions.
- Add the previously-unmodeled `prevent_empty_rollover` boolean to `ActionRollover` (`x-version-added: '3.4'`).

### Issues Resolved
Resolves [#1540](https://github.com/opensearch-project/index-management/issues/1540) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
