### PR TITLE
Fix: Add missing ignore_unmapped to the knn query schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Added `ignore_unmapped` to `KnnQuery` ([#XXXX](https://github.com/opensearch-project/opensearch-api-specification/pull/XXXX))
 - Added `sparse_encoding`, `text_image_embedding`, and `text_chunking` ingest processor schemas with `ChunkingAlgorithm` (`fixed_token_length`, `delimiter`) support, and `neural_sparse` query DSL ([#1191](https://github.com/opensearch-project/opensearch-api-specification/pull/1191))
 - Added apis for searching within search relevance objects such as search configurations, judgments, query sets, and experiments ([#1064](https://github.com/opensearch-project/opensearch-api-specification/pull/1064))
 - Added remaining APIs for LTR including store element operations, model management, feature set operations, routing support, and POST support for update operations ([#935](https://github.com/opensearch-project/opensearch-api-specification/pull/935))

--- a/spec/schemas/_common.query_dsl.yaml
+++ b/spec/schemas/_common.query_dsl.yaml
@@ -1133,6 +1133,9 @@ components:
             expand_nested_docs:
               type: boolean
               x-version-added: '2.19'
+            ignore_unmapped:
+              $ref: '#/components/schemas/IgnoreUnmapped'
+              x-version-added: '2.11'
           required:
             - vector
     KnnQueryRescore:

--- a/tests/default/_core/search/knn/search/search_ignore_unmapped.yaml
+++ b/tests/default/_core/search/knn/search/search_ignore_unmapped.yaml
@@ -1,0 +1,84 @@
+$schema: ../../../../../../json_schemas/test_story.schema.yaml
+
+description: Test search endpoint with knn query using the ignore_unmapped parameter.
+warnings:
+  invalid-path-detected: false
+version: '>= 1.2'
+prologues:
+  - path: /movies
+    method: PUT
+    request:
+      payload:
+        settings:
+          index:
+            knn: true
+        mappings:
+          properties:
+            director:
+              type: text
+            title:
+              type: text
+            year:
+              type: integer
+            embedding:
+              type: knn_vector
+              dimension: 5
+              method:
+                name: hnsw
+                space_type: l2
+                engine: faiss
+  - path: /movies/_doc
+    method: POST
+    parameters:
+      refresh: true
+    request:
+      payload:
+        director: Bennett Miller
+        title: Moneyball
+        year: 2011
+        embedding: [1.4, 2.3, 3.5, 4.1, 9.2]
+    status: [201]
+epilogues:
+  - path: /movies
+    method: DELETE
+    status: [200, 404]
+chapters:
+  - synopsis: Search a field that is not present in the mapping, ignoring it.
+    version: '>= 2.11'
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request:
+      payload:
+        query:
+          knn:
+            missing_embedding:
+              vector: [1.4, 2.3, 3.5, 4.1, 9.2]
+              k: 1
+              ignore_unmapped: true
+    response:
+      status: 200
+      payload:
+        timed_out: false
+        hits:
+          total:
+            value: 0
+            relation: eq
+          hits: []
+  - synopsis: Search a field that is not present in the mapping without ignoring it.
+    version: '>= 2.11'
+    path: /{index}/_search
+    parameters:
+      index: movies
+    method: POST
+    request:
+      payload:
+        query:
+          knn:
+            missing_embedding:
+              vector: [1.4, 2.3, 3.5, 4.1, 9.2]
+              k: 1
+              ignore_unmapped: false
+    response:
+      status: 400


### PR DESCRIPTION
The k-NN plugin has accepted ignore_unmapped on the knn query since 2.11.0 (k-NN#1071), but the schema never declared it. Because the spec drives client generation, the omission leaves generated clients unable to emit the parameter at all.

### Description

This adds `ignore_unmapped` as an option to k-NN queries so that it can be eventually exposed by the downstream opensearch-java project.

This addresses https://github.com/opensearch-project/opensearch-api-specification/issues/1224

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
