### PR TITLE
fix: Allow to tag non-exhaustive union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `query` to TermsLookup to support terms lookup by query
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
+- Added `x-non-exhaustive` vendor extension to mark plugin-extensible union types (`Property`, `Analyzer`, `TokenizerDefinition`, `TokenFilterDefinition`, `CharFilterDefinition`, `QueryContainer`, `SpanQuery`, `AggregationContainer`, `ProcessorContainer`, `FieldSuggester`)
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
 - Added `sltr` to query DSL schema  ([#1187](https://github.com/opensearch-project/opensearch-api-specification/pull/1187))
 - Added spec for the experimental `indices.modify_data_stream` API and the `attach_to_data_stream` restore snapshot body field ([#1176](https://github.com/opensearch-project/opensearch-api-specification/issues/1176))
+- Added `x-non-exhaustive` vendor extension to mark plugin-extensible union types (`Property`, `Analyzer`, `TokenizerDefinition`, `TokenFilterDefinition`, `CharFilterDefinition`, `QueryContainer`, `SpanQuery`, `AggregationContainer`, `ProcessorContainer`, `FieldSuggester`)
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -144,6 +144,7 @@ This repository includes several OpenAPI Specification Extensions to fill in any
 - `x-default`: Contains the default value of a parameter. This is often used to override the default value specified in the schema, or to avoid accidentally changing the default value when updating a shared schema.
 - `x-distributions-included`: Contains a list of distributions known to include the API.
 - `x-distributions-excluded`: Contains a list of distributions known to exclude the API.
+- `x-non-exhaustive`: Denotes that a discriminated union (tagged type) is non-exhaustive, meaning plugins can register additional variants at runtime. Code generators should treat these unions as open/extensible.
 
 Use `opensearch.org` for the official distribution in `x-distributions-*`, `amazon-managed` for Amazon Managed OpenSearch, and `amazon-serverless` for Amazon OpenSearch Serverless.
 

--- a/spec/schemas/_common.aggregations.yaml
+++ b/spec/schemas/_common.aggregations.yaml
@@ -1425,6 +1425,7 @@ components:
         - skewness
         - variance
     AggregationContainer:
+      x-non-exhaustive: true
       allOf:
         - $ref: '#/components/schemas/Aggregation'
         - type: object

--- a/spec/schemas/_common.analysis.yaml
+++ b/spec/schemas/_common.analysis.yaml
@@ -8,6 +8,7 @@ components:
   schemas:
     Analyzer:
       type: object
+      x-non-exhaustive: true
       discriminator:
         propertyName: type
       oneOf:
@@ -401,6 +402,7 @@ components:
           $ref: '#/components/schemas/CharFilterDefinition'
     CharFilterDefinition:
       type: object
+      x-non-exhaustive: true
       discriminator:
         propertyName: type
       oneOf:
@@ -500,6 +502,7 @@ components:
           $ref: '#/components/schemas/TokenFilterDefinition'
     TokenFilterDefinition:
       type: object
+      x-non-exhaustive: true
       discriminator:
         propertyName: type
       oneOf:
@@ -1586,6 +1589,7 @@ components:
           $ref: '#/components/schemas/TokenizerDefinition'
     TokenizerDefinition:
       type: object
+      x-non-exhaustive: true
       discriminator:
         propertyName: type
       oneOf:

--- a/spec/schemas/_common.mapping.yaml
+++ b/spec/schemas/_common.mapping.yaml
@@ -159,6 +159,7 @@ components:
         - xy_shape
     Property:
       type: object
+      x-non-exhaustive: true
       discriminator:
         propertyName: type
         x-default: object

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -17,6 +17,7 @@ components:
         # eslint-enable yml/sort-sequence-values
     QueryContainer:
       type: object
+      x-non-exhaustive: true
       properties:
         agentic:
           $ref: '#/components/schemas/AgenticQuery'
@@ -1951,6 +1952,7 @@ components:
             - little
     SpanQuery:
       type: object
+      x-non-exhaustive: true
       properties:
         span_containing:
           $ref: '#/components/schemas/SpanContainingQuery'

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -17,6 +17,7 @@ components:
         # eslint-enable yml/sort-sequence-values
     QueryContainer:
       type: object
+      x-non-exhaustive: true
       properties:
         agentic:
           $ref: '#/components/schemas/AgenticQuery'
@@ -2011,6 +2012,7 @@ components:
             - little
     SpanQuery:
       type: object
+      x-non-exhaustive: true
       properties:
         span_containing:
           $ref: '#/components/schemas/SpanContainingQuery'

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -1039,6 +1039,7 @@ components:
         description: The named suggesters.
         $ref: '#/components/schemas/FieldSuggester'
     FieldSuggester:
+      x-non-exhaustive: true
       allOf:
         - type: object
           properties:

--- a/spec/schemas/ingest._common.yaml
+++ b/spec/schemas/ingest._common.yaml
@@ -30,6 +30,7 @@ components:
           $ref: '_common.yaml#/components/schemas/Metadata'
     ProcessorContainer:
       type: object
+      x-non-exhaustive: true
       properties:
         attachment:
           $ref: '#/components/schemas/AttachmentProcessor'

--- a/tools/src/linter/SchemasValidator.ts
+++ b/tools/src/linter/SchemasValidator.ts
@@ -24,7 +24,8 @@ const ADDITIONAL_KEYWORDS = [
   'x-protobuf-excluded',
   'x-protobuf-data-type',
   'x-protobuf-name',
-  'x-protobuf-required'
+  'x-protobuf-required',
+  'x-non-exhaustive'
 ]
 
 export default class SchemasValidator {

--- a/tools/src/tester/SchemaValidator.ts
+++ b/tools/src/tester/SchemaValidator.ts
@@ -27,7 +27,8 @@ const ADDITIONAL_KEYWORDS = [
   'x-protobuf-excluded',
   'x-protobuf-data-type',
   'x-protobuf-name',
-  'x-protobuf-required'
+  'x-protobuf-required',
+  'x-non-exhaustive'
 ]
 
 export default class SchemaValidator {


### PR DESCRIPTION
## Description

Add a new `x-non-exhaustive` OpenAPI vendor extension that marks discriminated union (tagged) types as non-exhaustive. Union types are considered "non-exhaustive" when they can be extended through plugins at runtime — code generators should treat these unions as open/extensible rather than sealed.

## Changes

- **New vendor extension**: Introduced `x-non-exhaustive: true` annotation on the following plugin-extensible union schemas:
  - `Property` (`_common.mapping.yaml`)
  - `Analyzer`, `TokenizerDefinition`, `TokenFilterDefinition`, `CharFilterDefinition` (`_common.analysis.yaml`)
  - `QueryContainer`, `SpanQuery` (`_common.query_dsl.yaml`)
  - `AggregationContainer` (`_common.aggregations.yaml`)
  - `ProcessorContainer` (`ingest._common.yaml`)
  - `FieldSuggester` (`_core.search.yaml`)

- **Linter/Tester updates**: Registered `x-non-exhaustive` as a recognized additional keyword in both `SchemasValidator.ts` and `SchemaValidator.ts` to prevent unknown-keyword lint errors.

- **Documentation**: Added `x-non-exhaustive` to the vendor extensions section of `DEVELOPER_GUIDE.md`.

- **Changelog**: Documented the addition under the "Added" section.

## Motivation

Generators (e.g. opensearch-java) need a way to know which union types are open to extension so they can emit appropriate code — such as an "custom" variant or a custom deserialization fallback — rather than failing on unrecognized discriminator values introduced by plugins.

## Related Issues

- [[opensearch-project/opensearch-java#2083](https://github.com/opensearch-project/opensearch-java/issues/2083)](https://github.com/opensearch-project/opensearch-java/issues/2083)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
