### PR TITLE
fix(ci): replace unmaintained release action to unblock main-latest publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,11 @@ jobs:
 
       - name: Release Specification to GitHub
         id: release
-        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # v1.2.1
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: ${{ steps.branch.outputs.name }}-latest
+          tag_name: ${{ steps.branch.outputs.name }}-latest
           prerelease: true
-          title: OpenSearch OpenAPI Spec (${{ steps.branch.outputs.name }})
+          name: OpenSearch OpenAPI Spec (${{ steps.branch.outputs.name }})
           files: |
             LICENSE.txt
             build/*


### PR DESCRIPTION
## Summary

The `Build and Publish Spec` workflow fails at the release step with:

```
Repository rule violations found
Cannot update this protected ref.
```

Root cause: the org recently added a tag-protection ruleset (`global_block_tags_creation_update_deletion_forcepush_minusTagCreationRepo`) that blocks all tag creation/update/deletion/force-push repo-wide, with no bypass actors configured. `marvinpinto/action-automatic-releases@v1.2.1` (unmaintained since 2020) deletes and recreates the `main-latest` git tag on every push to `main` so it always points at the latest commit — that ref mutation now violates the ruleset.

## Fix

Replace it with `softprops/action-gh-release@v3.0.2` (actively maintained). When a release already exists for a given tag — as `main-latest` does — this action updates the existing release's body/assets via the REST API and never creates, moves, or deletes the underlying tag ref. This satisfies the new ruleset while keeping the `main-latest` release and its assets (`opensearch-openapi.yaml`) refreshed on every push to `main`, which downstream consumers like `opensearch-protobufs`, `opensearch-php`, and `opensearch-py` depend on via the stable download URL `releases/download/main-latest/opensearch-openapi.yaml`.

Fixes #1144

## Test plan

- [ ] CI run of `Build and Publish Spec` on this branch completes the `Release Specification to GitHub` step without a `Repository rule violations found` error
- [ ] `main-latest` release's `opensearch-openapi.yaml` asset is updated after merge to `main`
- [ ] Downstream consumers (`opensearch-protobufs`, `opensearch-php`, `opensearch-py`) can still fetch the artifact from the unchanged download URL