### PR TITLE
ci: add API coverage gap to the PR Changes Analysis comment

### DIFF
--- a/.github/pr-comment-templates/pr-change-analysis.template.md
+++ b/.github/pr-comment-templates/pr-change-analysis.template.md
@@ -21,3 +21,10 @@ The full API changes report is available at: {{.api_changes_report_url}}
 |       Unknown | {{.before.specified_but_not_provided}}              | {{.after.specified_but_not_provided}}             | {{.specified_but_not_provided_delta}}             |
 
 {{end}}
+{{with .api_uncovered}}
+<details>
+<summary>Uncovered endpoints (provided by the cluster, missing from the spec)</summary>
+
+{{.}}
+</details>
+{{end}}

--- a/.github/workflows/analyze-pr-changes.yml
+++ b/.github/workflows/analyze-pr-changes.yml
@@ -188,12 +188,24 @@ jobs:
       - name: Construct Comment Data Payload
         shell: bash -eo pipefail {0}
         run: |
+          # Render the uncovered endpoints (the gap) from the AFTER coverage data
+          # into a checklist the comment template embeds. Uncovered = provided by
+          # the cluster but absent from the spec.
+          jq -r '
+            .endpoints.uncovered
+            | to_entries
+            | map((.value[] | ascii_upcase) + " " + .key)
+            | sort[]
+            | "- [ ] \(.)"
+          ' $AFTER_COVERAGE > ./api-uncovered.md
+
           jq \
             --arg pr_number ${PR_NUMBER} \
             --arg before_sha ${BEFORE_SHA} \
             --arg after_sha ${AFTER_SHA} \
             --arg api_changes_report_url "${API_CHANGES_REPORT_URL}" \
             --rawfile api_changes_summary ./changes-summary.md \
+            --rawfile api_uncovered ./api-uncovered.md \
             --slurpfile api_coverage $COVERAGE_DIFF \
             --null-input '
             {
@@ -205,7 +217,8 @@ jobs:
                 "after_sha": ($after_sha),
                 "api_changes_report_url": ($api_changes_report_url),
                 "api_changes_summary": ($api_changes_summary),
-                "api_coverage": ($api_coverage[0])
+                "api_coverage": ($api_coverage[0]),
+                "api_uncovered": ($api_uncovered)
               }
             }
             ' | tee pr-comment.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix `AggregationContainer`  for all bucket aggregations so that `aggs`/`aggregations` are siblings of the aggregation type([#1069](https://github.com/opensearch-project/opensearch-api-specification/pull/1069))
 
 ### Changed
+- Add the API coverage gap (the uncovered-endpoint checklist) to the per-PR Changes Analysis comment, so the missing-API list is visible directly on the PR without opening the workflow run ([#1227](https://github.com/opensearch-project/opensearch-api-specification/pull/1227))
 - Add explicit `style: simple` to 13 path parameters whose schema is an array (or `oneOf` with an array branch) so code generators no longer have to infer the OpenAPI 3 default ([#1134](https://github.com/opensearch-project/opensearch-api-specification/pull/1134))
 - Replace inline `format` query response parameter schemas across cat, list, sql, and ppl operations with typed enums (`CatResponseFormat`, `ListResponseFormat`, `SQLResponseFormat`, `PPLResponseFormat`) in `_common`, including server-truthful `default` values ([#1133](https://github.com/opensearch-project/opensearch-api-specification/pull/1133))
 - Changed schema of `NodeInfoSearchPipelines`'s `response_processors` & `request_processors` to use `NodeInfoSearchPipelineProcessor` instead of `NodeInfoIngestProcessor` ([#922](https://github.com/opensearch-project/opensearch-api-specification/pull/922))


### PR DESCRIPTION
## Problem / Motivation

The coverage workflow computes the covered/uncovered API split, but the uncovered list — the missing-API gap — is only printed into the "Display Coverage Checklist" **step log**. Seeing it means opening the run and scrolling a raw log; it isn't surfaced on the PR itself.

## Why it matters

The uncovered list *is* the missing-API backlog (it feeds the "Add Missing API Specs" issue #168). The per-PR **Changes Analysis** comment already reports a covered/uncovered counts table, so the gap belongs right there next to it — but the actual endpoint list is absent.

## What changed (motivation -> approach -> change)

- **Approach:** fold the uncovered checklist into the **existing** per-PR Changes Analysis comment, reusing the repo's established artifact -> `pr-comment.yml` posting flow. This keeps it **fork-safe**: the `analyze` job (read-only token on forks) only builds the payload; the privileged `workflow_run`-triggered `pr-comment.yml` posts it. No new token permissions, no direct `gh pr comment`.
- **Change:**
  - `analyze-pr-changes.yml` — render the uncovered endpoints from the AFTER coverage JSON into `./api-uncovered.md` and thread it into the comment payload as `template_data.api_uncovered` (via `--rawfile`).
  - `pr-comment-templates/pr-change-analysis.template.md` — embed `{{.api_uncovered}}` as a collapsible `<details>` checklist under the existing coverage table (guarded by `{{with}}` so it renders only when present).

`coverage.yml` is unchanged. The uncovered-endpoint jq reuses the same `(.value[] | ascii_upcase) + " " + .key` shaping the "Display Coverage Checklist" step already uses.

## Tests

No automated tests (CI workflow change). Verified locally against fixtures — see Manual verification.

## Manual verification

- The uncovered-checklist `jq` filter, run against a fixture matching the coverage JSON shape, produced sorted `- [ ] <METHOD> <path>` lines.
- The full payload `jq` (with the new `--rawfile api_uncovered`) built valid JSON with `template_data.api_uncovered` present.
- Both `analyze-pr-changes.yml` and the template validated (`yaml.safe_load`; template is Go-template syntax consumed by `chuhlomin/render-template`).

The rendered comment will appear on the next `analyze` run for a PR.

> **Note on fork PRs:** the gap comment posts only on **same-repo** PRs. The posting workflow (`pr-comment.yml`, `workflow_run`) runs with a read-only `GITHUB_TOKEN` on fork PRs and fails at the post step with `Resource not accessible by integration` — a pre-existing repo limitation, independent of this change (the `analyze` job here still builds the payload and renders the template correctly; only the final post is gated). On a maintainer's same-repo branch it posts normally.

<!-- no-visual-delta -->
**Why no screenshot:** CI workflow + comment-template change only; output is a GitHub PR comment, not product UI.

no linked issue: workflow-usability follow-up (relates to the #168 missing-API tracking, but closes nothing)
