### PR TITLE
Add delete task API specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Added the Delete Task API for removing stored completed task results ([#1215](https://github.com/opensearch-project/opensearch-api-specification/pull/1215))
 - Added `sparse_encoding`, `text_image_embedding`, and `text_chunking` ingest processor schemas with `ChunkingAlgorithm` (`fixed_token_length`, `delimiter`) support, and `neural_sparse` query DSL ([#1191](https://github.com/opensearch-project/opensearch-api-specification/pull/1191))
 - Added apis for searching within search relevance objects such as search configurations, judgments, query sets, and experiments ([#1064](https://github.com/opensearch-project/opensearch-api-specification/pull/1064))
 - Added remaining APIs for LTR including store element operations, model management, feature set operations, routing support, and POST support for update operations ([#935](https://github.com/opensearch-project/opensearch-api-specification/pull/935))

--- a/spec/namespaces/tasks.yaml
+++ b/spec/namespaces/tasks.yaml
@@ -54,6 +54,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/tasks.get@200'
+    delete:
+      operationId: tasks.delete.0
+      x-operation-group: tasks.delete
+      x-version-added: '3.9'
+      description: Deletes a stored completed task result.
+      externalDocs:
+        url: https://docs.opensearch.org/latest/api-reference/tasks/delete-task/
+      parameters:
+        - $ref: '#/components/parameters/tasks.delete::path.task_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/tasks.delete@200'
   /_tasks/{task_id}/_cancel:
     post:
       operationId: tasks.cancel.1
@@ -79,6 +91,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/tasks._common.yaml#/components/schemas/TaskListResponseBase'
+    tasks.delete@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     tasks.get@200:
       content:
         application/json:
@@ -141,6 +158,14 @@ components:
         type: boolean
         default: false
       style: form
+    tasks.delete::path.task_id:
+      in: path
+      name: task_id
+      description: The ID of the stored completed task result to delete (`node_id:task_number`).
+      required: true
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/TaskId'
+      style: simple
     tasks.get::path.task_id:
       in: path
       name: task_id

--- a/tests/default/_core/tasks.yaml
+++ b/tests/default/_core/tasks.yaml
@@ -37,3 +37,14 @@ chapters:
     method: GET
     parameters:
       task_id: ${task.id}
+      wait_for_completion: true
+  - synopsis: Delete a stored completed task result.
+    version: '>=3.9'
+    path: /_tasks/{task_id}
+    method: DELETE
+    parameters:
+      task_id: ${task.id}
+    response:
+      status: 200
+      payload:
+        acknowledged: true


### PR DESCRIPTION
### Description

Adds the API specification for `DELETE /_tasks/{task_id}`, introduced in OpenSearch 3.9 by opensearch-project/OpenSearch#21727.

The API deletes a stored completed task result and returns an acknowledged response. This change also extends the existing Tasks test story to wait for the asynchronous task to complete before deleting its stored result.

Related documentation: opensearch-project/documentation-website#12954

### Testing

- `npm run lint:spec`
- `npm run lint`
- `npm run merge`
- `npm run test:unit -- --runInBand`
- `npm run test:spec -- --opensearch-url http://localhost:9200 --tests tests/default/_core/tasks.yaml --verbose` against a locally built OpenSearch 3.9.0-SNAPSHOT cluster

The focused Tasks specification story passed, including validation of the delete response:

```json
{
  "acknowledged": true
}
```
