### PR TITLE
Trigger protobuf conversion from build artifact upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           event-type: spec-updated
           client-payload: |
             {
-              "artifact_url": "${{ steps.upload.outputs.artifact-url }}"
+              "artifact_download_url": "${{ steps.upload.outputs.artifact-url }}"
             }
 
       - name: Release Specification to GitHub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,17 @@ jobs:
           path: |
             build/*
 
+      - name: Trigger Proto Convert Workflow
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
+        with:
+          token: ${{ secrets.OSPT_PAT }}
+          repository: opensearch-project/opensearch-protobufs
+          event-type: spec-updated
+          client-payload: |
+            {
+              "artifact_url": "${{ steps.upload.outputs.artifact-url }}"
+            }
+
       - name: Release Specification to GitHub
         id: release
         uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -41,18 +41,3 @@ jobs:
         with:
           folder: _site
           branch: gh-pages
-
-
-      - name: Trigger Proto Convert Workflow
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
-        with:
-          token: ${{ secrets.OSPT_PAT }}
-          repository: opensearch-project/opensearch-protobufs
-          event-type: spec-updated
-          client-payload: |
-            {
-              "spec_repository": "opensearch-project/opensearch-api-specification",
-              "spec_tag": "main-latest",
-              "pr_number": "${{ github.event.pull_request.number || '' }}",
-              "ref": "${{ github.ref }}"
-            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `allow_no_indices`, `ignore_unavailable`, and `ignore_throttled` query parameters to `create_pit` ([#1141](https://github.com/opensearch-project/opensearch-api-specification/pull/1141))
 - Added `query` to TermsLookup to support terms lookup by query
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
+- Added artifact-based protobuf conversion trigger after spec build upload ([#1164](https://github.com/opensearch-project/opensearch-api-specification/pull/1164))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))


### PR DESCRIPTION
## Summary
- trigger `opensearch-protobufs` from `build.yml` immediately after uploading the merged spec artifact
- pass the uploaded workflow artifact URL in the dispatch payload
- remove the old protobuf trigger from `deploy-gh-pages.yml`

## Why this change is needed
The protobuf conversion flow should not depend on `main-latest` release publication succeeding. By dispatching right after artifact upload, downstream protobuf generation can consume the merged spec artifact even if the later GitHub release step fails.

## Behavior change
- before: protobuf conversion was triggered from `deploy-gh-pages.yml` and expected `main-latest`
- now: protobuf conversion is triggered from `build.yml` after artifact upload and receives `artifact_url`
