### PR TITLE
Add synonym_analyzer to synonym and synonym_graph token filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
 - Added `sltr` to query DSL schema  ([#1187](https://github.com/opensearch-project/opensearch-api-specification/pull/1187))
 - Added spec for the experimental `indices.modify_data_stream` API and the `attach_to_data_stream` restore snapshot body field ([#1176](https://github.com/opensearch-project/opensearch-api-specification/issues/1176))
+- Added `synonym_analyzer` to the `synonym` and `synonym_graph` token filters
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `search` and `warm` node roles to `NodeRole`, and modeled the pre-3.0 `search` role (renamed to `warm` in 3.0) as a version-scoped branch ([#1006](https://github.com/opensearch-project/opensearch-api-specification/pull/1006))
 - Added `sltr` to query DSL schema  ([#1187](https://github.com/opensearch-project/opensearch-api-specification/pull/1187))
 - Added spec for the experimental `indices.modify_data_stream` API and the `attach_to_data_stream` restore snapshot body field ([#1176](https://github.com/opensearch-project/opensearch-api-specification/issues/1176))
-- Added `synonym_analyzer` to the `synonym` and `synonym_graph` token filters
+- Added `synonym_analyzer` to the `synonym` and `synonym_graph` token filters ([#1230](https://github.com/opensearch-project/opensearch-api-specification/issues/1230))
 
 ### Deprecated
 - Marked the plural `_aliases` URL forms of `put_alias` and `delete_alias` as deprecated; the singular `_alias` form is the canonical path ([#1131](https://github.com/opensearch-project/opensearch-api-specification/pull/1131))

--- a/spec/schemas/_common.analysis.yaml
+++ b/spec/schemas/_common.analysis.yaml
@@ -1105,6 +1105,9 @@ components:
               $ref: '#/components/schemas/SynonymFormat'
             lenient:
               type: boolean
+            synonym_analyzer:
+              type: string
+              description: The name of an analyzer (built-in or defined in the index settings) used to analyze the synonym rules.
             synonyms:
               type: array
               items:
@@ -1137,6 +1140,9 @@ components:
               $ref: '#/components/schemas/SynonymFormat'
             lenient:
               type: boolean
+            synonym_analyzer:
+              type: string
+              description: The name of an analyzer (built-in or defined in the index settings) used to analyze the synonym rules.
             synonyms:
               type: array
               items:


### PR DESCRIPTION
### Description

Adds the `synonym_analyzer` setting to the `synonym` and `synonym_graph` token filter schemas in `spec/schemas/_common.analysis.yaml`.

This setting was introduced in OpenSearch core by opensearch-project/OpenSearch#16488 (released in v2.19.0). It specifies the name of an analyzer — built-in, plugin-provided, or a custom analyzer defined in the index settings — to be used for analyzing the synonym rules, instead of the analysis chain the filter is part of:

```json
PUT /my-index
{
  "settings": {
    "analysis": {
      "filter": {
        "my_synonym_filter": {
          "type": "synonym_graph",
          "synonym_analyzer": "standard",
          "synonyms": ["quick, fast"]
        }
      }
    }
  }
}
```

The property is modeled as `type: string` (not an enum of analyzer schemas), because `SynonymTokenFilterFactory` resolves the value **by name** via `settings.get("synonym_analyzer", null)` against the index's analyzers and the analysis registry — the value space is open and includes user-defined analyzer names. This also matches how other analyzer-name fields are modeled in this spec (e.g. `analyzer` / `search_analyzer` in `_common.mapping.yaml`).

`npm run lint:spec` passes with no errors.

### Issues Resolved

Closes #1230


### Check List
- [ ] New functionality includes testing
- [x] API is documented in the spec
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-api-specification/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

