### PR TITLE
Add `sltr` to query DSL schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `query` to TermsLookup to support terms lookup by query
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
+- Added `sltr` to query DSL schema  ([#1187](https://github.com/opensearch-project/opensearch-api-specification/pull/1187))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -1962,6 +1962,8 @@ components:
           additionalProperties: true
         store:
           type: string
+      required:
+        - params
     SpanContainingQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -189,6 +189,8 @@ components:
           $ref: '#/components/schemas/ScriptScoreQuery'
         simple_query_string:
           $ref: '#/components/schemas/SimpleQueryStringQuery'
+        sltr:
+          $ref: '#/components/schemas/StoredLtrQuery'
         span_containing:
           $ref: '#/components/schemas/SpanContainingQuery'
         field_masking_span:
@@ -1937,6 +1939,29 @@ components:
         - PREFIX
         - SLOP
         - WHITESPACE
+    StoredLtrQuery:
+      type: object
+      properties:
+        _name:
+          type: string
+        active_features:
+          type: array
+          items:
+            type: string
+        boost:
+          type: number
+          format: float
+        cache:
+          type: boolean
+        featureset:
+          type: string
+        model:
+          type: string
+        params:
+          type: object
+          additionalProperties: true
+        store:
+          type: string
     SpanContainingQuery:
       allOf:
         - $ref: '#/components/schemas/QueryBase'

--- a/tests/default/ltr/sltr_query.yaml
+++ b/tests/default/ltr/sltr_query.yaml
@@ -1,0 +1,122 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Validate the sltr (StoredLtrQuery) search query schema.
+warnings:
+  invalid-path-detected: false
+version: '>= 2.17.1'
+
+prologues:
+  - path: /_ltr
+    method: PUT
+  - path: /test_ltr
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            title:
+              type: text
+            overview:
+              type: text
+            popularity:
+              type: float
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {index: {_index: test_ltr, _id: '1'}}
+        - {title: Rambo, overview: John Rambo returns, popularity: 8.5}
+        - {index: {_index: test_ltr, _id: '2'}}
+        - {title: Rocky, overview: A boxer named Rocky, popularity: 7.2}
+        - {index: {_index: test_ltr, _id: '3'}}
+        - {title: First Blood Rambo, overview: Rambo action film, popularity: 9.1}
+  - path: /_ltr/_featureset/{name}
+    method: POST
+    parameters:
+      name: movie_features
+    request:
+      payload:
+        featureset:
+          name: movie_features
+          features:
+            - name: title_match
+              params: [keywords]
+              template_language: mustache
+              template:
+                match:
+                  title: '{{keywords}}'
+            - name: overview_match
+              params: [keywords]
+              template_language: mustache
+              template:
+                match:
+                  overview: '{{keywords}}'
+            - name: popularity
+              params: []
+              template_language: mustache
+              template:
+                function_score:
+                  functions:
+                    - field_value_factor:
+                        field: popularity
+                        missing: 0
+                  query:
+                    match_all: {}
+
+epilogues:
+  - path: /test_ltr
+    method: DELETE
+    status: [200, 404]
+  - path: /_ltr
+    method: DELETE
+    status: [200, 404]
+
+chapters:
+  - synopsis: Search with an sltr query in the main query body, referencing a feature set.
+    path: /{index}/_search
+    method: POST
+    parameters:
+      index: test_ltr
+    request:
+      payload:
+        query:
+          bool:
+            should:
+              - match:
+                  title: rambo
+              - sltr:
+                  _name: logged_featureset
+                  featureset: movie_features
+                  params:
+                    keywords: rambo
+    response:
+      status: 200
+
+  - synopsis: Search with an sltr query in the rescore section with feature logging enabled.
+    path: /{index}/_search
+    method: POST
+    parameters:
+      index: test_ltr
+    request:
+      payload:
+        query:
+          match:
+            title: rambo
+        rescore:
+          window_size: 10
+          query:
+            rescore_query:
+              sltr:
+                featureset: movie_features
+                params:
+                  keywords: rambo
+        ext:
+          ltr_log:
+            log_specs:
+              - name: log_entry1
+                rescore_index: 0
+    response:
+      status: 200


### PR DESCRIPTION
### Description
Adds the `sltr` (Stored LTR) query to the query DSL schema to support LTR searches.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
