### PR TITLE
Propose moving @tokesh to Emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @harshavamsi @sachetalva @Xtansia @VachaShah @Tokesh @aabeshov @karenyrx @lucy66hw @sean-
+*   @harshavamsi @sachetalva @Xtansia @VachaShah @aabeshov @karenyrx @lucy66hw @sean-

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,7 +15,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sachet Alva          | [sachetalva](https://github.com/sachetalva)   | Amazon      |
 | Sean Chittenden      | [sean-](https://github.com/sean-)             | CrowdStrike |
 | Thomas Farr          | [Xtansia](https://github.com/Xtansia)         | Independent |
-| Torekeldi Niyazbek   | [Tokesh](https://github.com/Tokesh)           |             |
 | Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |
 | Xi Lu                | [lucy66hw](https://github.com/lucy66hw)       | Uber        |
 
@@ -28,3 +27,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Daniel Doubrovkine | [dblock](https://github.com/dblock)     | Independent |
 | Pranav Garg        | [pgtgrly](https://github.com/pgtgrly)   | Amazon      |
 | Theo Truong        | [nhtruong](https://github.com/nhtruong) | Independent |
+| Torekeldi Niyazbek   | [Tokesh](https://github.com/Tokesh)           |             |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 ## Current Maintainers
 
 | Maintainer           | GitHub ID                                     | Affiliation |
-|----------------------|-----------------------------------------------|-------------|
+| -------------------- | --------------------------------------------- | ----------- |
 | Alen Abeshov         | [aabeshov](https://github.com/aabeshov)       |             |
 | Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
 | Karen Xu             | [karenyrx](https://github.com/karenyrx)       | Uber        |
@@ -18,7 +18,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |
 | Xi Lu                | [lucy66hw](https://github.com/lucy66hw)       | Uber        |
 
-
 ## Emeritus
 
 | Maintainer         | GitHub ID                               | Affiliation |
@@ -27,4 +26,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Daniel Doubrovkine | [dblock](https://github.com/dblock)     | Independent |
 | Pranav Garg        | [pgtgrly](https://github.com/pgtgrly)   | Amazon      |
 | Theo Truong        | [nhtruong](https://github.com/nhtruong) | Independent |
-| Torekeldi Niyazbek   | [Tokesh](https://github.com/Tokesh)           |             |
+| Torekeldi Niyazbek | [Tokesh](https://github.com/Tokesh)     |             |


### PR DESCRIPTION
Hey @tokesh, we see you haven't used your maintainer privileges in the [past year](https://metrics.opensearch.org/_dashboards/app/dashboards?security_tenant=global#/view/30fedc30-9ae2-11ef-a168-f19b1bbc360c?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30d,to:now))&_a=(description:'Shows%20data%20about%20the%20activity%20of%20maintainers%20in%20the%20OpenSearch%20Project(since%2010-12-24,%20and%20the%20technical-steering%20repo%20since%2011-7-24).%20',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Maintainer%20Dashboard',viewMode:view)) for this repo. 
If you plan on continuing to contribute, please respond here and close this PR. Otherwise, per our [inactivity policy](https://github.com/opensearch-project/technical-steering/blob/main/policies/RESPONSIBILITIES.md#inactivity) you'll be moved to emeritus, but you can move back to active status at any time.