### PR TITLE
[#22409] Add HTTP QUERY method to search API endpoints

### DIFF
--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -827,6 +827,71 @@ paths:
           $ref: '#/components/responses/search@400'
         '404':
           $ref: '#/components/responses/search@404'
+    query:
+      operationId: search.2
+      x-operation-group: search
+      x-version-added: '2.17'
+      description: Returns results matching a query using the HTTP QUERY method (RFC 10008).
+      externalDocs:
+        url: https://opensearch.org/docs/latest/api-reference/search/
+      parameters:
+        - $ref: '#/components/parameters/search::query._source'
+        - $ref: '#/components/parameters/search::query._source_excludes'
+        - $ref: '#/components/parameters/search::query._source_includes'
+        - $ref: '#/components/parameters/search::query.allow_no_indices'
+        - $ref: '#/components/parameters/search::query.allow_partial_search_results'
+        - $ref: '#/components/parameters/search::query.analyze_wildcard'
+        - $ref: '#/components/parameters/search::query.analyzer'
+        - $ref: '#/components/parameters/search::query.batched_reduce_size'
+        - $ref: '#/components/parameters/search::query.cancel_after_time_interval'
+        - $ref: '#/components/parameters/search::query.ccs_minimize_roundtrips'
+        - $ref: '#/components/parameters/search::query.default_operator'
+        - $ref: '#/components/parameters/search::query.df'
+        - $ref: '#/components/parameters/search::query.docvalue_fields'
+        - $ref: '#/components/parameters/search::query.expand_wildcards'
+        - $ref: '#/components/parameters/search::query.explain'
+        - $ref: '#/components/parameters/search::query.from'
+        - $ref: '#/components/parameters/search::query.ignore_throttled'
+        - $ref: '#/components/parameters/search::query.ignore_unavailable'
+        - $ref: '#/components/parameters/search::query.include_named_queries_score'
+        - $ref: '#/components/parameters/search::query.index'
+        - $ref: '#/components/parameters/search::query.lenient'
+        - $ref: '#/components/parameters/search::query.max_concurrent_shard_requests'
+        - $ref: '#/components/parameters/search::query.phase_took'
+        - $ref: '#/components/parameters/search::query.pre_filter_shard_size'
+        - $ref: '#/components/parameters/search::query.preference'
+        - $ref: '#/components/parameters/search::query.q'
+        - $ref: '#/components/parameters/search::query.request_cache'
+        - $ref: '#/components/parameters/search::query.rest_total_hits_as_int'
+        - $ref: '#/components/parameters/search::query.routing'
+        - $ref: '#/components/parameters/search::query.scroll'
+        - $ref: '#/components/parameters/search::query.search_pipeline'
+        - $ref: '#/components/parameters/search::query.search_type'
+        - $ref: '#/components/parameters/search::query.seq_no_primary_term'
+        - $ref: '#/components/parameters/search::query.size'
+        - $ref: '#/components/parameters/search::query.sort'
+        - $ref: '#/components/parameters/search::query.stats'
+        - $ref: '#/components/parameters/search::query.stored_fields'
+        - $ref: '#/components/parameters/search::query.suggest_field'
+        - $ref: '#/components/parameters/search::query.suggest_mode'
+        - $ref: '#/components/parameters/search::query.suggest_size'
+        - $ref: '#/components/parameters/search::query.suggest_text'
+        - $ref: '#/components/parameters/search::query.terminate_after'
+        - $ref: '#/components/parameters/search::query.timeout'
+        - $ref: '#/components/parameters/search::query.track_scores'
+        - $ref: '#/components/parameters/search::query.track_total_hits'
+        - $ref: '#/components/parameters/search::query.typed_keys'
+        - $ref: '#/components/parameters/search::query.verbose_pipeline'
+        - $ref: '#/components/parameters/search::query.version'
+      requestBody:
+        $ref: '#/components/requestBodies/search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search@200'
+        '400':
+          $ref: '#/components/responses/search@400'
+        '404':
+          $ref: '#/components/responses/search@404'
   /_search/point_in_time:
     delete:
       operationId: delete_pit.0
@@ -1882,6 +1947,72 @@ paths:
       x-operation-group: search
       x-version-added: '1.0'
       description: Returns results matching a query.
+      externalDocs:
+        url: https://opensearch.org/docs/latest/api-reference/search/
+      parameters:
+        - $ref: '#/components/parameters/search::path.index'
+        - $ref: '#/components/parameters/search::query._source'
+        - $ref: '#/components/parameters/search::query._source_excludes'
+        - $ref: '#/components/parameters/search::query._source_includes'
+        - $ref: '#/components/parameters/search::query.allow_no_indices'
+        - $ref: '#/components/parameters/search::query.allow_partial_search_results'
+        - $ref: '#/components/parameters/search::query.analyze_wildcard'
+        - $ref: '#/components/parameters/search::query.analyzer'
+        - $ref: '#/components/parameters/search::query.batched_reduce_size'
+        - $ref: '#/components/parameters/search::query.cancel_after_time_interval'
+        - $ref: '#/components/parameters/search::query.ccs_minimize_roundtrips'
+        - $ref: '#/components/parameters/search::query.default_operator'
+        - $ref: '#/components/parameters/search::query.df'
+        - $ref: '#/components/parameters/search::query.docvalue_fields'
+        - $ref: '#/components/parameters/search::query.expand_wildcards'
+        - $ref: '#/components/parameters/search::query.explain'
+        - $ref: '#/components/parameters/search::query.from'
+        - $ref: '#/components/parameters/search::query.ignore_throttled'
+        - $ref: '#/components/parameters/search::query.ignore_unavailable'
+        - $ref: '#/components/parameters/search::query.include_named_queries_score'
+        - $ref: '#/components/parameters/search::query.index'
+        - $ref: '#/components/parameters/search::query.lenient'
+        - $ref: '#/components/parameters/search::query.max_concurrent_shard_requests'
+        - $ref: '#/components/parameters/search::query.phase_took'
+        - $ref: '#/components/parameters/search::query.pre_filter_shard_size'
+        - $ref: '#/components/parameters/search::query.preference'
+        - $ref: '#/components/parameters/search::query.q'
+        - $ref: '#/components/parameters/search::query.request_cache'
+        - $ref: '#/components/parameters/search::query.rest_total_hits_as_int'
+        - $ref: '#/components/parameters/search::query.routing'
+        - $ref: '#/components/parameters/search::query.scroll'
+        - $ref: '#/components/parameters/search::query.search_pipeline'
+        - $ref: '#/components/parameters/search::query.search_type'
+        - $ref: '#/components/parameters/search::query.seq_no_primary_term'
+        - $ref: '#/components/parameters/search::query.size'
+        - $ref: '#/components/parameters/search::query.sort'
+        - $ref: '#/components/parameters/search::query.stats'
+        - $ref: '#/components/parameters/search::query.stored_fields'
+        - $ref: '#/components/parameters/search::query.suggest_field'
+        - $ref: '#/components/parameters/search::query.suggest_mode'
+        - $ref: '#/components/parameters/search::query.suggest_size'
+        - $ref: '#/components/parameters/search::query.suggest_text'
+        - $ref: '#/components/parameters/search::query.terminate_after'
+        - $ref: '#/components/parameters/search::query.timeout'
+        - $ref: '#/components/parameters/search::query.track_scores'
+        - $ref: '#/components/parameters/search::query.track_total_hits'
+        - $ref: '#/components/parameters/search::query.typed_keys'
+        - $ref: '#/components/parameters/search::query.verbose_pipeline'
+        - $ref: '#/components/parameters/search::query.version'
+      requestBody:
+        $ref: '#/components/requestBodies/search'
+      responses:
+        '200':
+          $ref: '#/components/responses/search@200'
+        '400':
+          $ref: '#/components/responses/search@400'
+        '404':
+          $ref: '#/components/responses/search@404'
+    query:
+      operationId: search.4
+      x-operation-group: search
+      x-version-added: '2.17'
+      description: Returns results matching a query using the HTTP QUERY method (RFC 10008).
       externalDocs:
         url: https://opensearch.org/docs/latest/api-reference/search/
       parameters:


### PR DESCRIPTION

### Description

Implement RFC 10008 support by adding the QUERY method to /_search and /{index}/_search endpoints with proper parameter references and response definitions.

Note: Integration tests will be added after client libraries add QUERY support.

### Issues Resolved

* https://github.com/opensearch-project/OpenSearch/pull/22410
* https://github.com/opensearch-project/OpenSearch/issues/22409
    
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
