### PR TITLE
Fix: Make ExplainAnalyzeToken.termFrequency optional (#1132)

### DIFF
--- a/spec/schemas/indices.analyze.yaml
+++ b/spec/schemas/indices.analyze.yaml
@@ -89,7 +89,6 @@ components:
         - position
         - positionLength
         - start_offset
-        - termFrequency
         - token
         - type
     CharFilterDetail:


### PR DESCRIPTION
### Description
This PR fixes a deserialization bug in generated clients where calling the `_analyze` API with `explain: true` throws a missing required property exception.

`termFrequency` is only returned by OpenSearch when the `delimited_term_freq` token filter is included in the analysis chain. However, it was strictly marked as `required` in the `ExplainAnalyzeToken` schema, causing clients like `opensearch-java 3.1.0` to fail on standard analyzers. 

By removing `termFrequency` from the `required` array, the code generators will now correctly treat it as an optional field.

### Issues Resolved
Resolves #1132

### Changes made 
* Removed `- termFrequency` from the `required` array of `ExplainAnalyzeToken` in `spec/schemas/indices.analyze.yaml`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
