### PR TITLE
Add data stream modify API and restore attach_to_data_stream field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
 - Added `sltr` to query DSL schema  ([#1187](https://github.com/opensearch-project/opensearch-api-specification/pull/1187))
+- Added `POST /_data_stream/_modify` (`indices.modify_data_stream`) and restore snapshot body field `attach_to_data_stream` ([#1213](https://github.com/opensearch-project/opensearch-api-specification/pull/1213))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -244,6 +244,22 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/indices.data_streams_stats@200'
+  /_data_stream/_modify:
+    post:
+      operationId: indices.modify_data_stream.0
+      x-operation-group: indices.modify_data_stream
+      x-version-added: '3.8'
+      description: Adds or removes backing indexes of a data stream. Actions are applied atomically as a metadata-only cluster state update.
+      externalDocs:
+        url: https://docs.opensearch.org/latest/im-plugin/data-streams/
+      parameters:
+        - $ref: '#/components/parameters/indices.modify_data_stream::query.cluster_manager_timeout'
+        - $ref: '#/components/parameters/indices.modify_data_stream::query.timeout'
+      requestBody:
+        $ref: '#/components/requestBodies/indices.modify_data_stream'
+      responses:
+        '200':
+          $ref: '#/components/responses/indices.modify_data_stream@200'
   /_data_stream/{name}:
     get:
       operationId: indices.get_data_stream.1
@@ -2011,6 +2027,22 @@ components:
           schema:
             type: object
             description: The data stream definition
+    indices.modify_data_stream:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              actions:
+                description: Actions to add or remove backing indexes of a data stream. All actions in a request are applied atomically.
+                type: array
+                minItems: 1
+                items:
+                  $ref: '../schemas/indices.modify_data_stream.yaml#/components/schemas/Action'
+            required:
+              - actions
+            description: The data stream modify actions.
+      required: true
     indices.put_alias:
       content:
         application/json:
@@ -2565,6 +2597,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/indices._common.yaml#/components/schemas/IndexGetUpgradeStatus'
+    indices.modify_data_stream@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.open@200:
       content:
         application/json:
@@ -4207,6 +4244,21 @@ components:
       schema:
         type: boolean
         description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
+    indices.modify_data_stream::query.cluster_manager_timeout:
+      name: cluster_manager_timeout
+      in: query
+      description: Operation timeout for connection to cluster-manager node.
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/Duration'
+    indices.modify_data_stream::query.timeout:
+      in: query
+      name: timeout
+      description: |-
+        Period to wait for a response.
+        If no response is received before the timeout expires, the request fails and returns an error.
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/Duration'
+      style: form
     indices.open::path.index:
       in: path
       name: index

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -422,6 +422,13 @@ components:
                   Where will be the authoritative store of the restored indexes' data.
                   A value of `local` indicates that all snapshot metadata and index data will be downloaded to local storage.
                   A value of `remote_snapshot` indicates that snapshot metadata will be downloaded to the cluster, but the remote repository will remain the authoritative store of the index data. Data will be downloaded and cached as necessary to service queries. At least one node in the cluster must be configured with the search role in order to restore a snapshot using the type `remote_snapshot`.
+              attach_to_data_stream:
+                x-version-added: '3.8'
+                type: boolean
+                default: false
+                description: |-
+                  When `true`, a restored index whose name matches the data stream backing index convention (`.ds-<stream>-NNNNNN`) is attached to a pre-existing data stream of the same name as part of the restore.
+                  When `false`, such an index is restored as a standalone index.
             description: Determines which settings and indexes to restore when restoring a snapshot
   responses:
     snapshot.cleanup_repository@200:

--- a/spec/schemas/indices.modify_data_stream.yaml
+++ b/spec/schemas/indices.modify_data_stream.yaml
@@ -1,0 +1,29 @@
+openapi: 3.1.0
+info:
+  title: Schemas of `indices.modify_data_stream` Category
+  description: Schemas of `indices.modify_data_stream` category.
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Action:
+      description: A single add or remove backing index action for a data stream.
+      type: object
+      properties:
+        add_backing_index:
+          $ref: '#/components/schemas/BackingIndexAction'
+        remove_backing_index:
+          $ref: '#/components/schemas/BackingIndexAction'
+      minProperties: 1
+      maxProperties: 1
+    BackingIndexAction:
+      description: The data stream and index targeted by a modify data stream action.
+      type: object
+      properties:
+        data_stream:
+          $ref: '_common.yaml#/components/schemas/DataStreamName'
+        index:
+          $ref: '_common.yaml#/components/schemas/IndexName'
+      required:
+        - data_stream
+        - index

--- a/tests/default/indices/data_stream/modify.yaml
+++ b/tests/default/indices/data_stream/modify.yaml
@@ -1,0 +1,93 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test adding and removing data stream backing indexes.
+version: '>= 3.8'
+prologues:
+  - path: /_index_template/logs-template-nginx
+    method: PUT
+    request:
+      payload:
+        index_patterns:
+          - logs-*
+        data_stream:
+          timestamp_field:
+            name: request_time
+        priority: 100
+  - path: /_data_stream/logs-nginx
+    method: PUT
+  - path: /logs-nginx/_doc
+    method: POST
+    request:
+      payload:
+        message: login attempt failed
+        request_time: '2013-03-01T00:00:00'
+  - path: /legacy-logs-nginx
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            request_time:
+              type: date
+epilogues:
+  - path: /_data_stream/logs-nginx
+    method: DELETE
+    status: [200, 404]
+  - path: /legacy-logs-nginx
+    method: DELETE
+    status: [200, 404]
+  - path: /_index_template/logs-template-nginx
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Add a regular index as a data stream backing index.
+    path: /_data_stream/_modify
+    method: POST
+    request:
+      payload:
+        actions:
+          - add_backing_index:
+              data_stream: logs-nginx
+              index: legacy-logs-nginx
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Confirm the added index is a backing index of the data stream.
+    path: /_data_stream/{name}
+    method: GET
+    parameters:
+      name: logs-nginx
+    response:
+      status: 200
+      payload:
+        data_streams:
+          - name: logs-nginx
+            indices:
+              - index_name: legacy-logs-nginx
+              - index_name: .ds-logs-nginx-000001
+  - synopsis: Remove a non-write backing index from the data stream.
+    path: /_data_stream/_modify
+    method: POST
+    request:
+      payload:
+        actions:
+          - remove_backing_index:
+              data_stream: logs-nginx
+              index: legacy-logs-nginx
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Confirm the removed index is no longer a backing index.
+    path: /_data_stream/{name}
+    method: GET
+    parameters:
+      name: logs-nginx
+    response:
+      status: 200
+      payload:
+        data_streams:
+          - name: logs-nginx
+            indices:
+              - index_name: .ds-logs-nginx-000001

--- a/tests/snapshot/snapshot/restore_data_stream.yaml
+++ b/tests/snapshot/snapshot/restore_data_stream.yaml
@@ -1,0 +1,111 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test restoring a data stream backing index with attach_to_data_stream.
+version: '>= 3.8'
+prologues:
+  - path: /_snapshot/{repository}
+    method: PUT
+    parameters:
+      repository: ds-fs-repository
+    request:
+      payload:
+        type: fs
+        settings:
+          location: /tmp/opensearch/repo/ds-attach
+  - path: /_index_template/logs-attach-template
+    method: PUT
+    request:
+      payload:
+        index_patterns:
+          - logs-attach
+        data_stream:
+          timestamp_field:
+            name: request_time
+        priority: 100
+  - path: /_data_stream/logs-attach
+    method: PUT
+  - path: /logs-attach/_doc
+    method: POST
+    request:
+      payload:
+        message: login attempt failed
+        request_time: '2013-03-01T00:00:00'
+  - path: /_snapshot/{repository}/{snapshot}
+    method: PUT
+    parameters:
+      repository: ds-fs-repository
+      snapshot: ds-attach-snapshot
+      wait_for_completion: true
+    request:
+      payload:
+        indices: .ds-logs-attach-000001
+        include_global_state: false
+  - path: /{alias}/_rollover
+    method: POST
+    parameters:
+      alias: logs-attach
+  - path: /_data_stream/_modify
+    method: POST
+    request:
+      payload:
+        actions:
+          - remove_backing_index:
+              data_stream: logs-attach
+              index: .ds-logs-attach-000001
+  - path: /{index}
+    method: DELETE
+    parameters:
+      index: .ds-logs-attach-000001
+epilogues:
+  - path: /_data_stream/logs-attach
+    method: DELETE
+    status: [200, 404]
+  - path: /{index}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      index: .ds-logs-attach-000001
+  - path: /_index_template/logs-attach-template
+    method: DELETE
+    status: [200, 404]
+  - path: /_snapshot/{repository}/{snapshot}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      repository: ds-fs-repository
+      snapshot: ds-attach-snapshot
+  - path: /_snapshot/{repository}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      repository: ds-fs-repository
+chapters:
+  - synopsis: Restore a backing index and attach it to the existing data stream.
+    path: /_snapshot/{repository}/{snapshot}/_restore
+    method: POST
+    parameters:
+      repository: ds-fs-repository
+      snapshot: ds-attach-snapshot
+      wait_for_completion: true
+    request:
+      payload:
+        indices: .ds-logs-attach-000001
+        attach_to_data_stream: true
+    response:
+      status: 200
+      payload:
+        snapshot:
+          snapshot: ds-attach-snapshot
+  - synopsis: Confirm the restored backing index is attached to the data stream.
+    path: /_data_stream/{name}
+    method: GET
+    parameters:
+      name: logs-attach
+    response:
+      status: 200
+      payload:
+        data_streams:
+          - name: logs-attach
+            indices:
+              - index_name: .ds-logs-attach-000001
+              - index_name: .ds-logs-attach-000002


### PR DESCRIPTION
Adds the OpenSearch 3.8 data stream modify API and the restore option that reattaches a restored backing index to an existing data stream.

- `POST /_data_stream/_modify` (`indices.modify_data_stream`): required `actions` body with `add_backing_index` / `remove_backing_index`, query params `cluster_manager_timeout` and `timeout`, acknowledged response.
- Optional restore body field `attach_to_data_stream` (boolean, default `false`, added in 3.8). When `true`, a restored `.ds-<stream>-NNNNNN` index is attached to a pre-existing data stream of the same name.

Matches the server REST spec (`indices.modify_data_stream.json`) and `RestoreSnapshotRequest`.