### PR TITLE
Allow indexed_shape-only geo_shape and xy_shape queries

### DIFF
--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -806,8 +806,7 @@ components:
           $ref: '#/components/schemas/GeoShape'
         relation:
           $ref: '_common.yaml#/components/schemas/GeoShapeRelation'
-      required:
-        - shape
+      
     GeoShapeQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'
@@ -2260,8 +2259,7 @@ components:
           $ref: '#/components/schemas/XyShape'
         relation:
           $ref: '_common.yaml#/components/schemas/GeoShapeRelation'
-      required:
-        - shape
+      
     XyShapeQuery:
       x-version-added: '2.4'
       allOf:


### PR DESCRIPTION
## Summary

Fixes #1160.

The current API specification marks `shape` as required in both `GeoShapeQueryField` and `XyShapeQueryField`. However, OpenSearch supports pre-indexed shape queries using `indexed_shape` without an accompanying `shape`, as documented.

Because this specification is the source of truth for generated clients, the current requirement prevents clients from constructing valid `indexed_shape`-only queries.

This PR removes the `shape` requirement from both schemas, allowing both inline `shape` queries and pre-indexed `indexed_shape` queries.

## Changes

- Remove `required: [shape]` from `GeoShapeQueryField`
- Remove `required: [shape]` from `XyShapeQueryField`

## Motivation

The OpenSearch documentation describes `shape` and `indexed_shape` as alternative ways to define a geo/xy shape query. Requiring `shape` makes valid pre-indexed shape queries fail schema validation and propagates incorrect constraints to generated clients.

This change aligns the API specification with the documented query behavior.

## Testing

- Verified that the schema changes are limited to `GeoShapeQueryField` and `XyShapeQueryField`.
- Existing query behavior remains unchanged for inline `shape` queries.

## Notes

The current specification tests cover inline shape queries but do not include coverage for the indexed_shape path. This PR focuses on correcting the schema; regression tests for indexed_shape can be added separately if maintainers prefer additional coverage.