### PR TITLE
Add spec for indices.modify_data_stream API and attach_to_data_stream restore field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
 - Added `sltr` to query DSL schema  ([#1187](https://github.com/opensearch-project/opensearch-api-specification/pull/1187))
+- Added spec for the experimental `indices.modify_data_stream` API and the `attach_to_data_stream` restore snapshot body field ([#1176](https://github.com/opensearch-project/opensearch-api-specification/issues/1176))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -232,6 +232,24 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/indices.get_data_stream@200'
+  /_data_stream/_modify:
+    post:
+      operationId: indices.modify_data_stream.0
+      x-operation-group: indices.modify_data_stream
+      x-version-added: '3.8'
+      description: |-
+        Adds or removes backing indexes of a data stream with metadata-only actions.
+        This is an experimental API.
+      externalDocs:
+        url: https://docs.opensearch.org/latest/im-plugin/data-streams/
+      parameters:
+        - $ref: '#/components/parameters/indices.modify_data_stream::query.cluster_manager_timeout'
+        - $ref: '#/components/parameters/indices.modify_data_stream::query.timeout'
+      requestBody:
+        $ref: '#/components/requestBodies/indices.modify_data_stream'
+      responses:
+        '200':
+          $ref: '#/components/responses/indices.modify_data_stream@200'
   /_data_stream/_stats:
     get:
       operationId: indices.data_streams_stats.0
@@ -2011,6 +2029,21 @@ components:
           schema:
             type: object
             description: The data stream definition
+    indices.modify_data_stream:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              actions:
+                description: The actions to perform on the data stream.
+                type: array
+                items:
+                  $ref: '../schemas/indices.modify_data_stream.yaml#/components/schemas/Action'
+            required:
+              - actions
+            description: The data stream modify actions.
+      required: true
     indices.put_alias:
       content:
         application/json:
@@ -2565,6 +2598,11 @@ components:
         application/json:
           schema:
             $ref: '../schemas/indices._common.yaml#/components/schemas/IndexGetUpgradeStatus'
+    indices.modify_data_stream@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/_common.yaml#/components/schemas/AcknowledgedResponseBase'
     indices.open@200:
       content:
         application/json:
@@ -4207,6 +4245,20 @@ components:
       schema:
         type: boolean
         description: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
+    indices.modify_data_stream::query.cluster_manager_timeout:
+      name: cluster_manager_timeout
+      in: query
+      description: Operation timeout for connection to cluster-manager node.
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/Duration'
+    indices.modify_data_stream::query.timeout:
+      name: timeout
+      in: query
+      description: |-
+        Period to wait for a response.
+        If no response is received before the timeout expires, the request fails and returns an error.
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/Duration'
     indices.open::path.index:
       in: path
       name: index

--- a/spec/namespaces/indices.yaml
+++ b/spec/namespaces/indices.yaml
@@ -2040,6 +2040,7 @@ components:
                 type: array
                 items:
                   $ref: '../schemas/indices.modify_data_stream.yaml#/components/schemas/Action'
+                minItems: 1
             required:
               - actions
             description: The data stream modify actions.

--- a/spec/namespaces/snapshot.yaml
+++ b/spec/namespaces/snapshot.yaml
@@ -347,6 +347,14 @@ components:
           schema:
             type: object
             properties:
+              attach_to_data_stream:
+                x-version-added: '3.8'
+                type: boolean
+                default: false
+                description: |-
+                  Whether to attach restored backing indexes to a pre-existing data stream of the same name.
+                  When `true`, a restored backing index (`.ds-<stream>-NNNNNN`) is attached to an existing data stream with a matching name during the restore.
+                  This is an experimental feature.
               ignore_index_settings:
                 description: A comma-delimited list of index settings to ignore when restoring indexes from a snapshot.
                 type: array

--- a/spec/schemas/indices.modify_data_stream.yaml
+++ b/spec/schemas/indices.modify_data_stream.yaml
@@ -1,0 +1,40 @@
+openapi: 3.1.0
+info:
+  title: Schemas of `indices.modify_data_stream` Category
+  description: Schemas of `indices.modify_data_stream` category.
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Action:
+      description: The action to perform on the backing indexes of a data stream.
+      type: object
+      properties:
+        add_backing_index:
+          $ref: '#/components/schemas/AddBackingIndexAction'
+        remove_backing_index:
+          $ref: '#/components/schemas/RemoveBackingIndexAction'
+      minProperties: 1
+      maxProperties: 1
+    AddBackingIndexAction:
+      description: The configuration for adding a backing index to a data stream.
+      type: object
+      properties:
+        data_stream:
+          $ref: '_common.yaml#/components/schemas/DataStreamName'
+        index:
+          $ref: '_common.yaml#/components/schemas/IndexName'
+      required:
+        - data_stream
+        - index
+    RemoveBackingIndexAction:
+      description: The configuration for removing a backing index from a data stream.
+      type: object
+      properties:
+        data_stream:
+          $ref: '_common.yaml#/components/schemas/DataStreamName'
+        index:
+          $ref: '_common.yaml#/components/schemas/IndexName'
+      required:
+        - data_stream
+        - index

--- a/tests/default/indices/data_stream/modify.yaml
+++ b/tests/default/indices/data_stream/modify.yaml
@@ -3,13 +3,12 @@ $schema: ../../../../json_schemas/test_story.schema.yaml
 description: Test modifying the backing indexes of a data stream.
 version: '>= 3.8'
 prologues:
-  - path: /_index_template/logs-template-nginx
+  - path: /_index_template/logs-template-modify
     method: PUT
     request:
       payload:
         index_patterns:
-          - logs-*
-          - my-data-stream
+          - logs-modify*
         data_stream:
           timestamp_field:
             name: request_time
@@ -23,6 +22,9 @@ epilogues:
     method: DELETE
     status: [200, 404]
   - path: /.ds-logs-modify-000001
+    method: DELETE
+    status: [200, 404]
+  - path: /_index_template/logs-template-modify
     method: DELETE
     status: [200, 404]
 chapters:

--- a/tests/default/indices/data_stream/modify.yaml
+++ b/tests/default/indices/data_stream/modify.yaml
@@ -1,0 +1,54 @@
+$schema: ../../../../json_schemas/test_story.schema.yaml
+
+description: Test modifying the backing indexes of a data stream.
+version: '>= 3.8'
+prologues:
+  - path: /_index_template/logs-template-nginx
+    method: PUT
+    request:
+      payload:
+        index_patterns:
+          - logs-*
+          - my-data-stream
+        data_stream:
+          timestamp_field:
+            name: request_time
+        priority: 100
+  - path: /_data_stream/logs-modify
+    method: PUT
+  - path: /logs-modify/_rollover
+    method: POST
+epilogues:
+  - path: /_data_stream/logs-modify
+    method: DELETE
+    status: [200, 404]
+  - path: /.ds-logs-modify-000001
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Remove a backing index from a data stream.
+    path: /_data_stream/_modify
+    method: POST
+    request:
+      payload:
+        actions:
+          - remove_backing_index:
+              data_stream: logs-modify
+              index: .ds-logs-modify-000001
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Add a backing index to a data stream.
+    path: /_data_stream/_modify
+    method: POST
+    request:
+      payload:
+        actions:
+          - add_backing_index:
+              data_stream: logs-modify
+              index: .ds-logs-modify-000001
+    response:
+      status: 200
+      payload:
+        acknowledged: true

--- a/tests/snapshot/snapshot/restore_data_stream.yaml
+++ b/tests/snapshot/snapshot/restore_data_stream.yaml
@@ -68,6 +68,11 @@ epilogues:
   - path: /_index_template/logs-template-attach
     method: DELETE
     status: [200, 404]
+  - path: /_snapshot/{repository}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      repository: my-fs-repository
 chapters:
   - synopsis: Restore a backing index and attach it to its data stream.
     path: /_snapshot/{repository}/{snapshot}/_restore

--- a/tests/snapshot/snapshot/restore_data_stream.yaml
+++ b/tests/snapshot/snapshot/restore_data_stream.yaml
@@ -1,0 +1,87 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Test restoring a data stream backing index with `attach_to_data_stream`.
+version: '>= 3.8'
+warnings:
+  invalid-path-detected: false
+prologues:
+  - path: /_index_template/logs-template-attach
+    method: PUT
+    request:
+      payload:
+        index_patterns:
+          - logs-attach*
+        data_stream:
+          timestamp_field:
+            name: request_time
+        priority: 200
+  - path: /_data_stream/logs-attach
+    method: PUT
+  - path: /logs-attach/_doc
+    method: POST
+    request:
+      payload:
+        message: login attempt failed
+        request_time: '2013-03-01T00:00:00'
+  - path: /_snapshot/{repository}
+    method: PUT
+    parameters:
+      repository: my-fs-repository
+    request:
+      payload:
+        type: fs
+        settings:
+          location: /tmp/opensearch/repo
+  - path: /_snapshot/{repository}/{snapshot}
+    method: PUT
+    parameters:
+      repository: my-fs-repository
+      snapshot: my-attach-snapshot
+      wait_for_completion: true
+    request:
+      payload:
+        indices:
+          - logs-attach
+        include_global_state: false
+  - path: /logs-attach/_rollover
+    method: POST
+  - path: /_data_stream/_modify
+    method: POST
+    request:
+      payload:
+        actions:
+          - remove_backing_index:
+              data_stream: logs-attach
+              index: .ds-logs-attach-000001
+  - path: /.ds-logs-attach-000001
+    method: DELETE
+epilogues:
+  - path: /_snapshot/{repository}/{snapshot}
+    method: DELETE
+    status: [200, 404]
+    parameters:
+      repository: my-fs-repository
+      snapshot: my-attach-snapshot
+  - path: /_data_stream/logs-attach
+    method: DELETE
+    status: [200, 404]
+  - path: /_index_template/logs-template-attach
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Restore a backing index and attach it to its data stream.
+    path: /_snapshot/{repository}/{snapshot}/_restore
+    method: POST
+    parameters:
+      repository: my-fs-repository
+      snapshot: my-attach-snapshot
+      wait_for_completion: true
+    request:
+      payload:
+        indices: .ds-logs-attach-000001
+        attach_to_data_stream: true
+    response:
+      status: 200
+      payload:
+        snapshot:
+          snapshot: my-attach-snapshot


### PR DESCRIPTION
### Description
Adds the OpenAPI spec for the experimental `POST /_data_stream/_modify` API, which lets callers add or remove backing indexes of a data stream via metadata-only actions. Also adds the `attach_to_data_stream` boolean field to the snapshot restore request body, which attaches a restored backing index to a pre-existing data stream of the same name.

  - New schema `indices.modify_data_stream.yaml` defining `Action`, `AddBackingIndexAction`, and `RemoveBackingIndexAction`.
  - New path `/_data_stream/_modify` in `indices.yaml` (`operationId: indices.modify_data_stream.0`), added in `3.8`.
  - New `attach_to_data_stream` field on the snapshot restore request body in `snapshot.yaml`, added in `3.8`.
  - Test fixtures for both under `tests/default/indices/data_stream/modify.yaml` and `tests/snapshot/snapshot/restore_data_stream.yaml`.
  - CHANGELOG entry.

### Issues Resolved
Closes [#1176]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
