### PR TITLE
Update opensearch-api-spec maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @harshavamsi @sachetalva @Xtansia @VachaShah @Tokesh @aabeshov @karenyrx @lucy66hw
+*   @harshavamsi @sachetalva @Xtansia @VachaShah @Tokesh @aabeshov @karenyrx @lucy66hw @sean-

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
 | Karen Xu             | [karenyrx](https://github.com/karenyrx)       | Uber        |
 | Sachet Alva          | [sachetalva](https://github.com/sachetalva)   | Amazon      |
+| Sean Chittenden      | [sean-](https://github.com/sean-)             |             |
 | Thomas Farr          | [Xtansia](https://github.com/Xtansia)         | Independent |
 | Torekeldi Niyazbek   | [Tokesh](https://github.com/Tokesh)           |             |
 | Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
 | Karen Xu             | [karenyrx](https://github.com/karenyrx)       | Uber        |
 | Sachet Alva          | [sachetalva](https://github.com/sachetalva)   | Amazon      |
-| Sean Chittenden      | [sean-](https://github.com/sean-)             | Independent |
+| Sean Chittenden      | [sean-](https://github.com/sean-)             | CrowdStrike |
 | Thomas Farr          | [Xtansia](https://github.com/Xtansia)         | Independent |
 | Torekeldi Niyazbek   | [Tokesh](https://github.com/Tokesh)           |             |
 | Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |
@@ -27,4 +27,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Abhi Kalra         | [abhivka7](https://github.com/abhivka7) | Amazon      |
 | Daniel Doubrovkine | [dblock](https://github.com/dblock)     | Independent |
 | Pranav Garg        | [pgtgrly](https://github.com/pgtgrly)   | Amazon      |
-| Theo Truong        | [nhtruong](https://github.com/nhtruong)       | Independent |
+| Theo Truong        | [nhtruong](https://github.com/nhtruong) | Independent |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
 | Karen Xu             | [karenyrx](https://github.com/karenyrx)       | Uber        |
 | Sachet Alva          | [sachetalva](https://github.com/sachetalva)   | Amazon      |
-| Sean Chittenden      | [sean-](https://github.com/sean-)             |             |
+| Sean Chittenden      | [sean-](https://github.com/sean-)             | Independent |
 | Thomas Farr          | [Xtansia](https://github.com/Xtansia)         | Independent |
 | Torekeldi Niyazbek   | [Tokesh](https://github.com/Tokesh)           |             |
 | Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |


### PR DESCRIPTION
_Ammending on behalf of Sean_

@sean- made following contributions for spec correctness:

- [PR #1145: Add native_memory fields to nodes.stats spec](https://github.com/opensearch-project/opensearch-api-specification/pull/1145)

- [PR #1137: Add x-error-responses extension for partial-failure response shapes](https://github.com/opensearch-project/opensearch-api-specification/pull/1137)

- [PR #1134: Add style: simple to 13 path parameters with array schemas](https://github.com/opensearch-project/opensearch-api-specification/pull/1134)

- [PR #1133: Define typed enum schemas for format query parameter on cat, list, sql, ppl](https://github.com/opensearch-project/opensearch-api-specification/pull/1133)

Sean has also contributed through PR review in the repository:

- https://github.com/opensearch-project/opensearch-api-specification/pull/1095

Based on these contributions, the maintainers have voted and accepted him to become new maintainers, will forward the email thread as needed