### PR TITLE
fix(ml): align predict_model request bodies with RemoteInferenceMLInput parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unused dependencies: `eslint-config-standard-with-typescript`, `eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-promise`, `@eslint/eslintrc`
 
 ### Fixed
+- Fixed `ml.predict_model` and `ml.predict_model_stream` request body schemas to match `RemoteInferenceMLInput` parser: corrected `parameters` type to `Map<String,String>`, removed incorrect `required` constraints, added `action_type`, `dlq`, `question`, and `context` fields, and added `PredictionActionType` enum ([#1188](https://github.com/opensearch-project/opensearch-api-specification/pull/1188))
 - Fixed stale and malformed OpenSearch documentation links in spec `externalDocs` and schema descriptions ([#1163](https://github.com/opensearch-project/opensearch-api-specification/pull/1163))
 - Fixed `DeletedPit` to mark `pit_id` and `successful` as required ([#1146](https://github.com/opensearch-project/opensearch-api-specification/pull/1146))
 - Fixed `HitsMetadata` to mark `max_score` as required ([#1103](https://github.com/opensearch-project/opensearch-api-specification/pull/1103))

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -1347,7 +1347,7 @@ components:
                 type: object
                 additionalProperties:
                   type: string
-                description: The parameters to pass to the model. Used by remote connector models; connector request_body template variables (e.g. ${parameters.inputText}) are filled from this map.
+                description: The parameters to pass to the model. Used by remote connector models to fill the connector request_body template variables from this map.
               action_type:
                 $ref: '../schemas/ml._common.yaml#/components/schemas/PredictionActionType'
                 description: Overrides the action type derived from the request path. Used for remote connector models.

--- a/spec/namespaces/ml.yaml
+++ b/spec/namespaces/ml.yaml
@@ -1343,27 +1343,52 @@ components:
           schema:
             type: object
             properties:
-              query_text:
-                type: string
-                description: The query text.
+              parameters:
+                type: object
+                additionalProperties:
+                  type: string
+                description: The parameters to pass to the model. Used by remote connector models; connector request_body template variables (e.g. ${parameters.inputText}) are filled from this map.
+              action_type:
+                $ref: '../schemas/ml._common.yaml#/components/schemas/PredictionActionType'
+                description: Overrides the action type derived from the request path. Used for remote connector models.
+              dlq:
+                type: object
+                additionalProperties:
+                  type: string
+                description: Dead-letter queue configuration for batch predict on remote connector models (since OpenSearch 2.19).
               text_docs:
                 type: array
                 items:
                   type: string
-                description: The text documents.
-            required:
-              - text_docs
+                description: The text documents. Used by local text-embedding and sparse-encoding models.
+              query_text:
+                type: string
+                description: The query text. Used by local text-similarity models.
+              question:
+                type: string
+                description: The question input. Used by local question-answering models.
+              context:
+                type: string
+                description: The context input. Used by local question-answering models.
     ml.predict_model_stream:
       content:
         application/json:
           schema:
             type: object
-            title: MLPredictModelStreamRequestBody
             properties:
               parameters:
-                $ref: '../schemas/ml._common.yaml#/components/schemas/Parameters'
-            required:
-              - parameters
+                type: object
+                additionalProperties:
+                  type: string
+                description: The parameters to pass to the remote connector model.
+              action_type:
+                $ref: '../schemas/ml._common.yaml#/components/schemas/PredictionActionType'
+                description: Overrides the action type derived from the request path.
+              dlq:
+                type: object
+                additionalProperties:
+                  type: string
+                description: Dead-letter queue configuration for batch predict on remote connector models.
     ml.search_tasks:
       content:
         application/json:

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -1690,11 +1690,11 @@ components:
       type: string
       description: The action type for model prediction.
       enum:
-        - predict
-        - execute
         - batch_predict
-        - cancel_batch_predict
         - batch_predict_status
+        - cancel_batch_predict
+        - execute
+        - predict
     PayloadType:
       type: string
       description: The type of payload.

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -1686,6 +1686,15 @@ components:
         - ADD
         - DELETE
         - UPDATE
+    PredictionActionType:
+      type: string
+      description: The action type for model prediction.
+      enum:
+        - predict
+        - execute
+        - batch_predict
+        - cancel_batch_predict
+        - batch_predict_status
     PayloadType:
       type: string
       description: The type of payload.


### PR DESCRIPTION
### Description

Fixes the `ml.predict_model` and `ml.predict_model_stream` request body schemas to accurately reflect what the ml-commons server-side Java code actually parses.

### Root Cause

Both endpoints route through `RestMLPredictionAction.getRequest()` → `MLInput.parse()` → `RemoteInferenceMLInput` for REMOTE connector models. That parser only reads three fields — `parameters`, `action_type`, `dlq` — and silently skips everything else via `parser.skipChildren()`.

The previous spec had `text_docs` as the only field with `required: [text_docs]`, which is wrong for REMOTE connector models where `text_docs` is always ignored.

### Changes

**`spec/namespaces/ml.yaml`**

`ml.predict_model`:
- Remove incorrect `required: [text_docs]`
- Add `parameters` (`Map<String,String>`) — primary input for remote connector models; fills connector `request_body` template variables
- Add `action_type` (`PredictionActionType`) — overrides the action derived from the request path
- Add `dlq` (`Map<String,String>`) — dead-letter queue config for batch predict on remote connectors (since 2.19)
- Add `question` and `context` — used by local question-answering models
- Keep `text_docs` and `query_text` with corrected descriptions

`ml.predict_model_stream`:
- Remove incorrect `required: [parameters]`
- Change `parameters` from `$ref: Parameters` to `Map<String,String>`
- Add `action_type` and `dlq`

**`spec/schemas/ml._common.yaml`**

- Add `PredictionActionType` enum: `predict`, `execute`, `batch_predict`, `cancel_batch_predict`, `batch_predict_status` — matching `ConnectorAction.ActionType` in ml-commons (parsed case-insensitively; lowercase form matches the connector blueprints in `docs/remote_inference_blueprints/`)

### Source Code References

- [`RemoteInferenceMLInput.java`](https://github.com/opensearch-project/ml-commons/blob/main/common/src/main/java/org/opensearch/ml/common/input/remote/RemoteInferenceMLInput.java) — only parses `parameters`, `action_type`, `dlq`; all other fields hit `default: parser.skipChildren()`
- [`StringUtils.getParameterMap`](https://github.com/opensearch-project/ml-commons/blob/main/common/src/main/java/org/opensearch/ml/common/utils/StringUtils.java) — converts `Map<String,?>` to `Map<String,String>`
- [`ConnectorAction.ActionType`](https://github.com/opensearch-project/ml-commons/blob/main/common/src/main/java/org/opensearch/ml/common/connector/ConnectorAction.java) — source of the `PredictionActionType` enum values

### Testing

Existing integration test `tests/plugins/ml/ml/models/predict.yaml` exercises `ml.predict_model` against a local `sentence-transformers` model using `query_text` + `text_docs`, and continues to pass — request/response are schema-validated against the updated (now all-optional) body.

The remote-connector fields (`parameters`, `action_type`, `dlq`) and `ml.predict_model_stream` are **not** covered by the integration suite: the `RemoteInferenceMLInput` path only applies to REMOTE connector models, which require external provider credentials (Bedrock/OpenAI/SageMaker) and cannot run against the local CI cluster. Streaming predict has the same constraint. These schema changes are therefore verified against the server source (see references above) rather than by live remote-model tests.

### Check List

- [x] Updated the CHANGELOG.
- [x] All tests pass (unrelated pre-existing flakes in `plugins/ml` model-deploy prologue and `plugins/security` `_core/settings` also fail on `main`).
