### PR TITLE
remove incorrect model_id from SearchHitsHit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Removed unused dependencies: `eslint-config-standard-with-typescript`, `eslint-plugin-import`, `eslint-plugin-n`, `eslint-plugin-promise`, `@eslint/eslintrc`
 
 ### Fixed
+- Removed incorrect `model_id` from ML `SearchHitsHit`; ML search APIs return a standard search hit and the document ID is `_id` ([#1180](https://github.com/opensearch-project/opensearch-api-specification/issues/1180))
 - Fixed `ml.predict_model` and `ml.predict_model_stream` request body schemas to match `RemoteInferenceMLInput` parser: corrected `parameters` type to `Map<String,String>`, removed incorrect `required` constraints, added `action_type`, `dlq`, `question`, and `context` fields, and added `PredictionActionType` enum ([#1188](https://github.com/opensearch-project/opensearch-api-specification/pull/1188))
 - Fixed stale and malformed OpenSearch documentation links in spec `externalDocs` and schema descriptions ([#1163](https://github.com/opensearch-project/opensearch-api-specification/pull/1163))
 - Fixed `DeletedPit` to mark `pit_id` and `successful` as required ([#1146](https://github.com/opensearch-project/opensearch-api-specification/pull/1146))

--- a/spec/schemas/ml._common.yaml
+++ b/spec/schemas/ml._common.yaml
@@ -72,8 +72,6 @@ components:
           description: The score.
         _source:
           $ref: '#/components/schemas/Source'
-        model_id:
-          $ref: '_common.yaml#/components/schemas/Name'
         sort:
           type: array
           items:


### PR DESCRIPTION
Removes model_id from the ML SearchHitsHit schema. ML search APIs (/_plugins/_ml/models/_search, /_plugins/_ml/agents/_search, /_plugins/_ml/tasks/_search, /_plugins/_ml/model_groups/_search, etc.) return a standard OpenSearch SearchResponse. The document ID is _id; there is no top-level model_id on the hit.

Fixes #1180.

SearchModelTransportAction (and the other ML search handlers) delegate to MLSearchHandler.search(), which returns a normal SearchResponse. No custom field is injected onto the hit.

The spec still declared model_id as a sibling of _id / _source on SearchHitsHit. That made generated clients (see opensearch-js#1032 (https://github.com/opensearch-project/opensearch-js/issues/1032)) expose hit.model_id, which is always undefined at runtime.

model_id is valid inside _source for some ML documents (e.g. model chunks). That field stays on the Source schema.