### PR TITLE
Add `ext` to SearchResult for plugin-specific search responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
 - Added `sltr` to query DSL schema  ([#1187](https://github.com/opensearch-project/opensearch-api-specification/pull/1187))
+- Added `ext` to `SearchResult` so generated clients can read plugin-specific search response fields ([#831](https://github.com/opensearch-project/opensearch-api-specification/issues/831))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/schemas/_core.search.yaml
+++ b/spec/schemas/_core.search.yaml
@@ -1391,6 +1391,11 @@ components:
               $ref: '#/components/schemas/Suggest'
         terminated_early:
           type: boolean
+        ext:
+          x-version-added: '2.10'
+          description: Plugin-specific fields returned by OpenSearch plugins.
+          type: object
+          additionalProperties: true
       required:
         - _shards
         - hits


### PR DESCRIPTION
Adds the missing ext field to the search response (SearchResult). It is already on the request body, documented, and used by plugins. Generated clients currently drop it.