### PR TITLE
Add missing search pipeline processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
 - Added `sltr` to query DSL schema  ([#1187](https://github.com/opensearch-project/opensearch-api-specification/pull/1187))
-- Added missing search pipeline processors `ml_inference` (request and response), `neural_sparse_two_phase_processor`, and `hybrid_score_explanation` ([#507](https://github.com/opensearch-project/opensearch-api-specification/issues/507))
+- Added missing search pipeline processors `ml_inference` (request and response), `neural_sparse_two_phase_processor`, and `hybrid_score_explanation` ([#1221](https://github.com/opensearch-project/opensearch-api-specification/pull/1221))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `mapper_type` and `mapper_settings` to `IngestionSource` index settings ([#1155](https://github.com/opensearch-project/opensearch-api-specification/pull/1155))
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
 - Added `sltr` to query DSL schema  ([#1187](https://github.com/opensearch-project/opensearch-api-specification/pull/1187))
+- Added missing search pipeline processors `ml_inference` (request and response), `neural_sparse_two_phase_processor`, and `hybrid_score_explanation` ([#507](https://github.com/opensearch-project/opensearch-api-specification/issues/507))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/schemas/search_pipeline._common.yaml
+++ b/spec/schemas/search_pipeline._common.yaml
@@ -47,6 +47,14 @@ components:
               $ref: '#/components/schemas/FilterQueryRequestProcessor'
           required:
             - filter_query
+        - x-version-added: '2.16'
+          type: object
+          title: ml_inference
+          properties:
+            ml_inference:
+              $ref: '#/components/schemas/MLInferenceSearchRequestProcessor'
+          required:
+            - ml_inference
         - type: object
           title: neural_query_enricher
           properties:
@@ -54,6 +62,14 @@ components:
               $ref: '#/components/schemas/NeuralQueryEnricherRequestProcessor'
           required:
             - neural_query_enricher
+        - x-version-added: '2.15'
+          type: object
+          title: neural_sparse_two_phase_processor
+          properties:
+            neural_sparse_two_phase_processor:
+              $ref: '#/components/schemas/NeuralSparseTwoPhaseRequestProcessor'
+          required:
+            - neural_sparse_two_phase_processor
         - type: object
           title: script
           properties:
@@ -185,6 +201,22 @@ components:
               $ref: '#/components/schemas/CollapseResponseProcessor'
           required:
             - collapse
+        - x-version-added: '2.19'
+          type: object
+          title: hybrid_score_explanation
+          properties:
+            hybrid_score_explanation:
+              $ref: '#/components/schemas/HybridScoreExplanationResponseProcessor'
+          required:
+            - hybrid_score_explanation
+        - x-version-added: '2.16'
+          type: object
+          title: ml_inference
+          properties:
+            ml_inference:
+              $ref: '#/components/schemas/MLInferenceSearchResponseProcessor'
+          required:
+            - ml_inference
         - type: object
           title: truncate_hits
           properties:
@@ -461,3 +493,141 @@ components:
       type: string
       enum:
         - rrf
+    MLInferenceFieldMap:
+      type: object
+      additionalProperties:
+        type: string
+    MLInferenceProcessorBase:
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean
+        model_id:
+          description: The ID of the ML model used by the processor.
+          type: string
+        function_name:
+          description: The function name of the ML model. For local models, valid values are `sparse_encoding`, `sparse_tokenize`, `text_embedding`, and `text_similarity`. For externally hosted models, the valid value is `remote`. Default is `remote`.
+          type: string
+        model_config:
+          description: Custom configuration options for the ML model.
+          type: object
+          additionalProperties: true
+        model_input:
+          description: A template that defines the input field format expected by the model. Required for local models.
+          type: string
+        input_map:
+          description: Maps query or document fields to model input fields. Each element is one model invocation.
+          type: array
+          items:
+            $ref: '#/components/schemas/MLInferenceFieldMap'
+        output_map:
+          description: Maps model output fields to query or document fields.
+          type: array
+          items:
+            $ref: '#/components/schemas/MLInferenceFieldMap'
+        optional_input_map:
+          x-version-added: '2.19'
+          description: Optional mappings from query or document fields to model input fields. Missing fields do not fail the processor.
+          type: array
+          items:
+            $ref: '#/components/schemas/MLInferenceFieldMap'
+        optional_output_map:
+          x-version-added: '2.19'
+          description: Optional mappings from model output fields to query or document fields.
+          type: array
+          items:
+            $ref: '#/components/schemas/MLInferenceFieldMap'
+        full_response_path:
+          description: If `true`, `model_output_field` is treated as a JSON path and the full model output is parsed. Default is `true` for local models and `false` for remotely hosted models.
+          type: boolean
+        ignore_missing:
+          description: If `true`, skip this processor when mapped input or output fields are missing. Default is `false`.
+          type: boolean
+        max_prediction_tasks:
+          description: The maximum number of concurrent model invocations during search. Default is `10`.
+          type: integer
+          format: int32
+      required:
+        - model_id
+    MLInferenceSearchRequestProcessor:
+      x-version-added: '2.16'
+      allOf:
+        - $ref: '#/components/schemas/MLInferenceProcessorBase'
+        - type: object
+          properties:
+            query_template:
+              description: A query string template used to construct a rewritten query from model output.
+              type: string
+    MLInferenceSearchResponseProcessor:
+      x-version-added: '2.16'
+      allOf:
+        - $ref: '#/components/schemas/MLInferenceProcessorBase'
+        - type: object
+          properties:
+            override:
+              description: If `true`, overwrite an existing document field when the output mapping targets that field. Default is `false`.
+              type: boolean
+            one_to_one:
+              description: If `true`, invoke the model once per document. Default is `false`, which invokes the model once for the full search response.
+              type: boolean
+    NeuralSparseTwoPhaseRequestProcessor:
+      x-version-added: '2.15'
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean
+        enabled:
+          description: Controls whether two-phase processing is enabled. Default is `true`.
+          type: boolean
+          default: true
+        two_phase_parameter:
+          $ref: '#/components/schemas/NeuralSparseTwoPhaseParameter'
+    NeuralSparseTwoPhaseParameter:
+      type: object
+      properties:
+        prune_type:
+          $ref: '#/components/schemas/SparseVectorPruneType'
+        prune_ratio:
+          description: Threshold used with `prune_type` to split high-weight and low-weight tokens. Default is `0.4`.
+          type: number
+          format: float
+          default: 0.4
+        expansion_rate:
+          description: Multiplier applied to the query size to determine how many documents are rescored in the second phase. Must be greater than or equal to `1.0`. Default is `5.0`.
+          type: number
+          format: float
+          minimum: 1
+          default: 5
+        max_window_size:
+          description: Maximum number of documents processed by the two-phase processor. Must be greater than or equal to `50`. Default is `10000`.
+          type: integer
+          format: int32
+          minimum: 50
+          default: 10000
+    SparseVectorPruneType:
+      description: The pruning strategy for separating high-weight and low-weight tokens. Default is `max_ratio`.
+      type: string
+      enum:
+        - abs_value
+        - alpha_mass
+        - max_ratio
+        - none
+        - top_k
+    HybridScoreExplanationResponseProcessor:
+      x-version-added: '2.19'
+      type: object
+      properties:
+        tag:
+          type: string
+        description:
+          type: string
+        ignore_failure:
+          type: boolean

--- a/tests/default/_core/search/pipeline/request_processor/ml_inference.yaml
+++ b/tests/default/_core/search/pipeline/request_processor/ml_inference.yaml
@@ -1,0 +1,46 @@
+$schema: ../../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the creation of a search pipeline with an ml_inference request processor.
+warnings:
+  invalid-path-detected: false
+version: '>= 2.16'
+epilogues:
+  - path: /_search/pipeline/ml-inference-request-pipeline
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create search pipeline with ml_inference request processor.
+    path: /_search/pipeline/{id}
+    method: PUT
+    parameters:
+      id: ml-inference-request-pipeline
+    request:
+      payload:
+        description: Rewrites queries using an ML model.
+        request_processors:
+          - ml_inference:
+              tag: ml_req
+              description: Rewrites the query using model inference.
+              ignore_failure: true
+              ignore_missing: true
+              model_id: dummy-model-id
+              function_name: remote
+              full_response_path: false
+              max_prediction_tasks: 10
+              model_config:
+                return_number: true
+              input_map:
+                - inputs: query.term.title.value
+              output_map:
+                - query.term.title.value: label
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Get the ml_inference request pipeline.
+    path: /_search/pipeline/{id}
+    method: GET
+    parameters:
+      id: ml-inference-request-pipeline
+    response:
+      status: 200

--- a/tests/default/_core/search/pipeline/request_processor/neural_sparse_two_phase.yaml
+++ b/tests/default/_core/search/pipeline/request_processor/neural_sparse_two_phase.yaml
@@ -1,0 +1,40 @@
+$schema: ../../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the creation of a search pipeline with a neural_sparse_two_phase_processor request processor.
+warnings:
+  invalid-path-detected: false
+version: '>= 2.15'
+epilogues:
+  - path: /_search/pipeline/two-phase-search-pipeline
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create search pipeline with neural_sparse_two_phase_processor.
+    path: /_search/pipeline/{id}
+    method: PUT
+    parameters:
+      id: two-phase-search-pipeline
+    request:
+      payload:
+        description: Accelerates neural sparse queries with two-phase scoring.
+        request_processors:
+          - neural_sparse_two_phase_processor:
+              tag: neural-sparse
+              description: This processor is making two-phase processor.
+              enabled: true
+              two_phase_parameter:
+                prune_type: max_ratio
+                prune_ratio: 0.4
+                expansion_rate: 5
+                max_window_size: 10000
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Get the neural sparse two-phase pipeline.
+    path: /_search/pipeline/{id}
+    method: GET
+    parameters:
+      id: two-phase-search-pipeline
+    response:
+      status: 200

--- a/tests/default/_core/search/pipeline/response_processor/hybrid_score_explanation.yaml
+++ b/tests/default/_core/search/pipeline/response_processor/hybrid_score_explanation.yaml
@@ -1,0 +1,90 @@
+$schema: ../../../../../../json_schemas/test_story.schema.yaml
+
+description: Test a search pipeline with a hybrid_score_explanation response processor.
+warnings:
+  invalid-path-detected: false
+version: '>= 2.19'
+prologues:
+  - path: /books
+    method: PUT
+    request:
+      payload:
+        mappings:
+          properties:
+            title:
+              type: text
+            author:
+              type: text
+  - path: /_bulk
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      content_type: application/x-ndjson
+      payload:
+        - {index: {_index: books, _id: book1}}
+        - {title: To Kill a Mockingbird, author: Harper Lee}
+        - {index: {_index: books, _id: book2}}
+        - {title: The Great Gatsby, author: F. Scott Fitzgerald}
+epilogues:
+  - path: /_search/pipeline/hybrid-explain-pipeline
+    method: DELETE
+    status: [200, 404]
+  - path: /books
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create search pipeline with hybrid_score_explanation processor.
+    path: /_search/pipeline/{id}
+    method: PUT
+    parameters:
+      id: hybrid-explain-pipeline
+    request:
+      payload:
+        description: Post processor for hybrid search.
+        phase_results_processors:
+          - normalization-processor:
+              normalization:
+                technique: min_max
+              combination:
+                technique: arithmetic_mean
+        response_processors:
+          - hybrid_score_explanation:
+              tag: hybrid-explain
+              description: Adds hybrid score explanation to search hits.
+              ignore_failure: true
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Get the hybrid score explanation pipeline.
+    path: /_search/pipeline/{id}
+    method: GET
+    parameters:
+      id: hybrid-explain-pipeline
+    response:
+      status: 200
+  - synopsis: Search with hybrid query and explain enabled.
+    warnings:
+      multiple-paths-detected: false
+    path: /{index}/_search
+    method: GET
+    parameters:
+      index: books
+      search_pipeline: hybrid-explain-pipeline
+      explain: true
+    request:
+      payload:
+        query:
+          hybrid:
+            queries:
+              - match:
+                  title: Kill
+              - match:
+                  title: Gatsby
+    response:
+      status: 200
+      payload:
+        hits:
+          total:
+            value: 2

--- a/tests/default/_core/search/pipeline/response_processor/ml_inference.yaml
+++ b/tests/default/_core/search/pipeline/response_processor/ml_inference.yaml
@@ -1,0 +1,46 @@
+$schema: ../../../../../../json_schemas/test_story.schema.yaml
+
+description: Test the creation of a search pipeline with an ml_inference response processor.
+warnings:
+  invalid-path-detected: false
+version: '>= 2.16'
+epilogues:
+  - path: /_search/pipeline/ml-inference-response-pipeline
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Create search pipeline with ml_inference response processor.
+    path: /_search/pipeline/{id}
+    method: PUT
+    parameters:
+      id: ml-inference-response-pipeline
+    request:
+      payload:
+        description: Adds model output to search hits.
+        response_processors:
+          - ml_inference:
+              tag: ml_res
+              description: Adds embeddings to search hits.
+              ignore_failure: true
+              ignore_missing: true
+              model_id: dummy-model-id
+              function_name: remote
+              full_response_path: false
+              override: false
+              one_to_one: false
+              max_prediction_tasks: 10
+              input_map:
+                - input: title
+              output_map:
+                - title_embedding: data
+    response:
+      status: 200
+      payload:
+        acknowledged: true
+  - synopsis: Get the ml_inference response pipeline.
+    path: /_search/pipeline/{id}
+    method: GET
+    parameters:
+      id: ml-inference-response-pipeline
+    response:
+      status: 200


### PR DESCRIPTION
Addresses #507. Adds the remaining documented search pipeline processors that were missing from the spec, including `ml_inference`, which this repo already uses in `tests/default/_core/search/knn/search/search_pipeline.yaml`.