### PR TITLE
Remove OpenSearch 2.0.0 from CI test matrix

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -27,8 +27,6 @@ jobs:
           # default test suite
           - version: 1.3.17
             admin_password: admin
-          - version: 2.0.0
-            admin_password: admin
           - version: 2.19.2
           - version: 3.1.0
           # TODO: Uncomment when a more complete 3.2.0 staging build is available. At time of writing, several plugins are missing from the distribution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))
 
 ### Removed
+- Removed OpenSearch 2.0.0 from CI test matrix; incompatible with modern GitHub Actions runners due to JDK cgroup v2 crash ([#1189](https://github.com/opensearch-project/opensearch-api-specification/pull/1189))
 - Remove unused cardinality aggregation execution hints - save_memory_heuristic/save_time_heuristic/segment_ordinals ([#970](https://github.com/opensearch-project/opensearch-api-specification/pull/970))
 - Remove unsupported `PinnedQuery` and mark x-version-deprecated to field `cutoff_frequency` in `MultiMatchQuery` ([#1000](https://github.com/opensearch-project/opensearch-api-specification/pull/1000))
 - Remove `force` from `VersionType` ([#1017](https://github.com/opensearch-project/opensearch-api-specification/pull/1017))


### PR DESCRIPTION
### Description

OpenSearch 2.0.0 Docker image consistently crashes on modern GitHub Actions runners (Ubuntu 24.04) due to a JDK/cgroup v2 incompatibility.

### Root Cause

The `opensearchproject/opensearch:2.0.0` Docker image bundles **OpenJDK 17.0.3 (Temurin-17.0.3+7)**:

```
openjdk version "17.0.3" 2022-04-19
OpenJDK Runtime Environment Temurin-17.0.3+7 (build 17.0.3+7)
OpenJDK 64-Bit Server VM Temurin-17.0.3+7 (build 17.0.3+7, mixed mode, sharing)
```

This JDK version has a known bug in `CgroupV2Subsystem.getInstance()` where the cgroup controller resolution returns null on certain cgroup v2 unified hierarchy layouts ([JDK-8287107](https://bugs.openjdk.org/browse/JDK-8287107), fixed in JDK 17.0.5+).

When GitHub Actions runners upgraded from Ubuntu 22.04 to 24.04, the host switched to cgroup v2 unified hierarchy, triggering this bug inside the container:

```
fatal error in thread [main], exiting
java.lang.ExceptionInInitializerError
    at org.opensearch.bootstrap.Bootstrap.initializeProbes(Bootstrap.java:179)
    at org.opensearch.bootstrap.Bootstrap.setup(Bootstrap.java:201)
    at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:414)
    ...
Caused by: java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
    at jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:80)
    at jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:114)
    at jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:177)
    at jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
    at jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
    at jdk.internal.platform.Container.metrics(Container.java:43)
    at com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
    ...
    at org.opensearch.monitor.process.ProcessProbe.<clinit>(ProcessProbe.java:51)
OpenSearch exited with code 1
```

See [example CI run](https://github.com/opensearch-project/opensearch-api-specification/actions/runs/31370201848/job/93397239311).

### Why this can't be fixed in the image

OpenSearch 2.0.0 is EOL (released May 2022, last patch 2.0.1). The Docker image will never be rebuilt with a newer JDK. The only options are:
1. Remove from CI matrix (this PR)
2. Pin runners to Ubuntu 22.04 (fragile, delays adopting newer runners)

### Fix

Remove `version: 2.0.0` from the CI test matrix. Coverage is maintained:
- **1.x line**: covered by `1.3.17` (passes)
- **2.x line**: covered by `2.19.2` (passes)
- **3.x line**: covered by `3.1.0` (passes)

### Testing

This eliminates a persistent false-positive CI failure that affects all PRs.