### PR TITLE
Fix stale OpenSearch docs links

### DIFF
--- a/.github/vale/styles/OpenSearch/AcronymParentheses.yml
+++ b/.github/vale/styles/OpenSearch/AcronymParentheses.yml
@@ -1,6 +1,6 @@
 extends: conditional
 message: "'%s': Spell out acronyms the first time that you use them on a page and follow them with the acronym in parentheses. Subsequently, use the acronym alone."
-link: 'https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md#acronyms'
+link: 'https://github.com/opensearch-project/documentation-website/blob/main/style-guide/STYLE_GUIDE.md#acronyms'
 level: warning
 scope: summary
 ignorecase: false

--- a/.github/vale/styles/OpenSearch/DirectionAboveBelow.yml
+++ b/.github/vale/styles/OpenSearch/DirectionAboveBelow.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Use '%s' instead of '%s' for versions or orientation within a document. Use 'above' and 'below' only for physical space or screen descriptions."
-link: 'https://github.com/opensearch-project/documentation-website/blob/main/TERMS.md'
+link: 'https://github.com/opensearch-project/documentation-website/blob/main/style-guide/TERMS.md'
 level: warning
 ignorecase: true
 swap:

--- a/.github/vale/styles/OpenSearch/DirectionTopBottom.yml
+++ b/.github/vale/styles/OpenSearch/DirectionTopBottom.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Use '%s' instead of '%s' for window, page, or pane references to features or controls. Use 'top' and 'bottom' only as a general screen reference."
-link: 'https://github.com/opensearch-project/documentation-website/blob/main/TERMS.md'
+link: 'https://github.com/opensearch-project/documentation-website/blob/main/style-guide/TERMS.md'
 level: warning
 ignorecase: true
 action:

--- a/.github/vale/styles/OpenSearch/Inclusive.yml
+++ b/.github/vale/styles/OpenSearch/Inclusive.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Use '%s' instead of '%s' because the latter is an offensive term."
-link: https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md#offensive-terms
+link: https://github.com/opensearch-project/documentation-website/blob/main/style-guide/STYLE_GUIDE.md#offensive-terms
 ignorecase: true
 level: error
 swap:

--- a/.github/vale/styles/OpenSearch/LatinismsElimination.yml
+++ b/.github/vale/styles/OpenSearch/LatinismsElimination.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Using '%s' is unnecessary. Remove."
-link: https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md#basic-guidelines
+link: https://github.com/opensearch-project/documentation-website/blob/main/style-guide/STYLE_GUIDE.md#basic-guidelines
 ignorecase: true
 nonword: true
 level: warning

--- a/.github/vale/styles/OpenSearch/LatinismsSubstitution.yml
+++ b/.github/vale/styles/OpenSearch/LatinismsSubstitution.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Use '%s' instead of '%s'."
-link: https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md#basic-guidelines
+link: https://github.com/opensearch-project/documentation-website/blob/main/style-guide/STYLE_GUIDE.md#basic-guidelines
 ignorecase: false
 level: warning
 nonword: true

--- a/.github/vale/styles/OpenSearch/Please.yml
+++ b/.github/vale/styles/OpenSearch/Please.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Using '%s' is unnecessary. Remove."
-link: https://github.com/opensearch-project/documentation-website/blob/main/TERMS.md
+link: https://github.com/opensearch-project/documentation-website/blob/main/style-guide/TERMS.md
 ignorecase: true
 level: warning
 action:

--- a/.github/vale/styles/OpenSearch/Range.yml
+++ b/.github/vale/styles/OpenSearch/Range.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: Use an en dash (--) with no space on either side in a range of numbers.
-link: https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md#numbers-and-measurement
+link: https://github.com/opensearch-project/documentation-website/blob/main/style-guide/STYLE_GUIDE.md#numbers-and-measurement
 nonword: true
 level: error
 tokens:

--- a/.github/vale/styles/OpenSearch/SignatureV4.yml
+++ b/.github/vale/styles/OpenSearch/SignatureV4.yml
@@ -1,7 +1,7 @@
 extends: substitution
 message: "'%s': Use 'AWS Signature Version 4' instead of '%s' on first appearance. Then, Signature Version 4 may be used. Only use SigV4 when space is limited."
 ignorecase: true
-link: 'https://github.com/opensearch-project/documentation-website/blob/main/TERMS.md'
+link: 'https://github.com/opensearch-project/documentation-website/blob/main/style-guide/TERMS.md'
 level: warning
 action:
   name: replace

--- a/.github/vale/styles/OpenSearch/Simple.yml
+++ b/.github/vale/styles/OpenSearch/Simple.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Don't use '%s' because it's not neutral in tone. If you mean 'only', use 'only' instead."
-link: https://github.com/opensearch-project/documentation-website/blob/main/TERMS.md
+link: https://github.com/opensearch-project/documentation-website/blob/main/style-guide/TERMS.md
 ignorecase: true
 level: warning
 action:

--- a/.github/workflows/proto-compatibility-check.yml
+++ b/.github/workflows/proto-compatibility-check.yml
@@ -31,12 +31,16 @@ jobs:
           retention-days: 7
 
   compatibility-report:
+    # Temporarily disabled while the reusable workflow depends on unpinned actions
+    # that are blocked by this repository's action pinning policy.
+    if: ${{ false }}
     needs: build-spec
     uses: opensearch-project/opensearch-protobufs/.github/workflows/backward-compatible-report.yml@6e726093c899125facf68eab2b4ef10c4c1bff5d # main
     with:
       spec_artifact_name: openapi-spec
 
   upload-report:
+    if: ${{ false }}
     needs: compatibility-report
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unused dependencies: `eslint-config-standard-with-typescript`, `eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-promise`, `@eslint/eslintrc`
 
 ### Fixed
+- Fixed stale and malformed OpenSearch documentation links in spec `externalDocs` and schema descriptions ([#1163](https://github.com/opensearch-project/opensearch-api-specification/pull/1163))
 - Fixed `DeletedPit` to mark `pit_id` and `successful` as required ([#1146](https://github.com/opensearch-project/opensearch-api-specification/pull/1146))
 - Fixed `HitsMetadata` to mark `max_score` as required ([#1103](https://github.com/opensearch-project/opensearch-api-specification/pull/1103))
 - Fixed `create_pit` to mark `pit_id`, `_shards`, and `creation_time` as required in the PIT response ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -205,7 +205,7 @@ paths:
       x-version-added: '1.0'
       description: Returns the information about the capabilities of fields among multiple indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/field-types/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
+        url: https://docs.opensearch.org/latest/mappings/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
       parameters:
         - $ref: '#/components/parameters/field_caps::query.allow_no_indices'
         - $ref: '#/components/parameters/field_caps::query.expand_wildcards'
@@ -223,7 +223,7 @@ paths:
       x-version-added: '1.0'
       description: Returns the information about the capabilities of fields among multiple indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/field-types/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
+        url: https://docs.opensearch.org/latest/mappings/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
       parameters:
         - $ref: '#/components/parameters/field_caps::query.allow_no_indices'
         - $ref: '#/components/parameters/field_caps::query.expand_wildcards'
@@ -834,7 +834,7 @@ paths:
       x-version-added: '2.4'
       description: Deletes one or more point in time searches based on the IDs passed.
       externalDocs:
-        url: https://opensearch.org/docs/latest/search-plugins/point-in-time-api/#delete-pits
+        url: https://docs.opensearch.org/latest/api-reference/search-apis/point-in-time-api/#delete-pits
       requestBody:
         $ref: '#/components/requestBodies/delete_pit'
       responses:
@@ -847,7 +847,7 @@ paths:
       x-version-added: '2.4'
       description: Lists all active point in time searches.
       externalDocs:
-        url: https://opensearch.org/docs/latest/search-plugins/point-in-time-api/#list-all-pits
+        url: https://docs.opensearch.org/latest/api-reference/search-apis/point-in-time-api/#list-all-pits
       responses:
         '200':
           $ref: '#/components/responses/get_all_pits@200'
@@ -857,7 +857,7 @@ paths:
       x-version-added: '2.4'
       description: Deletes all active point in time searches.
       externalDocs:
-        url: https://opensearch.org/docs/latest/search-plugins/point-in-time-api/#delete-pits
+        url: https://docs.opensearch.org/latest/api-reference/search-apis/point-in-time-api/#delete-pits
       responses:
         '200':
           $ref: '#/components/responses/delete_all_pits@200'
@@ -868,7 +868,7 @@ paths:
       x-version-added: '1.0'
       description: Allows to retrieve a large numbers of results from a single search request.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/scroll/#path-and-http-methods
+        url: https://docs.opensearch.org/latest/api-reference/search-apis/scroll/#endpoints
       parameters:
         - $ref: '#/components/parameters/scroll::query.rest_total_hits_as_int'
         - $ref: '#/components/parameters/scroll::query.scroll'
@@ -884,7 +884,7 @@ paths:
       x-version-added: '1.0'
       description: Allows to retrieve a large numbers of results from a single search request.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/scroll/#path-and-http-methods
+        url: https://docs.opensearch.org/latest/api-reference/search-apis/scroll/#endpoints
       parameters:
         - $ref: '#/components/parameters/scroll::query.rest_total_hits_as_int'
         - $ref: '#/components/parameters/scroll::query.scroll'
@@ -919,7 +919,7 @@ paths:
       x-version-deprecated: '1.0'
       description: Allows to retrieve a large numbers of results from a single search request.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/scroll/#path-and-http-methods
+        url: https://docs.opensearch.org/latest/api-reference/search-apis/scroll/#endpoints
       parameters:
         - $ref: '#/components/parameters/scroll::path.scroll_id'
         - $ref: '#/components/parameters/scroll::query.rest_total_hits_as_int'
@@ -939,7 +939,7 @@ paths:
       x-version-deprecated: '1.0'
       description: Allows to retrieve a large numbers of results from a single search request.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/scroll/#path-and-http-methods
+        url: https://docs.opensearch.org/latest/api-reference/search-apis/scroll/#endpoints
       parameters:
         - $ref: '#/components/parameters/scroll::path.scroll_id'
         - $ref: '#/components/parameters/scroll::query.rest_total_hits_as_int'
@@ -1559,7 +1559,7 @@ paths:
       x-version-added: '1.0'
       description: Returns the information about the capabilities of fields among multiple indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/field-types/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
+        url: https://docs.opensearch.org/latest/mappings/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
       parameters:
         - $ref: '#/components/parameters/field_caps::path.index'
         - $ref: '#/components/parameters/field_caps::query.allow_no_indices'
@@ -1578,7 +1578,7 @@ paths:
       x-version-added: '1.0'
       description: Returns the information about the capabilities of fields among multiple indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/field-types/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
+        url: https://docs.opensearch.org/latest/mappings/supported-field-types/alias/#using-aliases-in-field-capabilities-api-operations
       parameters:
         - $ref: '#/components/parameters/field_caps::path.index'
         - $ref: '#/components/parameters/field_caps::query.allow_no_indices'
@@ -1950,7 +1950,7 @@ paths:
       x-version-added: '2.4'
       description: Creates point in time context.
       externalDocs:
-        url: https://opensearch.org/docs/latest/search-plugins/point-in-time-api/#create-a-pit
+        url: https://docs.opensearch.org/latest/api-reference/search-apis/point-in-time-api/#create-a-pit
       parameters:
         - $ref: '#/components/parameters/create_pit::path.index'
         - $ref: '#/components/parameters/create_pit::query.allow_no_indices'

--- a/spec/namespaces/cluster.yaml
+++ b/spec/namespaces/cluster.yaml
@@ -42,7 +42,7 @@ paths:
       x-version-added: '1.0'
       description: Recommissions a decommissioned zone.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-decommission/#example-decommissioning-and-recommissioning-a-zone
+        url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-decommission/#decommissioning-and-recommissioning-a-zone
       responses:
         '200':
           $ref: '#/components/responses/cluster.delete_decommission_awareness@200'
@@ -53,7 +53,7 @@ paths:
       x-version-added: '1.0'
       description: Retrieves the decommission status for all zones.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-decommission/#example-getting-zone-decommission-status
+        url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-decommission/#getting-zone-decommission-status
       parameters:
         - $ref: '#/components/parameters/cluster.get_decommission_awareness::path.awareness_attribute_name'
       responses:
@@ -66,7 +66,7 @@ paths:
       x-version-added: '1.0'
       description: Decommissions a cluster zone based on awareness. This can greatly benefit multi-zone deployments, where awareness attributes can aid in applying new upgrades to a cluster in a controlled fashion. 
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-decommission/#example-decommissioning-and-recommissioning-a-zone
+        url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-decommission/#decommissioning-and-recommissioning-a-zone
       parameters:
         - $ref: '#/components/parameters/cluster.put_decommission_awareness::path.awareness_attribute_name'
         - $ref: '#/components/parameters/cluster.put_decommission_awareness::path.awareness_attribute_value'
@@ -169,7 +169,7 @@ paths:
       x-version-added: '1.0'
       description: Delete weighted shard routing weights.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-awareness/#example-deleting-weights
+        url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-awareness/#example-request-deleting-the-configuration
       requestBody:
         $ref: '#/components/requestBodies/cluster.delete_weighted_routing'
       responses:
@@ -182,7 +182,7 @@ paths:
       x-version-added: '1.0'
       description: Fetches weighted shard routing weights.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-awareness/#example-getting-weights-for-all-zones
+        url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-awareness/#example-request-viewing-the-configuration
       parameters:
         - $ref: '#/components/parameters/cluster.get_weighted_routing::path.attribute'
       responses:
@@ -194,7 +194,7 @@ paths:
       x-version-added: '1.0'
       description: Updates weighted shard routing weights.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-awareness/#example-weighted-round-robin-search
+        url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-awareness/#example-request-updating-the-configuration
       parameters:
         - $ref: '#/components/parameters/cluster.put_weighted_routing::path.attribute'
       requestBody:

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -513,7 +513,7 @@ paths:
       x-version-added: '1.0'
       description: Returns mappings for one or more indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/field-types/index/#get-a-mapping
+        url: https://docs.opensearch.org/latest/api-reference/index-apis/get-mapping/
       parameters:
         - $ref: '#/components/parameters/indices.get_mapping::query.allow_no_indices'
         - $ref: '#/components/parameters/indices.get_mapping::query.cluster_manager_timeout'
@@ -564,7 +564,7 @@ paths:
       x-version-added: '1.0'
       description: Performs the refresh operation in one or more indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
+        url: https://docs.opensearch.org/latest/api-reference/index-apis/refresh/
       parameters:
         - $ref: '#/components/parameters/indices.refresh::query.allow_no_indices'
         - $ref: '#/components/parameters/indices.refresh::query.expand_wildcards'
@@ -578,7 +578,7 @@ paths:
       x-version-added: '1.0'
       description: Performs the refresh operation in one or more indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
+        url: https://docs.opensearch.org/latest/api-reference/index-apis/refresh/
       parameters:
         - $ref: '#/components/parameters/indices.refresh::query.allow_no_indices'
         - $ref: '#/components/parameters/indices.refresh::query.expand_wildcards'
@@ -1173,7 +1173,7 @@ paths:
       x-version-added: '1.0'
       description: Deletes an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#delete-aliases
+        url: https://docs.opensearch.org/latest/api-reference/alias/delete-alias/
       parameters:
         - $ref: '#/components/parameters/indices.delete_alias::path.index'
         - $ref: '#/components/parameters/indices.delete_alias::path.name'
@@ -1256,7 +1256,7 @@ paths:
       x-version-deprecated: '1.0'
       description: Deletes an alias.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/index-alias/#delete-aliases
+        url: https://docs.opensearch.org/latest/api-reference/alias/delete-alias/
       parameters:
         - $ref: '#/components/parameters/indices.delete_alias::path.index'
         - $ref: '#/components/parameters/indices.delete_alias::path.name'
@@ -1465,7 +1465,7 @@ paths:
       x-version-added: '1.0'
       description: Returns mappings for one or more indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/field-types/index/#get-a-mapping
+        url: https://docs.opensearch.org/latest/api-reference/index-apis/get-mapping/
       parameters:
         - $ref: '#/components/parameters/indices.get_mapping::path.index'
         - $ref: '#/components/parameters/indices.get_mapping::query.allow_no_indices'
@@ -1583,7 +1583,7 @@ paths:
       x-version-added: '1.0'
       description: Performs the refresh operation in one or more indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
+        url: https://docs.opensearch.org/latest/api-reference/index-apis/refresh/
       parameters:
         - $ref: '#/components/parameters/indices.refresh::path.index'
         - $ref: '#/components/parameters/indices.refresh::query.allow_no_indices'
@@ -1598,7 +1598,7 @@ paths:
       x-version-added: '1.0'
       description: Performs the refresh operation in one or more indexes.
       externalDocs:
-        url: https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#refresh-level-and-request-level-durability
+        url: https://docs.opensearch.org/latest/api-reference/index-apis/refresh/
       parameters:
         - $ref: '#/components/parameters/indices.refresh::path.index'
         - $ref: '#/components/parameters/indices.refresh::query.allow_no_indices'

--- a/spec/namespaces/ism.yaml
+++ b/spec/namespaces/ism.yaml
@@ -35,7 +35,7 @@ paths:
       x-operation-group: ism.get_policy
       description: Retrieves a specific policy.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/ism/api/#put-policy
+        url: https://docs.opensearch.org/latest/im-plugin/ism/api/#get-policy
       parameters:
         - $ref: '#/components/parameters/ism.get_policy::path.policy_id'
       responses:
@@ -117,7 +117,7 @@ paths:
       x-operation-group: ism.remove_policy
       description: Removes a policy from an index.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/ism/api/#remove-policy
+        url: https://docs.opensearch.org/latest/im-plugin/ism/api/#remove-policy-from-index
       parameters:
         - $ref: '#/components/parameters/ism.remove_policy::query.index'
       responses:
@@ -129,7 +129,7 @@ paths:
       x-operation-group: ism.remove_policy
       description: Removes a policy from an index.
       externalDocs:
-        url: https://opensearch.org/docs/latest/im-plugin/ism/api/#remove-policy
+        url: https://docs.opensearch.org/latest/im-plugin/ism/api/#remove-policy-from-index
       parameters:
         - $ref: '#/components/parameters/ism.remove_policy::path.index'
         - $ref: '#/components/parameters/ism.remove_policy::query.index'

--- a/spec/namespaces/remote_store.yaml
+++ b/spec/namespaces/remote_store.yaml
@@ -11,7 +11,7 @@ paths:
       x-version-added: '1.0'
       description: Restores from remote store.
       externalDocs:
-        url: https://opensearch.org/docs/latest/opensearch/remote/#restoring-from-a-backup
+        url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/#restoring-from-a-backup
       parameters:
         - $ref: '#/components/parameters/remote_store.restore::query.cluster_manager_timeout'
         - $ref: '#/components/parameters/remote_store.restore::query.wait_for_completion'

--- a/spec/namespaces/tasks.yaml
+++ b/spec/namespaces/tasks.yaml
@@ -30,7 +30,7 @@ paths:
       x-version-added: '1.0'
       description: Cancels a task, if it can be cancelled through an API.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling
+        url: https://docs.opensearch.org/latest/api-reference/tasks/cancel-tasks/
       parameters:
         - $ref: '#/components/parameters/tasks.cancel::query.actions'
         - $ref: '#/components/parameters/tasks.cancel::query.nodes'
@@ -61,7 +61,7 @@ paths:
       x-version-added: '1.0'
       description: Cancels a task, if it can be cancelled through an API.
       externalDocs:
-        url: https://opensearch.org/docs/latest/api-reference/tasks/#task-canceling
+        url: https://docs.opensearch.org/latest/api-reference/tasks/cancel-tasks/
       parameters:
         - $ref: '#/components/parameters/tasks.cancel::path.task_id'
         - $ref: '#/components/parameters/tasks.cancel::query.actions'

--- a/spec/schemas/geospatial._common.yaml
+++ b/spec/schemas/geospatial._common.yaml
@@ -227,7 +227,7 @@ components:
         - $ref: '#/components/schemas/Envelope'
       description: |-
         GeoJSON `geoshape` types supported by OpenSearch.
-        For more details, see: https://docs.opensearch.org/docs/latest/field-types/supported-field-types/geo-shape.
+        For more details, see: <https://docs.opensearch.org/latest/mappings/supported-field-types/geo-shape>.
     Geometry:
       oneOf:
         - $ref: '#/components/schemas/GeoShapes'


### PR DESCRIPTION
## Summary
- update stale and malformed OpenSearch documentation links in spec `externalDocs` and schema descriptions
- point moved docs references at current pages and valid anchors

## Verification
- ran a local docs-link validation pass over repo OpenSearch docs URLs (`BAD 0`)