### PR TITLE
Fix field_caps to exclude 'fields' from request body since those are passed as query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed SearchResult::hits specification ([#1011](https://github.com/opensearch-project/opensearch-api-specification/pull/1011))
 - Fixed the type of `Hit`'s `matched_queries` to be either an array or a map to support when `include_named_queries_score` is `true` ([#1015](https://github.com/opensearch-project/opensearch-api-specification/pull/1015))
 - Fixed aggregation schema strict mode compliance: restructured `MetricAggregationBase` and `TermsAggregation` by moving `field` and `script` into optional `anyOf` branches; added `value_type` to `MinAggregation` and `MaxAggregation`; updated `ValueType` enum (added `byte`, `float`, `integer`, `range`, `short`, `unsigned_long`; removed `date_nanos`); changed `min_doc_count` and `shard_min_doc_count` in `TermsAggregation` from int32 to int64 ([#1056](https://github.com/opensearch-project/opensearch-api-specification/pull/1056))
+- Fixed field_caps to exclude 'fields' from request body since those are passed as query parameters ([#1216](https://github.com/opensearch-project/opensearch-api-specification/pull/1216))
 
 ### Security
 - Upgraded `axios` 1.13.5 → 1.15.2 to fix 12+ CVEs (CVE-2026-42264, CVE-2026-42035, CVE-2026-42033, CVE-2026-42043, CVE-2025-62718, and others)

--- a/spec/namespaces/_core.yaml
+++ b/spec/namespaces/_core.yaml
@@ -2396,8 +2396,6 @@ components:
           schema:
             type: object
             properties:
-              fields:
-                $ref: '../schemas/_common.yaml#/components/schemas/Fields'
               index_filter:
                 $ref: '../schemas/_common.query_dsl.yaml#/components/schemas/QueryContainer'
             description: An index filter specified with the Query DSL


### PR DESCRIPTION
Fix `field_caps` to exclude `fields` since those are passed as query parameters. The `fields` is query parameter and is listed in the parameters list, but also was included in `field_caps` second time, as such query parameter was ignored:


```
      parameters:
        - $ref: '#/components/parameters/field_caps::query.allow_no_indices'
        - $ref: '#/components/parameters/field_caps::query.expand_wildcards'
        - $ref: '#/components/parameters/field_caps::query.fields'
        - $ref: '#/components/parameters/field_caps::query.ignore_unavailable'
        - $ref: '#/components/parameters/field_caps::query.include_unmapped'
```

### Description
Closes https://github.com/opensearch-project/opensearch-java/issues/1792

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
