### PR TITLE
Add false_allow_templates to DynamicMapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `query` to TermsLookup to support terms lookup by query
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
+- Added `false_allow_templates` to `DynamicMapping` ([#1178](https://github.com/opensearch-project/opensearch-api-specification/pull/1178))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/schemas/_common.mapping.yaml
+++ b/spec/schemas/_common.mapping.yaml
@@ -86,6 +86,7 @@ components:
         - type: string
           enum:
             - 'false'
+            - false_allow_templates
             - strict
             - strict_allow_templates
             - 'true'

--- a/tests/default/indices/mapping/mapping.yaml
+++ b/tests/default/indices/mapping/mapping.yaml
@@ -148,3 +148,21 @@ chapters:
       status: 200
       payload:
         acknowledged: true
+  - synopsis: Update mapping for an index with setting dynamic to `false_allow_templates`.
+    version: '>= 3.3'
+    path: /{index}/_mapping
+    method: PUT
+    parameters:
+      index: movies
+      allow_no_indices: true
+      expand_wildcards: all
+      ignore_unavailable: true
+      timeout: 10s
+      write_index_only: true
+    request:
+      payload:
+        dynamic: false_allow_templates
+    response:
+      status: 200
+      payload:
+        acknowledged: true


### PR DESCRIPTION
### Description

Adds the `false_allow_templates` value to the `DynamicMapping` schema.

OpenSearch's `dynamic` mapping parameter accepts `false_allow_templates` (new fields are only indexed when they match a dynamic template, otherwise they are not indexed), but the spec's `DynamicMapping` enum was missing it — it only listed `false`, `strict`, `strict_allow_templates`, `true`, and boolean. As a result, generated clients reject the value at the type level even though it works at runtime.

The value was introduced in OpenSearch 3.3.0 (opensearch-project/OpenSearch#19065), so the added integration test case is gated with `version: '>= 3.3'`, mirroring the existing `strict_allow_templates` case.

Reported downstream in the JS client: <!-- link the opensearch-js issue here -->.

### Issues Resolved

Fixes the missing `false_allow_templates` value in `DynamicMapping`.

### Changes

- `spec/schemas/_common.mapping.yaml`: add `false_allow_templates` to the `DynamicMapping` string enum.
- `tests/default/indices/mapping/mapping.yaml`: add an integration test setting `dynamic: false_allow_templates` (gated `>= 3.3`).
- `CHANGELOG.md`: changelog entry.

### Check List

- [x] All tests pass (`npm run lint:spec` passes; `npm run merge` succeeds and the bundled spec includes the value).
- [x] Updated the CHANGELOG.
- [ ] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
