### PR TITLE
add html_strip, copy, fingerprint, community_id, and remove_by_pattern processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Added `html_strip`, `copy`, `fingerprint`, `community_id`, and `remove_by_pattern` ingest processor schemas to `ProcessorContainer`, and `_type` on ingest simulate `DocumentSimulation` for OpenSearch 1.x
 - Added `sparse_encoding`, `text_image_embedding`, and `text_chunking` ingest processor schemas with `ChunkingAlgorithm` (`fixed_token_length`, `delimiter`) support, and `neural_sparse` query DSL ([#1191](https://github.com/opensearch-project/opensearch-api-specification/pull/1191))
 - Added apis for searching within search relevance objects such as search configurations, judgments, query sets, and experiments ([#1064](https://github.com/opensearch-project/opensearch-api-specification/pull/1064))
 - Added remaining APIs for LTR including store element operations, model management, feature set operations, routing support, and POST support for update operations ([#935](https://github.com/opensearch-project/opensearch-api-specification/pull/935))

--- a/spec/schemas/ingest._common.yaml
+++ b/spec/schemas/ingest._common.yaml
@@ -39,6 +39,8 @@ components:
           $ref: '#/components/schemas/CsvProcessor'
         convert:
           $ref: '#/components/schemas/ConvertProcessor'
+        copy:
+          $ref: '#/components/schemas/CopyProcessor'
         date:
           $ref: '#/components/schemas/DateProcessor'
         date_index_name:
@@ -47,6 +49,8 @@ components:
           $ref: '#/components/schemas/DotExpanderProcessor'
         fail:
           $ref: '#/components/schemas/FailProcessor'
+        fingerprint:
+          $ref: '#/components/schemas/FingerprintProcessor'
         foreach:
           $ref: '#/components/schemas/ForeachProcessor'
         json:
@@ -61,12 +65,16 @@ components:
           $ref: '#/components/schemas/GrokProcessor'
         gsub:
           $ref: '#/components/schemas/GsubProcessor'
+        html_strip:
+          $ref: '#/components/schemas/HtmlStripProcessor'
         join:
           $ref: '#/components/schemas/JoinProcessor'
         lowercase:
           $ref: '#/components/schemas/LowercaseProcessor'
         remove:
           $ref: '#/components/schemas/RemoveProcessor'
+        remove_by_pattern:
+          $ref: '#/components/schemas/RemoveByPatternProcessor'
         rename:
           $ref: '#/components/schemas/RenameProcessor'
         script:
@@ -95,6 +103,8 @@ components:
           $ref: '#/components/schemas/DropProcessor'
         circle:
           $ref: '#/components/schemas/CircleProcessor'
+        community_id:
+          $ref: '#/components/schemas/CommunityIdProcessor'
         text_embedding:
           $ref: '#/components/schemas/TextEmbeddingProcessor'
         sparse_encoding:
@@ -892,3 +902,196 @@ components:
         max_chunk_limit:
           type: integer
           format: int32
+    HtmlStripProcessor:
+      allOf:
+        - $ref: '#/components/schemas/ProcessorBase'
+        - type: object
+          properties:
+            field:
+              $ref: '_common.yaml#/components/schemas/Field'
+            ignore_missing:
+              description: If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
+              type: boolean
+            target_field:
+              $ref: '_common.yaml#/components/schemas/Field'
+          required:
+            - field
+    CopyProcessor:
+      allOf:
+        - $ref: '#/components/schemas/ProcessorBase'
+        - type: object
+          properties:
+            source_field:
+              description: The field to copy. Supports template snippets.
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            target_field:
+              description: The field to copy to. Supports template snippets.
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            ignore_missing:
+              description: If `true` and `source_field` does not exist or is `null`, the processor quietly exits without modifying the document.
+              type: boolean
+            override_target:
+              description: If `true`, the processor overwrites `target_field` when it already exists.
+              type: boolean
+            remove_source:
+              description: If `true`, the processor removes `source_field` after copying it.
+              type: boolean
+          required:
+            - source_field
+            - target_field
+    FingerprintProcessor:
+      allOf:
+        - $ref: '#/components/schemas/ProcessorBase'
+        - type: object
+          properties:
+            fields:
+              description: |-
+                Fields used to generate the hash value.
+                Mutually exclusive with `exclude_fields`.
+                If both `fields` and `exclude_fields` are empty or omitted, all fields are included.
+              type: array
+              items:
+                $ref: '_common.yaml#/components/schemas/Field'
+            exclude_fields:
+              description: |-
+                Fields to exclude from hash value generation.
+                Mutually exclusive with `fields`.
+                If both `fields` and `exclude_fields` are empty or omitted, all fields are included.
+              type: array
+              items:
+                $ref: '_common.yaml#/components/schemas/Field'
+            hash_method:
+              $ref: '#/components/schemas/FingerprintHashMethod'
+            target_field:
+              $ref: '_common.yaml#/components/schemas/Field'
+            ignore_missing:
+              description: If `true` and a specified field is missing, the processor quietly skips that field.
+              type: boolean
+          not:
+            type: object
+            properties:
+              exclude_fields:
+                type: array
+              fields:
+                type: array
+            required:
+              - exclude_fields
+              - fields
+    FingerprintHashMethod:
+      description: Hashing algorithm used by the fingerprint processor. The version suffix keeps hashes stable across OpenSearch versions. Matching is case-insensitive; use the mixed-case `@2.16.0` spelling.
+      type: string
+      enum:
+        - MD5@2.16.0
+        - SHA-1@2.16.0
+        - SHA-256@2.16.0
+        - SHA3-256@2.16.0
+    CommunityIdProcessor:
+      allOf:
+        - $ref: '#/components/schemas/ProcessorBase'
+        - type: object
+          properties:
+            source_ip_field:
+              description: The name of the field containing the source IP address.
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            destination_ip_field:
+              description: The name of the field containing the destination IP address.
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            source_port_field:
+              description: The name of the field containing the source port. Required for `TCP`, `UDP`, and `SCTP`.
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            destination_port_field:
+              description: The name of the field containing the destination port. Required for `TCP`, `UDP`, and `SCTP`.
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            iana_protocol_number_field:
+              description: The name of the field containing the `IANA` protocol number. Supported values are 1 (`ICMP`), 6 (`TCP`), 17 (`UDP`), 58 (`IPv6-ICMP`), and 132 (`SCTP`).
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            protocol_field:
+              description: The name of the field containing the protocol name. Required when `iana_protocol_number_field` is not set.
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            icmp_type_field:
+              description: The name of the field containing the `ICMP` message type. Required when the protocol is `ICMP` or `IPv6-ICMP`.
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            icmp_code_field:
+              description: The name of the field containing the `ICMP` message code. Required for `ICMP` message types that include a code.
+              allOf:
+                - $ref: '_common.yaml#/components/schemas/Field'
+            seed:
+              description: The seed for generating the community ID hash. Must be between 0 and 65535.
+              type: integer
+              format: int32
+              minimum: 0
+              maximum: 65535
+            target_field:
+              $ref: '_common.yaml#/components/schemas/Field'
+            ignore_missing:
+              description: If `true` and a required field is missing, the processor quietly exits without modifying the document.
+              type: boolean
+          required:
+            - destination_ip_field
+            - source_ip_field
+    FieldPattern:
+      description: A wildcard pattern, or a list of patterns, matching root-level field names.
+      oneOf:
+        - $ref: '_common.yaml#/components/schemas/Field'
+        - type: array
+          items:
+            $ref: '_common.yaml#/components/schemas/Field'
+    RemoveByPatternProcessor:
+      allOf:
+        - $ref: '#/components/schemas/ProcessorBase'
+        - type: object
+          properties:
+            field_pattern:
+              description: |-
+                Removes root-level fields that match the specified wildcard pattern or list of patterns.
+                Metadata fields such as `_index`, `_id`, `_version`, and `_version_type` are ignored.
+                Mutually exclusive with `exclude_field_pattern`.
+              allOf:
+                - $ref: '#/components/schemas/FieldPattern'
+            exclude_field_pattern:
+              description: |-
+                Removes root-level fields that do not match the specified wildcard pattern or list of patterns.
+                Metadata fields such as `_index`, `_id`, `_version`, and `_version_type` are ignored.
+                Mutually exclusive with `field_pattern`.
+              allOf:
+                - $ref: '#/components/schemas/FieldPattern'
+          oneOf:
+            - type: object
+              properties:
+                exclude_field_pattern:
+                  $ref: '#/components/schemas/FieldPattern'
+                field_pattern:
+                  $ref: '#/components/schemas/FieldPattern'
+              required:
+                - field_pattern
+              not:
+                type: object
+                properties:
+                  exclude_field_pattern:
+                    $ref: '#/components/schemas/FieldPattern'
+                required:
+                  - exclude_field_pattern
+            - type: object
+              properties:
+                exclude_field_pattern:
+                  $ref: '#/components/schemas/FieldPattern'
+                field_pattern:
+                  $ref: '#/components/schemas/FieldPattern'
+              required:
+                - exclude_field_pattern
+              not:
+                type: object
+                properties:
+                  field_pattern:
+                    $ref: '#/components/schemas/FieldPattern'
+                required:
+                  - field_pattern

--- a/spec/schemas/ingest.simulate.yaml
+++ b/spec/schemas/ingest.simulate.yaml
@@ -39,6 +39,8 @@ components:
           $ref: '_common.yaml#/components/schemas/Id'
         _index:
           $ref: '_common.yaml#/components/schemas/IndexName'
+        _type:
+          $ref: '_common.yaml#/components/schemas/Type'
         _ingest:
           $ref: '#/components/schemas/Ingest'
         _routing:

--- a/tests/default/ingest/pipeline/core_processors.yaml
+++ b/tests/default/ingest/pipeline/core_processors.yaml
@@ -1,0 +1,315 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test html_strip, copy, fingerprint, community_id, and remove_by_pattern ingest processors.
+warnings:
+  invalid-path-detected: false
+  multiple-paths-detected: false
+epilogues:
+  - path: /_ingest/pipeline/html_strip_pipeline
+    method: DELETE
+    status: [200, 404]
+  - path: /_ingest/pipeline/copy_pipeline
+    method: DELETE
+    status: [200, 404]
+  - path: /_ingest/pipeline/remove_by_pattern_pipeline
+    method: DELETE
+    status: [200, 404]
+  - path: /_ingest/pipeline/community_id_pipeline
+    method: DELETE
+    status: [200, 404]
+  - path: /_ingest/pipeline/fingerprint_pipeline
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create an ingest pipeline with the html_strip processor.
+    path: /_ingest/pipeline/{id}
+    method: PUT
+    parameters:
+      id: html_strip_pipeline
+    request:
+      payload:
+        description: Strip HTML tags from the description field.
+        processors:
+          - html_strip:
+              field: description
+              target_field: cleaned_description
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Get the html_strip pipeline.
+    path: /_ingest/pipeline/{id}
+    method: GET
+    parameters:
+      id: html_strip_pipeline
+    response:
+      status: 200
+  - synopsis: Simulate the html_strip processor.
+    path: /_ingest/pipeline/{id}/_simulate
+    method: POST
+    parameters:
+      id: html_strip_pipeline
+    request:
+      payload:
+        docs:
+          - _id: '1'
+            _index: products
+            _source:
+              description: This is a <b>test</b> description with <i>some</i> HTML tags.
+    response:
+      status: 200
+      payload:
+        docs:
+          - doc:
+              _source:
+                cleaned_description: This is a test description with some HTML tags.
+                description: This is a <b>test</b> description with <i>some</i> HTML tags.
+  - synopsis: Create an ingest pipeline with the copy processor.
+    version: '>= 2.12'
+    path: /_ingest/pipeline/{id}
+    method: PUT
+    parameters:
+      id: copy_pipeline
+    request:
+      payload:
+        description: Copy a nested object to a top-level field.
+        processors:
+          - copy:
+              ignore_missing: true
+              source_field: message.content
+              target_field: content
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Get the copy pipeline.
+    version: '>= 2.12'
+    path: /_ingest/pipeline/{id}
+    method: GET
+    parameters:
+      id: copy_pipeline
+    response:
+      status: 200
+  - synopsis: Simulate the copy processor.
+    version: '>= 2.12'
+    path: /_ingest/pipeline/{id}/_simulate
+    method: POST
+    parameters:
+      id: copy_pipeline
+    request:
+      payload:
+        docs:
+          - _id: '1'
+            _index: testindex1
+            _source:
+              message:
+                content:
+                  foo: bar
+                  zoo:
+                    - 1
+                    - 2
+                    - 3
+    response:
+      status: 200
+      payload:
+        docs:
+          - doc:
+              _source:
+                content:
+                  foo: bar
+                  zoo:
+                    - 1
+                    - 2
+                    - 3
+                message:
+                  content:
+                    foo: bar
+                    zoo:
+                      - 1
+                      - 2
+                      - 3
+  - synopsis: Create an ingest pipeline with the remove_by_pattern processor.
+    version: '>= 2.12'
+    path: /_ingest/pipeline/{id}
+    method: PUT
+    parameters:
+      id: remove_by_pattern_pipeline
+    request:
+      payload:
+        description: Remove root-level fields matching a wildcard pattern.
+        processors:
+          - remove_by_pattern:
+              field_pattern: foo*
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Get the remove_by_pattern pipeline.
+    version: '>= 2.12'
+    path: /_ingest/pipeline/{id}
+    method: GET
+    parameters:
+      id: remove_by_pattern_pipeline
+    response:
+      status: 200
+  - synopsis: Simulate the remove_by_pattern processor.
+    version: '>= 2.12'
+    path: /_ingest/pipeline/{id}/_simulate
+    method: POST
+    parameters:
+      id: remove_by_pattern_pipeline
+    request:
+      payload:
+        docs:
+          - _id: '1'
+            _index: testindex1
+            _source:
+              bar: bar
+              foo1: foo1
+              foo2: foo2
+    response:
+      status: 200
+      payload:
+        docs:
+          - doc:
+              _source:
+                bar: bar
+  - synopsis: Create an ingest pipeline with remove_by_pattern exclude_field_pattern.
+    version: '>= 2.12'
+    path: /_ingest/pipeline/{id}
+    method: PUT
+    parameters:
+      id: remove_by_pattern_pipeline
+    request:
+      payload:
+        description: Keep only root-level fields matching a wildcard pattern.
+        processors:
+          - remove_by_pattern:
+              exclude_field_pattern: foo*
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Simulate the remove_by_pattern processor with exclude_field_pattern.
+    version: '>= 2.12'
+    path: /_ingest/pipeline/{id}/_simulate
+    method: POST
+    parameters:
+      id: remove_by_pattern_pipeline
+    request:
+      payload:
+        docs:
+          - _id: '1'
+            _index: testindex1
+            _source:
+              bar: bar
+              foo1: foo1
+              foo2: foo2
+    response:
+      status: 200
+      payload:
+        docs:
+          - doc:
+              _source:
+                foo1: foo1
+                foo2: foo2
+  - synopsis: Create an ingest pipeline with the community_id processor.
+    version: '>= 2.13'
+    path: /_ingest/pipeline/{id}
+    method: PUT
+    parameters:
+      id: community_id_pipeline
+    request:
+      payload:
+        description: Generate a community ID hash for a network flow tuple.
+        processors:
+          - community_id:
+              destination_ip_field: destination_ip
+              destination_port_field: destination_port
+              iana_protocol_number_field: iana_protocol_number
+              source_ip_field: source_ip
+              source_port_field: source_port
+              target_field: community_id
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Get the community_id pipeline.
+    version: '>= 2.13'
+    path: /_ingest/pipeline/{id}
+    method: GET
+    parameters:
+      id: community_id_pipeline
+    response:
+      status: 200
+  - synopsis: Simulate the community_id processor.
+    version: '>= 2.13'
+    path: /_ingest/pipeline/{id}/_simulate
+    method: POST
+    parameters:
+      id: community_id_pipeline
+    request:
+      payload:
+        docs:
+          - _id: '1'
+            _index: testindex1
+            _source:
+              destination_ip: 128.232.110.120
+              destination_port: 34855
+              iana_protocol_number: 6
+              source_ip: 66.35.250.204
+              source_port: 80
+    response:
+      status: 200
+      payload:
+        docs:
+          - doc:
+              _source:
+                community_id: '1:LQU9qZlK+B5F3KDmev6m5PMibrg='
+  - synopsis: Create an ingest pipeline with the fingerprint processor.
+    version: '>= 2.16'
+    path: /_ingest/pipeline/{id}
+    method: PUT
+    parameters:
+      id: fingerprint_pipeline
+    request:
+      payload:
+        description: Generate a hash value for specified fields.
+        processors:
+          - fingerprint:
+              fields:
+                - bar
+                - foo
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Get the fingerprint pipeline.
+    version: '>= 2.16'
+    path: /_ingest/pipeline/{id}
+    method: GET
+    parameters:
+      id: fingerprint_pipeline
+    response:
+      status: 200
+  - synopsis: Simulate the fingerprint processor.
+    version: '>= 2.16'
+    path: /_ingest/pipeline/{id}/_simulate
+    method: POST
+    parameters:
+      id: fingerprint_pipeline
+    request:
+      payload:
+        docs:
+          - _id: '1'
+            _index: testindex1
+            _source:
+              bar: bar
+              foo: foo
+    response:
+      status: 200
+      payload:
+        docs:
+          - doc:
+              _source:
+                fingerprint: 'SHA-1@2.16.0:fYeen7hTJ2zs9lpmUnk6nvH54sM='


### PR DESCRIPTION
Adds five ingest-common processors that were missing from `ProcessorContainer`, so generated clients can type pipelines the server already accepts.

| Processor | Since | Required |
| --- | --- | --- |
| `html_strip` | 1.0 | `field` |
| `copy` | 2.12 | `source_field`, `target_field` |
| `remove_by_pattern` | 2.12 | exactly one of `field_pattern` / `exclude_field_pattern` |
| `community_id` | 2.13 | `source_ip_field`, `destination_ip_field` |
| `fingerprint` | 2.16 | none (`fields` and `exclude_fields` are mutually exclusive) |

Field names follow ingest-common Java, not docs (community_id uses `iana_protocol_number_field`).

`html_strip` addresses https://github.com/opensearch-project/opensearch-api-specification/issues/880. The other four are later ingest-common processors not covered by https://github.com/opensearch-project/opensearch-api-specification/pull/1191.