### PR TITLE
Add model_selection to SemanticProperty mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Added `model_selection` (`language_option`, `model_type`) to `SemanticProperty` and made `model_id` optional so the model id can be resolved from cluster settings ([#1214](https://github.com/opensearch-project/opensearch-api-specification/pull/1214))
 - Added `sparse_encoding`, `text_image_embedding`, and `text_chunking` ingest processor schemas with `ChunkingAlgorithm` (`fixed_token_length`, `delimiter`) support, and `neural_sparse` query DSL ([#1191](https://github.com/opensearch-project/opensearch-api-specification/pull/1191))
 - Added apis for searching within search relevance objects such as search configurations, judgments, query sets, and experiments ([#1064](https://github.com/opensearch-project/opensearch-api-specification/pull/1064))
 - Added remaining APIs for LTR including store element operations, model management, feature set operations, routing support, and POST support for update operations ([#935](https://github.com/opensearch-project/opensearch-api-specification/pull/935))

--- a/spec/schemas/_common.mapping.yaml
+++ b/spec/schemas/_common.mapping.yaml
@@ -982,6 +982,9 @@ components:
           type: string
         model_id:
           type: string
+        model_selection:
+          $ref: '#/components/schemas/SemanticModelSelection'
+          x-version-added: '3.9'
         search_model_id:
           type: string
         semantic_info_field_name:
@@ -1002,7 +1005,6 @@ components:
           type: boolean
           default: false
       required:
-        - model_id
         - type
     ShortNumberProperty:
       allOf:
@@ -1286,3 +1288,22 @@ components:
           type: string
         prune_ratio:
           type: number
+    SemanticModelSelection:
+      x-version-added: '3.9'
+      type: object
+      description: |-
+        Resolves the model to use for a semantic field from cluster settings instead of a hard-coded `model_id`.
+        The `model_type` and `language_option` pair maps to the cluster setting
+        `plugins.neural_search.model_selection.model_id.<model_type>.<language_option>` (lower-cased),
+        whose value is the resolved model id.
+      properties:
+        language_option:
+          type: string
+          enum:
+            - ENGLISH
+            - MULTILINGUAL
+        model_type:
+          type: string
+          enum:
+            - SPARSE
+            - DENSE


### PR DESCRIPTION
### Description

Adds the `model_selection` object to the `semantic` field mapping (`SemanticProperty`) and makes `model_id` optional.

The `semantic` field now supports resolving its model from cluster settings instead of a hard-coded `model_id`:

```json
{
  "mappings": {
    "properties": {
      "body": {
        "type": "semantic",
        "model_selection": { "language_option": "ENGLISH", "model_type": "SPARSE" }
      }
    }
  }
}
```

`model_type` (`SPARSE`/`DENSE`) + `language_option` (`ENGLISH`/`MULTILINGUAL`) map to the cluster setting
`plugins.neural_search.model_selection.model_id.<model_type>.<language_option>` (lower-cased), whose value is the resolved model id. On read-back the server returns both `model_selection` and the resolved `model_id`, so `model_id` is no longer required on input.

Changes:
- Added `model_selection` (`$ref` to new `SemanticModelSelection`) to `SemanticProperty`, `x-version-added: '3.9'`.
- Added the `SemanticModelSelection` schema (`language_option`, `model_type` enums).
- Removed `model_id` from `SemanticProperty.required` (optional when `model_selection` is supplied).

### Issues Resolved

Backing feature: opensearch-project/neural-search#1918 (implemented in opensearch-project/neural-search#1919).

### Validation

Ran the opensearch-java codegen against this spec change locally: it regenerates `SemanticProperty.java` (adds a nullable `modelSelection`, makes `modelId` nullable) and a new `SemanticModelSelection.java` with `languageOption`/`modelType`. Also verified end-to-end against a local `3.9.0-SNAPSHOT` cluster (create index with `model_selection` → server resolves and injects `model_id` from the cluster setting; ingest + neural query work).

### Check List
- [x] Updated the CHANGELOG.
- [x] All tests pass (spec YAML validated; repo linter/tests run in CI).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
