### PR TITLE
Reconcile search_relevance spec with plugin source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Added the Delete Task API for removing stored completed task results ([#1215](https://github.com/opensearch-project/opensearch-api-specification/pull/1215))
 - Added `sparse_encoding`, `text_image_embedding`, and `text_chunking` ingest processor schemas with `ChunkingAlgorithm` (`fixed_token_length`, `delimiter`) support, and `neural_sparse` query DSL ([#1191](https://github.com/opensearch-project/opensearch-api-specification/pull/1191))
+- Added search relevance APIs `PATCH /experiments/{id}`, `GET /experiments/{id}/validate`, `PUT /judgments/{id}` (update ratings), and `POST /judgments/{id}/_retry`, plus missing request fields and the `timeout`/`query_text` query parameters, reconciled against the plugin source ([#1233](https://github.com/opensearch-project/opensearch-api-specification/pull/1233))
 - Added apis for searching within search relevance objects such as search configurations, judgments, query sets, and experiments ([#1064](https://github.com/opensearch-project/opensearch-api-specification/pull/1064))
 - Added remaining APIs for LTR including store element operations, model management, feature set operations, routing support, and POST support for update operations ([#935](https://github.com/opensearch-project/opensearch-api-specification/pull/935))
 - Added specs for alert and finding endpoints of security_analytics plugin ([#907](https://github.com/opensearch-project/opensearch-api-specification/pull/907))

--- a/spec/namespaces/search_relevance.yaml
+++ b/spec/namespaces/search_relevance.yaml
@@ -106,6 +106,18 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.get_judgments@200'
+    put:
+      operationId: search_relevance.update_judgment_ratings.0
+      x-operation-group: search_relevance.update_judgment_ratings
+      x-version-added: '3.9'
+      description: Adjusts one or more ratings on an existing LLM judgment in place. Only the listed (query, docId) pairs are updated; all other ratings are left unchanged.
+      parameters:
+        - $ref: '#/components/parameters/search_relevance.update_judgment_ratings::path.judgment_id'
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.update_judgment_ratings'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.update_judgment_ratings@200'
     delete:
       operationId: search_relevance.delete_judgments.0
       x-operation-group: search_relevance.delete_judgments
@@ -116,6 +128,17 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_judgments@200'
+  /_plugins/_search_relevance/judgments/{judgment_id}/_retry:
+    post:
+      operationId: search_relevance.retry_judgments.0
+      x-operation-group: search_relevance.retry_judgments
+      x-version-added: '3.9'
+      description: Retries the failed documents in an existing LLM judgment.
+      parameters:
+        - $ref: '#/components/parameters/search_relevance.retry_judgments::path.judgment_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.retry_judgments@200'
   /_plugins/_search_relevance/judgments/_search:
     get:
       operationId: search_relevance.judgments_search.0
@@ -204,6 +227,8 @@ paths:
       x-operation-group: search_relevance.get_experiments
       x-version-added: '3.1'
       description: Gets experiments.
+      parameters:
+        - $ref: '#/components/parameters/search_relevance.get_experiments::query.query_text'
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.get_experiments@200'
@@ -225,9 +250,22 @@ paths:
       description: Gets experiments.
       parameters:
         - $ref: '#/components/parameters/search_relevance.get_experiments::path.experiment_id'
+        - $ref: '#/components/parameters/search_relevance.get_experiments::query.query_text'
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.get_experiments@200'
+    patch:
+      operationId: search_relevance.patch_experiments.0
+      x-operation-group: search_relevance.patch_experiments
+      x-version-added: '3.6'
+      description: Partially updates an experiment. At least one of `name` or `description` must be provided.
+      parameters:
+        - $ref: '#/components/parameters/search_relevance.patch_experiments::path.experiment_id'
+      requestBody:
+        $ref: '#/components/requestBodies/search_relevance.patch_experiments'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.patch_experiments@200'
     delete:
       operationId: search_relevance.delete_experiments.0
       x-operation-group: search_relevance.delete_experiments
@@ -238,6 +276,17 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.delete_experiments@200'
+  /_plugins/_search_relevance/experiments/{experiment_id}/validate:
+    get:
+      operationId: search_relevance.validate_experiments.0
+      x-operation-group: search_relevance.validate_experiments
+      x-version-added: '3.8'
+      description: Validates whether an experiment's inputs have drifted from the fingerprint recorded at execution time.
+      parameters:
+        - $ref: '#/components/parameters/search_relevance.validate_experiments::path.experiment_id'
+      responses:
+        '200':
+          $ref: '#/components/responses/search_relevance.validate_experiments@200'
   /_plugins/_search_relevance/experiments/_search:
     get:
       operationId: search_relevance.experiments_search.0
@@ -272,6 +321,7 @@ paths:
         - $ref: '#/components/parameters/search_relevance.get_node_stats::query.include_individual_nodes'
         - $ref: '#/components/parameters/search_relevance.get_node_stats::query.include_info'
         - $ref: '#/components/parameters/search_relevance.get_node_stats::query.include_metadata'
+        - $ref: '#/components/parameters/search_relevance.get_node_stats::query.timeout'
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.get_node_stats@200'
@@ -289,6 +339,7 @@ paths:
         - $ref: '#/components/parameters/search_relevance.get_node_stats::query.include_individual_nodes'
         - $ref: '#/components/parameters/search_relevance.get_node_stats::query.include_info'
         - $ref: '#/components/parameters/search_relevance.get_node_stats::query.include_metadata'
+        - $ref: '#/components/parameters/search_relevance.get_node_stats::query.timeout'
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.get_node_stats@200'
@@ -304,6 +355,7 @@ paths:
         - $ref: '#/components/parameters/search_relevance.get_stats::query.include_individual_nodes'
         - $ref: '#/components/parameters/search_relevance.get_stats::query.include_info'
         - $ref: '#/components/parameters/search_relevance.get_stats::query.include_metadata'
+        - $ref: '#/components/parameters/search_relevance.get_stats::query.timeout'
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.get_stats@200'
@@ -320,6 +372,7 @@ paths:
         - $ref: '#/components/parameters/search_relevance.get_stats::query.include_individual_nodes'
         - $ref: '#/components/parameters/search_relevance.get_stats::query.include_info'
         - $ref: '#/components/parameters/search_relevance.get_stats::query.include_metadata'
+        - $ref: '#/components/parameters/search_relevance.get_stats::query.timeout'
       responses:
         '200':
           $ref: '#/components/responses/search_relevance.get_stats@200'
@@ -419,6 +472,13 @@ components:
       schema:
         type:
           string
+    search_relevance.get_experiments::query.query_text:
+      name: query_text
+      in: query
+      required: false
+      description: An optional query text used to filter the experiment results for visualization.
+      schema:
+        type: string
     search_relevance.delete_experiments::path.experiment_id:
       name: experiment_id
       in: path
@@ -443,6 +503,34 @@ components:
       schema:
         type:
           string
+    search_relevance.patch_experiments::path.experiment_id:
+      name: experiment_id
+      in: path
+      required: true
+      description: The experiment id
+      schema:
+        type: string
+    search_relevance.validate_experiments::path.experiment_id:
+      name: experiment_id
+      in: path
+      required: true
+      description: The experiment id
+      schema:
+        type: string
+    search_relevance.update_judgment_ratings::path.judgment_id:
+      name: judgment_id
+      in: path
+      required: true
+      description: The judgment id
+      schema:
+        type: string
+    search_relevance.retry_judgments::path.judgment_id:
+      name: judgment_id
+      in: path
+      required: true
+      description: The judgment id
+      schema:
+        type: string
     search_relevance.get_node_stats::path.node_id:
       name: node_id
       in: path
@@ -455,98 +543,102 @@ components:
       name: stat
       in: path
       required: true
-      description: The statistic to return
+      description: |-
+        A comma-separated list of statistics to return. Valid values: `cluster_version`, `import_judgment_rating_generations`, `llm_judgment_rating_generations`, `ubi_judgment_rating_generations`, `experiment_executions`, `experiment_pairwise_comparison_executions`, `experiment_pointwise_evaluation_executions`, `experiment_hybrid_optimizer_executions`.
       schema:
-        type:
-          string
+        type: string
     search_relevance.get_stats::path.stat:
       name: stat
       in: path
       required: true
-      description: The statistic to return
+      description: |-
+        A comma-separated list of statistics to return. Valid values: `cluster_version`, `import_judgment_rating_generations`, `llm_judgment_rating_generations`, `ubi_judgment_rating_generations`, `experiment_executions`, `experiment_pairwise_comparison_executions`, `experiment_pointwise_evaluation_executions`, `experiment_hybrid_optimizer_executions`.
       schema:
-        type:
-          string
+        type: string
     search_relevance.get_node_stats::query.flat_stat_paths:
       name: flat_stat_paths
       in: query
       required: false
       description: Requests flattened stat paths as keys
       schema:
-        type:
-          string
+        type: boolean
     search_relevance.get_node_stats::query.include_metadata:
       name: include_metadata
       in: query
       required: false
       description: Whether to include metadata
       schema:
-        type:
-          string
+        type: boolean
     search_relevance.get_node_stats::query.include_individual_nodes:
       name: include_individual_nodes
       in: query
       required: false
       description: Whether to include individual nodes
       schema:
-        type:
-          string
+        type: boolean
     search_relevance.get_node_stats::query.include_all_nodes:
       name: include_all_nodes
       in: query
       required: false
       description: Whether to include all nodes
       schema:
-        type:
-          string
+        type: boolean
     search_relevance.get_node_stats::query.include_info:
       name: include_info
       in: query
       required: false
       description: Whether to include info
       schema:
-        type:
-          string
+        type: boolean
     search_relevance.get_stats::query.flat_stat_paths:
       name: flat_stat_paths
       in: query
       required: false
       description: Requests flattened stat paths as keys
       schema:
-        type:
-          string
+        type: boolean
     search_relevance.get_stats::query.include_metadata:
       name: include_metadata
       in: query
       required: false
       description: Whether to include metadata
       schema:
-        type:
-          string
+        type: boolean
     search_relevance.get_stats::query.include_individual_nodes:
       name: include_individual_nodes
       in: query
       required: false
       description: Whether to include individual nodes
       schema:
-        type:
-          string
+        type: boolean
     search_relevance.get_stats::query.include_all_nodes:
       name: include_all_nodes
       in: query
       required: false
       description: Whether to include all nodes
       schema:
-        type:
-          string
+        type: boolean
     search_relevance.get_stats::query.include_info:
       name: include_info
       in: query
       required: false
       description: Whether to include info
       schema:
-        type:
-          string
+        type: boolean
+    search_relevance.get_node_stats::query.timeout:
+      name: timeout
+      in: query
+      required: false
+      description: The amount of time to wait for a response.
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/Duration'
+    search_relevance.get_stats::query.timeout:
+      name: timeout
+      in: query
+      required: false
+      description: The amount of time to wait for a response.
+      schema:
+        $ref: '../schemas/_common.yaml#/components/schemas/Duration'
   requestBodies:
     search_relevance.post_query_sets:
       content:
@@ -604,6 +696,16 @@ components:
         application/json:
           schema:
             $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PostScheduledExperimentsRequest'
+    search_relevance.patch_experiments:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PatchExperimentRequest'
+    search_relevance.update_judgment_ratings:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/UpdateJudgmentRatingsRequest'
   responses:
     search_relevance.get_query_sets@200:
       content:
@@ -741,3 +843,23 @@ components:
         application/json:
           schema:
             $ref: '../schemas/_common.yaml#/components/schemas/WriteResponseBase'
+    search_relevance.patch_experiments@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/PatchExperimentResponse'
+    search_relevance.validate_experiments@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/ValidateExperimentResponse'
+    search_relevance.update_judgment_ratings@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/UpdateJudgmentRatingsResponse'
+    search_relevance.retry_judgments@200:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/search_relevance._common.yaml#/components/schemas/RetryJudgmentsResponse'

--- a/spec/schemas/search_relevance._common.yaml
+++ b/spec/schemas/search_relevance._common.yaml
@@ -39,56 +39,48 @@ components:
           type: string
         query_set_result:
           type: string
+    PutExperimentRequestBase:
+      type: object
+      description: The common fields shared by all experiment creation requests.
+      properties:
+        querySetId:
+          type: string
+        searchConfigurationList:
+          type: array
+          items:
+            type: string
+        size:
+          type: integer
+        type:
+          type: string
+      required:
+        - searchConfigurationList
+        - size
+        - type
     PutPairwiseExperimentRequest:
-      type: object
       description: The schema for a pairwise experiment.
-      properties:
-        querySetId:
-          type: string
-        searchConfigurationList:
-          type: array
-          items:
-            type: string
-        size:
-          type: integer
-        type:
-          type: string
+      allOf:
+        - $ref: '#/components/schemas/PutExperimentRequestBase'
     PutHybridOptimizerExperimentRequest:
-      type: object
       description: The schema for a hybrid optimizer experiment.
-      properties:
-        querySetId:
-          type: string
-        searchConfigurationList:
-          type: array
-          items:
-            type: string
-        judgmentList:
-          type: array
-          items:
-            type: string
-        size:
-          type: integer
-        type:
-          type: string
+      allOf:
+        - $ref: '#/components/schemas/PutExperimentRequestBase'
+        - type: object
+          properties:
+            judgmentList:
+              type: array
+              items:
+                type: string
     PutPointwiseExperimentRequest:
-      type: object
       description: The schema for a pointwise experiment.
-      properties:
-        querySetId:
-          type: string
-        searchConfigurationList:
-          type: array
-          items:
-            type: string
-        judgmentList:
-          type: array
-          items:
-            type: string
-        size:
-          type: integer
-        type:
-          type: string
+      allOf:
+        - $ref: '#/components/schemas/PutExperimentRequestBase'
+        - type: object
+          properties:
+            judgmentList:
+              type: array
+              items:
+                type: string
     PostQuerySetsRequest:
       type: object
       description: The schema for creating a query set.
@@ -101,6 +93,12 @@ components:
           type: string
         querySetSize:
           type: integer
+        ubiQueriesIndex:
+          type: string
+          description: The name of the UBI queries index to sample from.
+          x-version-added: '3.5'
+      required:
+        - name
     PutQuerySetsRequest:
       type: object
       description: The schema for updating a query set.
@@ -115,60 +113,109 @@ components:
           type: array
           items:
             type: object
+      required:
+        - name
+    PutJudgmentsRequestBase:
+      type: object
+      description: The common fields shared by all judgment creation requests.
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+      required:
+        - name
+        - type
     PutLLMJudgmentsRequest:
-      type: object
       description: The schema for a LLM judgment.
-      properties:
-        name:
-          type: string
-        description:
-          type: string
-        type:
-          type: string
-        modelId:
-          type: string
-        querySetId:
-          type: string
-        searchConfigurationList:
-          type: array
-          items:
-            type: string
-        size:
-          type: integer
-        ignoreFailure:
-          type: boolean
-        contextFields:
-          type: array
-          items:
-            type: string
+      allOf:
+        - $ref: '#/components/schemas/PutJudgmentsRequestBase'
+        - type: object
+          properties:
+            modelId:
+              type: string
+            querySetId:
+              type: string
+            searchConfigurationList:
+              type: array
+              items:
+                type: string
+            size:
+              type: integer
+            ignoreFailure:
+              type: boolean
+              description: Whether to continue when individual documents fail to be rated. Defaults to `false`.
+            contextFields:
+              type: array
+              items:
+                type: string
+            tokenLimit:
+              type: integer
+              description: The maximum number of tokens allowed for the LLM prompt. Defaults to 4000.
+            promptTemplate:
+              type: string
+              description: The prompt template to use. Must contain a `{{hits}}` or `{{results}}` placeholder. A default template is used when omitted.
+              x-version-added: '3.5'
+            llmJudgmentRatingType:
+              $ref: '#/components/schemas/LLMJudgmentRatingType'
+            existingJudgments:
+              type: array
+              description: A list of existing judgment ids whose ratings should be reused instead of being re-scored.
+              items:
+                type: string
+              x-version-added: '3.9'
+            overwriteCache:
+              type: boolean
+              deprecated: true
+              description: Deprecated and ignored. The global judgment cache was removed; use `existingJudgments` to reuse ratings or the `_retry` endpoint to re-score failed documents.
+          required:
+            - modelId
+    LLMJudgmentRatingType:
+      type: string
+      description: The rating scale used by the LLM judge. Defaults to `SCORE0_1`.
+      enum:
+        - RELEVANT_IRRELEVANT
+        - SCORE0_1
+      x-version-added: '3.5'
     PutUBIJudgmentsRequest:
-      type: object
       description: The schema for a UBI judgment.
-      properties:
-        name:
-          type: string
-        description:
-          type: string
-        type:
-          type: string
-        clickModel:
-          type: string
-        maxRank:
-          type: integer
+      allOf:
+        - $ref: '#/components/schemas/PutJudgmentsRequestBase'
+        - type: object
+          properties:
+            clickModel:
+              type: string
+            maxRank:
+              type: integer
+            startDate:
+              type: string
+              description: The start of the UBI events date range (inclusive).
+              x-version-added: '3.2'
+            endDate:
+              type: string
+              description: The end of the UBI events date range (inclusive).
+              x-version-added: '3.2'
+            ubiEventsIndex:
+              type: string
+              description: The name of the UBI events index to source click data from.
+              x-version-added: '3.5'
+          required:
+            - clickModel
+            - maxRank
     PutImportJudgmentsRequest:
-      type: object
       description: The schema for an import judgment.
-      properties:
-        name:
-          type: string
-        description:
-          type: string
-        type:
-          type: string
-        judgmentRatings:
-          type: array
-          items:
-            type: object
+      allOf:
+        - $ref: '#/components/schemas/PutJudgmentsRequestBase'
+        - type: object
+          properties:
+            judgmentRatings:
+              type: array
+              items:
+                type: object
+          required:
+            - judgmentRatings
     PutSearchConfigurationRequest:
       type: object
       properties:
@@ -183,6 +230,8 @@ components:
           type: string
         searchPipeline:
           type: string
+      required:
+        - name
     PostScheduledExperimentsRequest:
       type: object
       description: The schema for scheduling experiments.
@@ -191,6 +240,9 @@ components:
           type: string
         cronExpression:
           type: string
+      required:
+        - cronExpression
+        - experimentId
     PostScheduledExperimentsResponse:
       type: object
       properties:
@@ -215,3 +267,100 @@ components:
         sort:
           $ref: '_common.yaml#/components/schemas/Sort'
           description: The sort order.
+    PatchExperimentRequest:
+      type: object
+      description: The schema for partially updating an experiment. At least one of `name` or `description` must be provided.
+      minProperties: 1
+      properties:
+        name:
+          type: string
+          description: The new name of the experiment.
+        description:
+          type: string
+          description: The new description of the experiment.
+    PatchExperimentResponse:
+      type: object
+      properties:
+        experiment_id:
+          type: string
+        experiment_result:
+          type: string
+    ValidateExperimentResponse:
+      type: object
+      description: Describes whether an experiment's inputs have drifted from the fingerprint recorded at execution time.
+      properties:
+        status:
+          $ref: '#/components/schemas/ExperimentValidationStatus'
+        drifted_inputs:
+          type: array
+          description: The list of inputs that have drifted.
+          items:
+            type: string
+        message:
+          type: string
+          description: A human-readable message describing the validation result.
+      required:
+        - drifted_inputs
+        - message
+        - status
+    ExperimentValidationStatus:
+      type: string
+      description: The drift status of an experiment's inputs.
+      enum:
+        - DRIFTED
+        - UNAVAILABLE
+        - VALID
+    UpdateJudgmentRatingsRequest:
+      type: object
+      description: The schema for adjusting ratings on an existing LLM judgment in place.
+      properties:
+        judgmentRatings:
+          type: array
+          description: The ratings to update, grouped by query. Only the listed (query, docId) pairs are updated.
+          items:
+            $ref: '#/components/schemas/JudgmentRatingUpdate'
+      required:
+        - judgmentRatings
+    JudgmentRatingUpdate:
+      type: object
+      description: The ratings to update for a single query.
+      properties:
+        query:
+          type: string
+          description: The query text whose ratings are being updated.
+        ratings:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentRatingUpdate'
+      required:
+        - query
+        - ratings
+    DocumentRatingUpdate:
+      type: object
+      description: A single document rating to update.
+      properties:
+        docId:
+          type: string
+          description: The document id whose rating is being updated.
+        rating:
+          type: string
+          description: The new rating value.
+      required:
+        - docId
+        - rating
+    UpdateJudgmentRatingsResponse:
+      type: object
+      properties:
+        judgment_id:
+          type: string
+        result:
+          type: string
+    RetryJudgmentsResponse:
+      type: object
+      properties:
+        judgment_id:
+          type: string
+        status:
+          type: string
+        message:
+          type: string

--- a/tests/plugins/search_relevance/experiment_update.yaml
+++ b/tests/plugins/search_relevance/experiment_update.yaml
@@ -1,0 +1,133 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Tests partially updating (PATCH) an experiment and validating its input drift.
+version: '>= 3.8.0'
+
+prologues:
+  - path: /_plugins/ubi/initialize
+    method: POST
+  - path: /_cluster/settings
+    method: PUT
+    request:
+      payload:
+        transient:
+          plugins.search_relevance.workbench_enabled: true
+    response:
+      status: 201
+  - path: /{index}/_doc/{doc_id}
+    method: POST
+    parameters:
+      index: sample_index
+      doc_id: 1
+    request:
+      payload:
+        name: banana
+        price: 1.99
+        description: this is a banana
+    response:
+      status: 201
+  - id: query_set_sampling
+    path: /_plugins/_search_relevance/query_sets
+    method: POST
+    request:
+      payload:
+        name: test03
+        description: test03
+        sampling: random
+        querySetSize: 200
+    response:
+      status: 200
+    output:
+      query_set_id: payload.query_set_id
+  - id: search_configuration1
+    path: /_plugins/_search_relevance/search_configurations
+    method: PUT
+    request:
+      payload:
+        name: simple
+        query: "{\"query\": {\n\"match_all\": {}}}"
+        index: sample_index
+        searchPipeline: test_pipeline
+    response:
+      status: 200
+    output:
+      search_configuration_id: payload.search_configuration_id
+  - id: search_configuration2
+    path: /_plugins/_search_relevance/search_configurations
+    method: PUT
+    request:
+      payload:
+        name: multimatch
+        query: '{"query":{"multi_match":{"query":"%SearchText%","fields":["id","title","category","bullets","description","attrs.Brand","attrs.Color"]}}}'
+        index: sample_index
+        searchPipeline: test_pipeline
+    response:
+      status: 200
+    output:
+      search_configuration_id: payload.search_configuration_id
+
+epilogues:
+  - path: /_plugins/_search_relevance/search_configurations/{search_configuration_id}
+    method: DELETE
+    parameters:
+      search_configuration_id: ${search_configuration1.search_configuration_id}
+    response:
+      status: 200
+  - path: /_plugins/_search_relevance/search_configurations/{search_configuration_id}
+    method: DELETE
+    parameters:
+      search_configuration_id: ${search_configuration2.search_configuration_id}
+    response:
+      status: 200
+  - path: /_plugins/_search_relevance/query_sets/{query_set_id}
+    method: DELETE
+    parameters:
+      query_set_id: ${query_set_sampling.query_set_id}
+    response:
+      status: 200
+  - path: /sample_index
+    method: DELETE
+    status: [200, 404]
+
+chapters:
+  - synopsis: Create a pairwise experiment to update.
+    id: pairwise_experiment
+    path: /_plugins/_search_relevance/experiments
+    method: PUT
+    request:
+      payload:
+        querySetId: ${query_set_sampling.query_set_id}
+        searchConfigurationList:
+          - ${search_configuration1.search_configuration_id}
+          - ${search_configuration2.search_configuration_id}
+        size: 10
+        type: PAIRWISE_COMPARISON
+    response:
+      status: 200
+    output:
+      experiment_id: payload.experiment_id
+  - synopsis: Partially update the experiment's name and description.
+    path: /_plugins/_search_relevance/experiments/{experiment_id}
+    method: PATCH
+    parameters:
+      experiment_id: ${pairwise_experiment.experiment_id}
+    request:
+      payload:
+        name: renamed experiment
+        description: updated description
+    response:
+      status: 200
+  - synopsis: Validate the experiment's inputs for drift.
+    path: /_plugins/_search_relevance/experiments/{experiment_id}/validate
+    method: GET
+    parameters:
+      experiment_id: ${pairwise_experiment.experiment_id}
+    response:
+      status: 200
+  - synopsis: Delete the experiment.
+    path: /_plugins/_search_relevance/experiments/{experiment_id}
+    method: DELETE
+    parameters:
+      experiment_id: ${pairwise_experiment.experiment_id}
+    response:
+      status: 200

--- a/tests/plugins/search_relevance/experiments.yaml
+++ b/tests/plugins/search_relevance/experiments.yaml
@@ -222,6 +222,7 @@ chapters:
     method: GET
     parameters:
       experiment_id: ${pairwise_experiment.experiment_id}
+      query_text: banana
     response:
       status: 200
   - synopsis: Delete the pairwise experiment. 

--- a/tests/plugins/search_relevance/judgment_update.yaml
+++ b/tests/plugins/search_relevance/judgment_update.yaml
@@ -1,0 +1,120 @@
+$schema: ../../../json_schemas/test_story.schema.yaml
+
+description: Tests updating the ratings of an LLM judgment in place and retrying its failed documents.
+version: '>= 3.9.0'
+
+prologues:
+  - path: /_plugins/ubi/initialize
+    method: POST
+  - path: /_cluster/settings
+    method: PUT
+    request:
+      payload:
+        transient:
+          plugins.search_relevance.workbench_enabled: true
+    response:
+      status: 201
+  - path: /{index}/_doc/{doc_id}
+    method: POST
+    parameters:
+      index: sample_index
+      doc_id: 1
+    request:
+      payload:
+        name: banana
+        price: 1.99
+        description: this is a banana
+    response:
+      status: 201
+  - id: query_set_sampling
+    path: /_plugins/_search_relevance/query_sets
+    method: POST
+    request:
+      payload:
+        name: test03
+        description: test03
+        sampling: random
+        querySetSize: 200
+    response:
+      status: 200
+    output:
+      query_set_id: payload.query_set_id
+  - id: search_configuration1
+    path: /_plugins/_search_relevance/search_configurations
+    method: PUT
+    request:
+      payload:
+        name: simple
+        query: "{\"query\": {\n\"match_all\": {}}}"
+        index: sample_index
+        searchPipeline: test_pipeline
+    response:
+      status: 200
+    output:
+      search_configuration_id: payload.search_configuration_id
+
+epilogues:
+  - path: /_plugins/_search_relevance/search_configurations/{search_configuration_id}
+    method: DELETE
+    parameters:
+      search_configuration_id: ${search_configuration1.search_configuration_id}
+    response:
+      status: 200
+  - path: /_plugins/_search_relevance/query_sets/{query_set_id}
+    method: DELETE
+    parameters:
+      query_set_id: ${query_set_sampling.query_set_id}
+    response:
+      status: 200
+  - path: /sample_index
+    method: DELETE
+    status: [200, 404]
+
+chapters:
+  - synopsis: Create an LLM judgment to update.
+    id: llm_judgment
+    path: /_plugins/_search_relevance/judgments
+    method: PUT
+    request:
+      payload:
+        name: LLMbaseline
+        description: LLM judgment
+        type: LLM_JUDGMENT
+        querySetId: ${query_set_sampling.query_set_id}
+        modelId: '0' # ml model placeholder
+        size: 10
+        existingJudgments: []
+        searchConfigurationList:
+          - ${search_configuration1.search_configuration_id}
+    response:
+      status: 200
+    output:
+      judgment_id: payload.judgment_id
+  - synopsis: Update one rating on the judgment in place.
+    path: /_plugins/_search_relevance/judgments/{judgment_id}
+    method: PUT
+    parameters:
+      judgment_id: ${llm_judgment.judgment_id}
+    request:
+      payload:
+        judgmentRatings:
+          - query: banana
+            ratings:
+              - docId: '1'
+                rating: '1'
+    response:
+      status: 200
+  - synopsis: Retry the failed documents in the judgment.
+    path: /_plugins/_search_relevance/judgments/{judgment_id}/_retry
+    method: POST
+    parameters:
+      judgment_id: ${llm_judgment.judgment_id}
+    response:
+      status: 200
+  - synopsis: Delete the judgment.
+    path: /_plugins/_search_relevance/judgments/{judgment_id}
+    method: DELETE
+    parameters:
+      judgment_id: ${llm_judgment.judgment_id}
+    response:
+      status: 200

--- a/tests/plugins/search_relevance/judgments.yaml
+++ b/tests/plugins/search_relevance/judgments.yaml
@@ -125,6 +125,9 @@ chapters:
         type: UBI_JUDGMENT
         clickModel: coec
         maxRank: 10
+        startDate: 2023-01-01
+        endDate: 2023-12-31
+        ubiEventsIndex: ubi_events
     response:
       status: 200
     output: # Save the judgment id for later use.
@@ -141,6 +144,9 @@ chapters:
         querySetId: ${query_set_sampling.query_set_id}
         modelId: '0' # used a ml model placeholder.
         size: 10
+        tokenLimit: 4000
+        promptTemplate: 'Rate the relevance. Hits: {{hits}}'
+        llmJudgmentRatingType: SCORE0_1
         searchConfigurationList: # There is actually a list of search configurations. 
           - ${search_configuration1.search_configuration_id}
           - ${search_configuration2.search_configuration_id}

--- a/tests/plugins/search_relevance/query_sets.yaml
+++ b/tests/plugins/search_relevance/query_sets.yaml
@@ -67,6 +67,7 @@ chapters:
         description: test03
         sampling: random
         querySetSize: 200
+        ubiQueriesIndex: ubi_queries
     response:
       status: 200
     output: # Save the query id for later use.

--- a/tests/plugins/search_relevance/stats.yaml
+++ b/tests/plugins/search_relevance/stats.yaml
@@ -16,6 +16,13 @@ chapters:
   - synopsis: Get stats for all nodes.
     path: /_plugins/_search_relevance/stats
     method: GET
+    parameters:
+      flat_stat_paths: true
+      include_metadata: true
+      include_all_nodes: true
+      include_individual_nodes: true
+      include_info: true
+      timeout: 30s
     response:
       status: 200
   - synopsis: Get stats for a node.


### PR DESCRIPTION
### Description

Reconciles the `search_relevance` spec against the plugin source (`opensearch-project/search-relevance`).

**New operations**
- `PATCH /_plugins/_search_relevance/experiments/{experiment_id}` — partial update of name/description (3.6)
- `GET /_plugins/_search_relevance/experiments/{experiment_id}/validate` — input-drift check, VALID/DRIFTED/UNAVAILABLE (3.8)
- `PUT /_plugins/_search_relevance/judgments/{judgment_id}` — update judgment ratings in place (3.9)
- `POST /_plugins/_search_relevance/judgments/{judgment_id}/_retry` — retry failed LLM judgment documents (3.9)

**Schema/field fixes (existing operations)**
- Refactored the three experiment and three judgment request bodies to shared `PutExperimentRequestBase` / `PutJudgmentsRequestBase` via `allOf`; pairwise experiment gains the `querySetId` it actually reads.
- LLM judgment: added `tokenLimit`, `promptTemplate` (3.5), `llmJudgmentRatingType` enum (3.5), `existingJudgments` (3.9), and deprecated `overwriteCache`.
- UBI judgment: added `startDate`/`endDate` (3.2) and `ubiEventsIndex` (3.5).
- Query set: added `ubiQueriesIndex` (3.5); marked required fields on query-set / search-config / scheduled-experiment requests.
- `GET /experiments`: added the `query_text` query parameter.
- Stats: retyped the five `include_*` / `flat_stat_paths` params from `string` to `boolean` (parsed via `paramAsBoolean`), added the `timeout` param, and enumerated valid `{stat}` values.

`x-version-added` values were determined from the earliest release branch that contains each handler/field.

### Issues Resolved

N/A — spec-vs-code reconciliation.

### Testing

- `npm run lint:spec` passes.
- Added test stories `experiment_update.yaml` (>= 3.8.0) and `judgment_update.yaml` (>= 3.9.0) for the new operations, and exercised the new fields/params in the existing query_sets / judgments / experiments / stats stories. Story replay against a live cluster was not run locally.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
